### PR TITLE
feat: add REST API layer with token auth, rate limiting, and full tic…

### DIFF
--- a/app/controllers/concerns/escalated/api_authentication.rb
+++ b/app/controllers/concerns/escalated/api_authentication.rb
@@ -1,0 +1,52 @@
+module Escalated
+  module ApiAuthentication
+    extend ActiveSupport::Concern
+
+    included do
+      attr_reader :current_api_user, :current_api_token
+    end
+
+    private
+
+    def authenticate_api_token!
+      plain_text = extract_bearer_token
+      unless plain_text
+        render json: { message: "Unauthenticated." }, status: :unauthorized
+        return
+      end
+
+      api_token = Escalated::ApiToken.find_by_plain_text(plain_text)
+      unless api_token
+        render json: { message: "Invalid token." }, status: :unauthorized
+        return
+      end
+
+      if api_token.expired?
+        render json: { message: "Token has expired." }, status: :unauthorized
+        return
+      end
+
+      user = api_token.tokenable
+      unless user
+        render json: { message: "Token owner not found." }, status: :unauthorized
+        return
+      end
+
+      # Record usage
+      api_token.update_columns(
+        last_used_at: Time.current,
+        last_used_ip: request.remote_ip
+      )
+
+      @current_api_user = user
+      @current_api_token = api_token
+    end
+
+    def extract_bearer_token
+      header = request.headers["Authorization"].to_s
+      return nil unless header.start_with?("Bearer ")
+
+      header[7..]
+    end
+  end
+end

--- a/app/controllers/concerns/escalated/api_rate_limiting.rb
+++ b/app/controllers/concerns/escalated/api_rate_limiting.rb
@@ -1,0 +1,56 @@
+module Escalated
+  module ApiRateLimiting
+    extend ActiveSupport::Concern
+
+    private
+
+    def enforce_rate_limit!
+      key = rate_limit_key
+      max_attempts = Escalated.configuration.api_rate_limit
+      window = 60 # seconds
+
+      cache_key = "escalated_api_rate:#{key}"
+      current = Rails.cache.read(cache_key)
+
+      if current.nil?
+        Rails.cache.write(cache_key, { count: 1, reset_at: Time.current.to_i + window }, expires_in: window.seconds)
+        set_rate_limit_headers(max_attempts, max_attempts - 1)
+        return
+      end
+
+      if current[:count] >= max_attempts
+        retry_after = [current[:reset_at] - Time.current.to_i, 1].max
+
+        response.headers["Retry-After"] = retry_after.to_s
+        response.headers["X-RateLimit-Limit"] = max_attempts.to_s
+        response.headers["X-RateLimit-Remaining"] = "0"
+
+        render json: {
+          message: "Too many requests.",
+          retry_after: retry_after
+        }, status: :too_many_requests
+        return
+      end
+
+      current[:count] += 1
+      remaining_ttl = [current[:reset_at] - Time.current.to_i, 1].max
+      Rails.cache.write(cache_key, current, expires_in: remaining_ttl.seconds)
+
+      remaining = max_attempts - current[:count]
+      set_rate_limit_headers(max_attempts, remaining)
+    end
+
+    def rate_limit_key
+      if @current_api_token
+        "token:#{@current_api_token.id}"
+      else
+        "ip:#{request.remote_ip}"
+      end
+    end
+
+    def set_rate_limit_headers(limit, remaining)
+      response.headers["X-RateLimit-Limit"] = limit.to_s
+      response.headers["X-RateLimit-Remaining"] = [remaining, 0].max.to_s
+    end
+  end
+end

--- a/app/controllers/escalated/admin/api_tokens_controller.rb
+++ b/app/controllers/escalated/admin/api_tokens_controller.rb
@@ -1,0 +1,98 @@
+module Escalated
+  module Admin
+    class ApiTokensController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_token, only: [:update, :destroy]
+
+      def index
+        tokens = Escalated::ApiToken.includes(:tokenable).order(created_at: :desc).map { |token|
+          {
+            id: token.id,
+            name: token.name,
+            user_name: token.tokenable.respond_to?(:name) ? token.tokenable.name : token.tokenable&.email,
+            user_email: token.tokenable&.email,
+            abilities: token.abilities,
+            last_used_at: token.last_used_at&.iso8601,
+            last_used_ip: token.last_used_ip,
+            expires_at: token.expires_at&.iso8601,
+            is_expired: token.expired?,
+            created_at: token.created_at&.iso8601
+          }
+        }
+
+        users = agent_list
+
+        render inertia: "Escalated/Admin/ApiTokens/Index", props: {
+          tokens: tokens,
+          users: users,
+          api_enabled: Escalated.configuration.api_enabled
+        }
+      end
+
+      def create
+        user = Escalated.configuration.user_model.find(params[:user_id])
+
+        expires_at = if params[:expires_in_days].present?
+          params[:expires_in_days].to_i.days.from_now
+        else
+          nil
+        end
+
+        abilities = params[:abilities].present? ? Array(params[:abilities]) : ["*"]
+
+        result = Escalated::ApiToken.create_token(
+          user,
+          params[:name],
+          abilities,
+          expires_at
+        )
+
+        redirect_back(
+          fallback_location: escalated.admin_api_tokens_path,
+          flash: {
+            success: "API token created.",
+            plain_text_token: result[:plain_text_token]
+          }
+        )
+      end
+
+      def update
+        update_attrs = {}
+        update_attrs[:name] = params[:name] if params[:name].present?
+        update_attrs[:abilities] = Array(params[:abilities]) if params[:abilities].present?
+
+        @token.update!(update_attrs)
+
+        redirect_back(
+          fallback_location: escalated.admin_api_tokens_path,
+          flash: { success: "Token updated." }
+        )
+      end
+
+      def destroy
+        @token.destroy!
+
+        redirect_back(
+          fallback_location: escalated.admin_api_tokens_path,
+          flash: { success: "Token revoked." }
+        )
+      end
+
+      private
+
+      def set_token
+        @token = Escalated::ApiToken.find(params[:id])
+      end
+
+      def agent_list
+        if Escalated.configuration.user_model.respond_to?(:escalated_agents)
+          Escalated.configuration.user_model.escalated_agents.map { |a|
+            { id: a.id, name: a.respond_to?(:name) ? a.name : a.email, email: a.email }
+          }
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/api/v1/auth_controller.rb
+++ b/app/controllers/escalated/api/v1/auth_controller.rb
@@ -1,0 +1,24 @@
+module Escalated
+  module Api
+    module V1
+      class AuthController < BaseController
+        def validate
+          user = current_user
+
+          render json: {
+            user: {
+              id: user.id,
+              name: user.respond_to?(:name) ? user.name : user.email,
+              email: user.email
+            },
+            abilities: @current_api_token.abilities || [],
+            is_agent: user.respond_to?(:escalated_agent?) ? user.escalated_agent? : false,
+            is_admin: user.respond_to?(:escalated_admin?) ? user.escalated_admin? : false,
+            token_name: @current_api_token.name,
+            expires_at: @current_api_token.expires_at&.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/api/v1/base_controller.rb
+++ b/app/controllers/escalated/api/v1/base_controller.rb
@@ -1,0 +1,58 @@
+module Escalated
+  module Api
+    module V1
+      class BaseController < ActionController::API
+        include Escalated::ApiAuthentication
+        include Escalated::ApiRateLimiting
+
+        before_action :check_api_enabled!
+        before_action :authenticate_api_token!
+        before_action :enforce_rate_limit!
+
+        rescue_from ActiveRecord::RecordNotFound, with: :not_found
+        rescue_from ActiveRecord::RecordInvalid, with: :unprocessable
+
+        private
+
+        def check_api_enabled!
+          unless Escalated.configuration.api_enabled
+            render json: { message: "API is not enabled." }, status: :not_found
+          end
+        end
+
+        def current_user
+          @current_api_user
+        end
+
+        def not_found
+          render json: { message: "The requested resource was not found." }, status: :not_found
+        end
+
+        def unprocessable(exception)
+          render json: {
+            message: "Validation failed.",
+            errors: exception.record.errors.full_messages
+          }, status: :unprocessable_entity
+        end
+
+        def paginate(scope, per_page: 25)
+          page = (params[:page] || 1).to_i
+          per = (params[:per_page] || per_page).to_i
+
+          total = scope.count
+          records = scope.offset((page - 1) * per).limit(per)
+
+          {
+            data: records,
+            meta: {
+              current_page: page,
+              per_page: per,
+              total: total,
+              total_pages: (total.to_f / per).ceil
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/api/v1/dashboard_controller.rb
+++ b/app/controllers/escalated/api/v1/dashboard_controller.rb
@@ -1,0 +1,75 @@
+module Escalated
+  module Api
+    module V1
+      class DashboardController < BaseController
+        def index
+          user_id = current_user.id
+
+          render json: {
+            stats: {
+              open: Escalated::Ticket.by_open.count,
+              my_assigned: Escalated::Ticket.assigned_to(user_id).by_open.count,
+              unassigned: Escalated::Ticket.by_open.unassigned.count,
+              sla_breached: Escalated::Ticket.by_open.breached_sla.count,
+              resolved_today: Escalated::Ticket.where(
+                status: :resolved
+              ).where(
+                resolved_at: Time.current.beginning_of_day..Time.current.end_of_day
+              ).count
+            },
+            recent_tickets: Escalated::Ticket
+              .includes(:requester, :assignee, :department)
+              .recent
+              .limit(10)
+              .map { |t| ticket_summary_json(t) },
+            needs_attention: {
+              sla_breaching: Escalated::Ticket
+                .by_open
+                .breached_sla
+                .includes(:requester, :assignee)
+                .limit(5)
+                .map { |t| attention_ticket_json(t) },
+              unassigned_urgent: Escalated::Ticket
+                .by_open
+                .unassigned
+                .where(priority: [:urgent, :critical])
+                .includes(:requester)
+                .limit(5)
+                .map { |t| attention_ticket_json(t) }
+            },
+            my_performance: {
+              resolved_this_week: Escalated::Ticket
+                .assigned_to(user_id)
+                .where("resolved_at >= ?", Time.current.beginning_of_week)
+                .count
+            }
+          }
+        end
+
+        private
+
+        def ticket_summary_json(ticket)
+          {
+            id: ticket.id,
+            reference: ticket.reference,
+            subject: ticket.subject,
+            status: ticket.status,
+            priority: ticket.priority,
+            requester_name: ticket.requester_name,
+            assignee_name: ticket.assignee.respond_to?(:name) ? ticket.assignee.name : ticket.assignee&.email,
+            created_at: ticket.created_at&.iso8601
+          }
+        end
+
+        def attention_ticket_json(ticket)
+          {
+            reference: ticket.reference,
+            subject: ticket.subject,
+            priority: ticket.priority,
+            requester_name: ticket.requester_name
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/api/v1/resources_controller.rb
+++ b/app/controllers/escalated/api/v1/resources_controller.rb
@@ -1,0 +1,112 @@
+module Escalated
+  module Api
+    module V1
+      class ResourcesController < BaseController
+        # GET /api/v1/agents
+        def agents
+          agent_data = if Escalated.configuration.user_model.respond_to?(:escalated_agents)
+            Escalated.configuration.user_model.escalated_agents.map { |a|
+              {
+                id: a.id,
+                name: a.respond_to?(:name) ? a.name : a.email,
+                email: a.email
+              }
+            }
+          else
+            []
+          end
+
+          render json: { data: agent_data }
+        end
+
+        # GET /api/v1/departments
+        def departments
+          departments = Escalated::Department.active.ordered
+
+          render json: {
+            data: departments.map { |d|
+              {
+                id: d.id,
+                name: d.name,
+                slug: d.slug,
+                description: d.description,
+                email: d.email,
+                is_active: d.is_active,
+                open_ticket_count: d.open_ticket_count,
+                agent_count: d.agent_count
+              }
+            }
+          }
+        end
+
+        # GET /api/v1/tags
+        def tags
+          tags = Escalated::Tag.ordered
+
+          render json: {
+            data: tags.map { |t|
+              {
+                id: t.id,
+                name: t.name,
+                slug: t.slug,
+                color: t.color,
+                description: t.description,
+                ticket_count: t.ticket_count
+              }
+            }
+          }
+        end
+
+        # GET /api/v1/canned-responses
+        def canned_responses
+          responses = Escalated::CannedResponse.for_user(current_user.id).ordered
+
+          render json: {
+            data: responses.map { |r|
+              {
+                id: r.id,
+                title: r.title,
+                body: r.body,
+                shortcode: r.shortcode,
+                category: r.category,
+                is_shared: r.is_shared
+              }
+            }
+          }
+        end
+
+        # GET /api/v1/macros
+        def macros
+          macros = Escalated::Macro.for_agent(current_user.id).ordered
+
+          render json: {
+            data: macros.map { |m|
+              {
+                id: m.id,
+                name: m.name,
+                description: m.description,
+                actions: m.actions,
+                is_shared: m.is_shared
+              }
+            }
+          }
+        end
+
+        # GET /api/v1/realtime/config
+        def realtime_config
+          # Return ActionCable/AnyCable config if available
+          cable_config = Rails.application.config.action_cable rescue nil
+
+          if cable_config && cable_config.respond_to?(:url) && cable_config.url.present?
+            render json: {
+              driver: "action_cable",
+              url: cable_config.url
+            }
+          else
+            render json: nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/api/v1/tickets_controller.rb
+++ b/app/controllers/escalated/api/v1/tickets_controller.rb
@@ -1,0 +1,281 @@
+module Escalated
+  module Api
+    module V1
+      class TicketsController < BaseController
+        before_action :set_ticket, only: [:show, :reply, :status, :priority, :assign, :follow, :apply_macro, :tags, :destroy]
+
+        # GET /api/v1/tickets
+        def index
+          scope = Escalated::Ticket.all.recent
+
+          scope = scope.where(status: params[:status]) if params[:status].present?
+          scope = scope.where(priority: params[:priority]) if params[:priority].present?
+          scope = scope.assigned_to(params[:assigned_to]) if params[:assigned_to].present?
+          scope = scope.where(department_id: params[:department_id]) if params[:department_id].present?
+          scope = scope.unassigned if params[:unassigned] == "true"
+          scope = scope.breached_sla if params[:sla_breached] == "true"
+          scope = scope.search(params[:search]) if params[:search].present?
+
+          if params[:tag_ids].present?
+            tag_ids = Array(params[:tag_ids]).map(&:to_i)
+            scope = scope.joins(:tags).where(Escalated.table_name("tags") => { id: tag_ids }).distinct
+          end
+
+          if params[:following] == "true"
+            followed_ticket_ids = Escalated::Ticket
+              .joins("INNER JOIN #{Escalated.table_name('ticket_followers')} ON #{Escalated.table_name('ticket_followers')}.ticket_id = #{Escalated.table_name('tickets')}.id")
+              .where("#{Escalated.table_name('ticket_followers')}.user_id = ?", current_user.id)
+              .pluck(:id)
+            scope = scope.where(id: followed_ticket_ids)
+          end
+
+          result = paginate(scope)
+
+          render json: {
+            data: result[:data].includes(:requester, :assignee, :department, :tags).map { |t| ticket_list_json(t) },
+            meta: result[:meta]
+          }
+        end
+
+        # GET /api/v1/tickets/:reference
+        def show
+          render json: {
+            data: ticket_detail_json(@ticket)
+          }
+        end
+
+        # POST /api/v1/tickets
+        def create
+          params.require(:subject)
+          params.require(:description)
+
+          ticket_params = {
+            subject: params[:subject],
+            description: params[:description],
+            requester: current_user,
+            priority: params[:priority] || Escalated.configuration.default_priority.to_s,
+            department_id: params[:department_id]
+          }
+
+          ticket = Services::TicketService.create(ticket_params)
+
+          if params[:tags].present?
+            tag_ids = Array(params[:tags]).map(&:to_i)
+            Services::TicketService.add_tags(ticket, tag_ids, actor: current_user)
+          end
+
+          ticket.reload
+
+          render json: {
+            data: ticket_detail_json(ticket),
+            message: "Ticket created."
+          }, status: :created
+        end
+
+        # POST /api/v1/tickets/:reference/reply
+        def reply
+          params.require(:body)
+
+          is_internal = params[:is_internal_note] == true || params[:is_internal_note] == "true"
+
+          reply = Services::TicketService.reply(@ticket, {
+            body: params[:body],
+            author: current_user,
+            is_internal: is_internal
+          })
+
+          render json: {
+            data: {
+              id: reply.id,
+              body: reply.body,
+              is_internal_note: reply.is_internal,
+              author: {
+                id: current_user.id,
+                name: current_user.respond_to?(:name) ? current_user.name : current_user.email
+              },
+              created_at: reply.created_at&.iso8601
+            },
+            message: is_internal ? "Note added." : "Reply sent."
+          }, status: :created
+        end
+
+        # PATCH /api/v1/tickets/:reference/status
+        def status
+          params.require(:status)
+
+          Services::TicketService.transition_status(
+            @ticket,
+            params[:status],
+            actor: current_user,
+            note: params[:note]
+          )
+
+          render json: { message: "Status updated.", status: params[:status] }
+        end
+
+        # PATCH /api/v1/tickets/:reference/priority
+        def priority
+          params.require(:priority)
+
+          Services::TicketService.change_priority(@ticket, params[:priority], actor: current_user)
+
+          render json: { message: "Priority updated.", priority: params[:priority] }
+        end
+
+        # POST /api/v1/tickets/:reference/assign
+        def assign
+          params.require(:agent_id)
+
+          agent = Escalated.configuration.user_model.find(params[:agent_id])
+          Services::AssignmentService.assign(@ticket, agent, actor: current_user)
+
+          render json: { message: "Ticket assigned." }
+        end
+
+        # POST /api/v1/tickets/:reference/follow
+        def follow
+          user_id = current_user.id
+
+          if @ticket.followed_by?(user_id)
+            @ticket.unfollow(user_id)
+            render json: { message: "Unfollowed ticket.", following: false }
+          else
+            @ticket.follow(user_id)
+            render json: { message: "Following ticket.", following: true }
+          end
+        end
+
+        # POST /api/v1/tickets/:reference/apply_macro
+        def apply_macro
+          params.require(:macro_id)
+
+          macro = Escalated::Macro.for_agent(current_user.id).find(params[:macro_id])
+          Services::MacroService.apply(macro, @ticket, actor: current_user)
+
+          render json: { message: "Macro \"#{macro.name}\" applied." }
+        end
+
+        # POST /api/v1/tickets/:reference/tags
+        def tags
+          params.require(:tag_ids)
+
+          new_tag_ids = Array(params[:tag_ids]).map(&:to_i)
+          current_tag_ids = @ticket.tags.pluck(:id)
+
+          to_add = new_tag_ids - current_tag_ids
+          to_remove = current_tag_ids - new_tag_ids
+
+          Services::TicketService.add_tags(@ticket, to_add, actor: current_user) if to_add.any?
+          Services::TicketService.remove_tags(@ticket, to_remove, actor: current_user) if to_remove.any?
+
+          render json: { message: "Tags updated." }
+        end
+
+        # DELETE /api/v1/tickets/:reference
+        def destroy
+          @ticket.destroy!
+
+          render json: { message: "Ticket deleted." }
+        end
+
+        private
+
+        def set_ticket
+          @ticket = Escalated::Ticket.find_by!(reference: params[:reference])
+        rescue ActiveRecord::RecordNotFound
+          @ticket = Escalated::Ticket.find(params[:reference])
+        end
+
+        def ticket_list_json(ticket)
+          {
+            id: ticket.id,
+            reference: ticket.reference,
+            subject: ticket.subject,
+            status: ticket.status,
+            priority: ticket.priority,
+            requester: {
+              name: ticket.requester_name
+            },
+            assignee: ticket.assignee ? {
+              id: ticket.assignee.id,
+              name: ticket.assignee.respond_to?(:name) ? ticket.assignee.name : ticket.assignee.email
+            } : nil,
+            department: ticket.department ? {
+              id: ticket.department.id,
+              name: ticket.department.name
+            } : nil,
+            tags: ticket.tags.map { |t| { id: t.id, name: t.name, color: t.color } },
+            sla_breached: ticket.sla_breached,
+            created_at: ticket.created_at&.iso8601,
+            updated_at: ticket.updated_at&.iso8601
+          }
+        end
+
+        def ticket_detail_json(ticket)
+          ticket.reload
+
+          replies = ticket.replies.chronological.includes(:author, :attachments)
+          activities = ticket.activities.reverse_chronological.limit(20)
+
+          ticket_list_json(ticket).merge(
+            description: ticket.description,
+            metadata: ticket.metadata,
+            sla_policy: ticket.sla_policy ? {
+              id: ticket.sla_policy.id,
+              name: ticket.sla_policy.name
+            } : nil,
+            sla_first_response_due_at: ticket.sla_first_response_due_at&.iso8601,
+            sla_resolution_due_at: ticket.sla_resolution_due_at&.iso8601,
+            first_response_at: ticket.first_response_at&.iso8601,
+            resolved_at: ticket.resolved_at&.iso8601,
+            closed_at: ticket.closed_at&.iso8601,
+            reply_count: ticket.replies.count,
+            attachment_count: ticket.attachments.count,
+            satisfaction_rating: ticket.satisfaction_rating ? {
+              id: ticket.satisfaction_rating.id,
+              rating: ticket.satisfaction_rating.rating,
+              comment: ticket.satisfaction_rating.comment,
+              created_at: ticket.satisfaction_rating.created_at&.iso8601
+            } : nil,
+            pinned_notes: ticket.pinned_notes.includes(:author).map { |n| reply_json(n) },
+            replies: replies.map { |r| reply_json(r) },
+            activities: activities.map { |a| activity_json(a) }
+          )
+        end
+
+        def reply_json(reply)
+          {
+            id: reply.id,
+            body: reply.body,
+            is_internal: reply.is_internal,
+            is_internal_note: reply.is_internal,
+            is_system: reply.is_system,
+            is_pinned: reply.respond_to?(:is_pinned) ? reply.is_pinned : false,
+            author: reply.author ? {
+              id: reply.author.id,
+              name: reply.author.respond_to?(:name) ? reply.author.name : reply.author.email,
+              is_agent: reply.author.respond_to?(:escalated_agent?) ? reply.author.escalated_agent? : false
+            } : { name: "System", is_agent: true },
+            attachments: reply.attachments.map { |a|
+              { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type }
+            },
+            created_at: reply.created_at&.iso8601
+          }
+        end
+
+        def activity_json(activity)
+          {
+            id: activity.id,
+            action: activity.action,
+            description: activity.description,
+            causer: activity.causer ? {
+              name: activity.causer.respond_to?(:name) ? activity.causer.name : activity.causer.email
+            } : nil,
+            details: activity.details,
+            created_at: activity.created_at&.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/models/escalated/api_token.rb
+++ b/app/models/escalated/api_token.rb
@@ -1,0 +1,55 @@
+module Escalated
+  class ApiToken < ApplicationRecord
+    self.table_name = Escalated.table_name("api_tokens")
+
+    belongs_to :tokenable, polymorphic: true
+
+    validates :name, presence: true, length: { maximum: 255 }
+    validates :token, presence: true, uniqueness: true, length: { maximum: 64 }
+
+    scope :active, -> {
+      where(expires_at: nil).or(where("expires_at > ?", Time.current))
+    }
+    scope :expired, -> {
+      where.not(expires_at: nil).where("expires_at <= ?", Time.current)
+    }
+
+    # Create a new API token for a user.
+    # Returns { token: <ApiToken>, plain_text_token: <String> }
+    def self.create_token(user, name, abilities = ["*"], expires_at = nil)
+      plain_text = SecureRandom.hex(32)
+
+      token = create!(
+        tokenable_type: user.class.name,
+        tokenable_id: user.id,
+        name: name,
+        token: Digest::SHA256.hexdigest(plain_text),
+        abilities: abilities,
+        expires_at: expires_at
+      )
+
+      { token: token, plain_text_token: plain_text }
+    end
+
+    # Look up a token by its plain-text value (hashes before query).
+    def self.find_by_plain_text(plain_text)
+      return nil if plain_text.blank?
+
+      where(token: Digest::SHA256.hexdigest(plain_text)).first
+    end
+
+    # Check whether this token grants the given ability.
+    # A token with ["*"] has all abilities.
+    def has_ability?(ability)
+      abilities_list = abilities || []
+      abilities_list.include?("*") || abilities_list.include?(ability.to_s)
+    end
+
+    # Whether this token has passed its expiration date.
+    def expired?
+      return false if expires_at.nil?
+
+      expires_at <= Time.current
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Escalated::Engine.routes.draw do
     resources :tags, only: [:index, :create, :update, :destroy]
     resources :canned_responses, only: [:index, :create, :update, :destroy]
     resources :macros, only: [:index, :create, :update, :destroy]
+    resources :api_tokens, only: [:index, :create, :update, :destroy]
     get :reports, to: "reports#index"
     get :settings, to: "settings#index"
     post :settings, to: "settings#update"

--- a/db/migrate/017_create_escalated_api_tokens.rb
+++ b/db/migrate/017_create_escalated_api_tokens.rb
@@ -1,0 +1,22 @@
+class CreateEscalatedApiTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("api_tokens") do |t|
+      # Polymorphic tokenable (the user who owns this token)
+      t.string :tokenable_type, null: false
+      t.bigint :tokenable_id, null: false
+
+      t.string :name, null: false
+      t.string :token, limit: 64, null: false
+      t.json :abilities, default: ["*"]
+      t.datetime :last_used_at
+      t.string :last_used_ip, limit: 45
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("api_tokens"), :token, unique: true
+    add_index Escalated.table_name("api_tokens"), [:tokenable_type, :tokenable_id]
+    add_index Escalated.table_name("api_tokens"), :expires_at
+  end
+end

--- a/lib/escalated/configuration.rb
+++ b/lib/escalated/configuration.rb
@@ -34,7 +34,12 @@ module Escalated
                   :imap_encryption,
                   :imap_username,
                   :imap_password,
-                  :imap_mailbox
+                  :imap_mailbox,
+                  # REST API settings
+                  :api_enabled,
+                  :api_rate_limit,
+                  :api_token_expiry_days,
+                  :api_prefix
 
     def initialize
       @mode = :self_hosted
@@ -78,6 +83,12 @@ module Escalated
       @imap_username = nil
       @imap_password = nil
       @imap_mailbox = "INBOX"
+
+      # REST API defaults
+      @api_enabled = false
+      @api_rate_limit = 60
+      @api_token_expiry_days = nil
+      @api_prefix = "support/api/v1"
     end
 
     def self_hosted?

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -31,6 +31,39 @@ module Escalated
       end
     end
 
+    initializer "escalated.api_routes" do |app|
+      # Conditionally load API routes when api_enabled is true.
+      # These are mounted directly on the host app (not inside the engine mount)
+      # so they can use ActionController::API without CSRF.
+      app.routes.append do
+        if Escalated.configuration.api_enabled
+          scope Escalated.configuration.api_prefix, module: "escalated/api/v1", as: "escalated_api_v1" do
+            post "auth/validate", to: "auth#validate"
+            get "dashboard", to: "dashboard#index"
+
+            resources :tickets, param: :reference, only: [:index, :show, :create, :destroy] do
+              member do
+                post :reply
+                patch :status
+                patch :priority
+                post :assign
+                post :follow
+                post :apply_macro
+                post :tags
+              end
+            end
+
+            get "agents", to: "resources#agents"
+            get "departments", to: "resources#departments"
+            get "tags", to: "resources#tags"
+            get "canned-responses", to: "resources#canned_responses"
+            get "macros", to: "resources#macros"
+            get "realtime/config", to: "resources#realtime_config"
+          end
+        end
+      end
+    end
+
     initializer "escalated.inertia" do
       ActiveSupport.on_load(:action_controller) do
         # Configure Inertia shared data at engine level

--- a/lib/generators/escalated/templates/initializer.rb
+++ b/lib/generators/escalated/templates/initializer.rb
@@ -82,6 +82,21 @@ Escalated.configure do |config|
   config.webhook_url = nil
 
   # ============================================================
+  # REST API
+  # ============================================================
+  # Enable the REST API (Bearer token authentication, JSON endpoints)
+  # config.api_enabled = false
+
+  # Maximum requests per token per minute
+  # config.api_rate_limit = 60
+
+  # Default token expiry in days (nil = never expires)
+  # config.api_token_expiry_days = nil
+
+  # API URL prefix (mounted on the host app, outside the engine)
+  # config.api_prefix = "support/api/v1"
+
+  # ============================================================
   # Cloud Configuration (only for :synced and :cloud modes)
   # ============================================================
   # config.hosted_api_url = "https://cloud.escalated.dev/api/v1"


### PR DESCRIPTION
…ket CRUD

Adds SHA-256 hashed API tokens, Bearer auth middleware, per-token rate limiting, and complete JSON API for tickets, dashboard, agents, departments, tags, canned responses, and macros. Includes Inertia admin UI for token management. All business logic reuses existing service classes.