### PR TITLE
feat: add multi-language (i18n) support with EN, ES, FR, DE translations

### DIFF
--- a/app/controllers/escalated/admin/bulk_actions_controller.rb
+++ b/app/controllers/escalated/admin/bulk_actions_controller.rb
@@ -35,7 +35,7 @@ module Escalated
         end
 
         redirect_back fallback_location: escalated.admin_tickets_path,
-                      notice: "#{success_count} ticket(s) updated."
+                      notice: I18n.t('escalated.bulk.updated', count: success_count)
       end
     end
   end

--- a/app/controllers/escalated/admin/canned_responses_controller.rb
+++ b/app/controllers/escalated/admin/canned_responses_controller.rb
@@ -17,7 +17,7 @@ module Escalated
         response.created_by = escalated_current_user.id
 
         if response.save
-          redirect_to admin_canned_responses_path, notice: "Canned response created."
+          redirect_to admin_canned_responses_path, notice: I18n.t('escalated.admin.canned_response.created')
         else
           redirect_back fallback_location: admin_canned_responses_path,
                         alert: response.errors.full_messages.join(", ")
@@ -26,7 +26,7 @@ module Escalated
 
       def update
         if @canned_response.update(canned_response_params)
-          redirect_to admin_canned_responses_path, notice: "Canned response updated."
+          redirect_to admin_canned_responses_path, notice: I18n.t('escalated.admin.canned_response.updated')
         else
           redirect_back fallback_location: admin_canned_responses_path,
                         alert: @canned_response.errors.full_messages.join(", ")
@@ -35,7 +35,7 @@ module Escalated
 
       def destroy
         @canned_response.destroy!
-        redirect_to admin_canned_responses_path, notice: "Canned response deleted."
+        redirect_to admin_canned_responses_path, notice: I18n.t('escalated.admin.canned_response.deleted')
       end
 
       private

--- a/app/controllers/escalated/admin/departments_controller.rb
+++ b/app/controllers/escalated/admin/departments_controller.rb
@@ -25,7 +25,7 @@ module Escalated
 
         if department.save
           sync_agents(department, params[:agent_ids])
-          redirect_to admin_department_path(department), notice: "Department created."
+          redirect_to admin_department_path(department), notice: I18n.t('escalated.admin.department.created')
         else
           redirect_back fallback_location: new_admin_department_path,
                         alert: department.errors.full_messages.join(", ")
@@ -58,7 +58,7 @@ module Escalated
       def update
         if @department.update(department_params)
           sync_agents(@department, params[:agent_ids]) if params.key?(:agent_ids)
-          redirect_to admin_department_path(@department), notice: "Department updated."
+          redirect_to admin_department_path(@department), notice: I18n.t('escalated.admin.department.updated')
         else
           redirect_back fallback_location: edit_admin_department_path(@department),
                         alert: @department.errors.full_messages.join(", ")
@@ -67,7 +67,7 @@ module Escalated
 
       def destroy
         @department.destroy!
-        redirect_to admin_departments_path, notice: "Department deleted."
+        redirect_to admin_departments_path, notice: I18n.t('escalated.admin.department.deleted')
       end
 
       private

--- a/app/controllers/escalated/admin/escalation_rules_controller.rb
+++ b/app/controllers/escalated/admin/escalation_rules_controller.rb
@@ -26,7 +26,7 @@ module Escalated
         rule = Escalated::EscalationRule.new(rule_params)
 
         if rule.save
-          redirect_to admin_escalation_rule_path(rule), notice: "Escalation rule created."
+          redirect_to admin_escalation_rule_path(rule), notice: I18n.t('escalated.admin.escalation_rule.created')
         else
           redirect_back fallback_location: new_admin_escalation_rule_path,
                         alert: rule.errors.full_messages.join(", ")
@@ -51,7 +51,7 @@ module Escalated
 
       def update
         if @rule.update(rule_params)
-          redirect_to admin_escalation_rule_path(@rule), notice: "Escalation rule updated."
+          redirect_to admin_escalation_rule_path(@rule), notice: I18n.t('escalated.admin.escalation_rule.updated')
         else
           redirect_back fallback_location: edit_admin_escalation_rule_path(@rule),
                         alert: @rule.errors.full_messages.join(", ")
@@ -60,7 +60,7 @@ module Escalated
 
       def destroy
         @rule.destroy!
-        redirect_to admin_escalation_rules_path, notice: "Escalation rule deleted."
+        redirect_to admin_escalation_rules_path, notice: I18n.t('escalated.admin.escalation_rule.deleted')
       end
 
       private

--- a/app/controllers/escalated/admin/macros_controller.rb
+++ b/app/controllers/escalated/admin/macros_controller.rb
@@ -17,7 +17,7 @@ module Escalated
         macro.created_by = escalated_current_user.id
 
         if macro.save
-          redirect_to admin_macros_path, notice: "Macro created."
+          redirect_to admin_macros_path, notice: I18n.t('escalated.admin.macro.created')
         else
           redirect_back fallback_location: admin_macros_path,
                         alert: macro.errors.full_messages.join(", ")
@@ -26,7 +26,7 @@ module Escalated
 
       def update
         if @macro.update(macro_params)
-          redirect_to admin_macros_path, notice: "Macro updated."
+          redirect_to admin_macros_path, notice: I18n.t('escalated.admin.macro.updated')
         else
           redirect_back fallback_location: admin_macros_path,
                         alert: @macro.errors.full_messages.join(", ")
@@ -35,7 +35,7 @@ module Escalated
 
       def destroy
         @macro.destroy!
-        redirect_to admin_macros_path, notice: "Macro deleted."
+        redirect_to admin_macros_path, notice: I18n.t('escalated.admin.macro.deleted')
       end
 
       private

--- a/app/controllers/escalated/admin/settings_controller.rb
+++ b/app/controllers/escalated/admin/settings_controller.rb
@@ -41,7 +41,7 @@ module Escalated
         # Inbound email settings
         update_inbound_email_settings
 
-        redirect_to escalated.admin_settings_path, notice: "Settings updated successfully."
+        redirect_to escalated.admin_settings_path, notice: I18n.t('escalated.admin.settings.updated')
       end
 
       private

--- a/app/controllers/escalated/admin/sla_policies_controller.rb
+++ b/app/controllers/escalated/admin/sla_policies_controller.rb
@@ -23,7 +23,7 @@ module Escalated
         policy = Escalated::SlaPolicy.new(sla_policy_params)
 
         if policy.save
-          redirect_to admin_sla_policy_path(policy), notice: "SLA Policy created."
+          redirect_to admin_sla_policy_path(policy), notice: I18n.t('escalated.admin.sla_policy.created')
         else
           redirect_back fallback_location: new_admin_sla_policy_path,
                         alert: policy.errors.full_messages.join(", ")
@@ -48,7 +48,7 @@ module Escalated
 
       def update
         if @sla_policy.update(sla_policy_params)
-          redirect_to admin_sla_policy_path(@sla_policy), notice: "SLA Policy updated."
+          redirect_to admin_sla_policy_path(@sla_policy), notice: I18n.t('escalated.admin.sla_policy.updated')
         else
           redirect_back fallback_location: edit_admin_sla_policy_path(@sla_policy),
                         alert: @sla_policy.errors.full_messages.join(", ")
@@ -57,7 +57,7 @@ module Escalated
 
       def destroy
         @sla_policy.destroy!
-        redirect_to admin_sla_policies_path, notice: "SLA Policy deleted."
+        redirect_to admin_sla_policies_path, notice: I18n.t('escalated.admin.sla_policy.deleted')
       end
 
       private

--- a/app/controllers/escalated/admin/tags_controller.rb
+++ b/app/controllers/escalated/admin/tags_controller.rb
@@ -16,7 +16,7 @@ module Escalated
         tag = Escalated::Tag.new(tag_params)
 
         if tag.save
-          redirect_to admin_tags_path, notice: "Tag created."
+          redirect_to admin_tags_path, notice: I18n.t('escalated.admin.tag.created')
         else
           redirect_back fallback_location: admin_tags_path,
                         alert: tag.errors.full_messages.join(", ")
@@ -25,7 +25,7 @@ module Escalated
 
       def update
         if @tag.update(tag_params)
-          redirect_to admin_tags_path, notice: "Tag updated."
+          redirect_to admin_tags_path, notice: I18n.t('escalated.admin.tag.updated')
         else
           redirect_back fallback_location: admin_tags_path,
                         alert: @tag.errors.full_messages.join(", ")
@@ -34,7 +34,7 @@ module Escalated
 
       def destroy
         @tag.destroy!
-        redirect_to admin_tags_path, notice: "Tag deleted."
+        redirect_to admin_tags_path, notice: I18n.t('escalated.admin.tag.deleted')
       end
 
       private

--- a/app/controllers/escalated/admin/tickets_controller.rb
+++ b/app/controllers/escalated/admin/tickets_controller.rb
@@ -82,7 +82,7 @@ module Escalated
           Services::AttachmentService.attach(reply, params[:attachments])
         end
 
-        redirect_to admin_ticket_path(@ticket), notice: "Reply sent."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.reply_sent')
       end
 
       def note
@@ -92,17 +92,17 @@ module Escalated
           is_internal: true
         })
 
-        redirect_to admin_ticket_path(@ticket), notice: "Internal note added."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.note_added')
       end
 
       def assign
         if params[:agent_id].present?
           agent = Escalated.configuration.user_model.find(params[:agent_id])
           Services::AssignmentService.assign(@ticket, agent, actor: escalated_current_user)
-          redirect_to admin_ticket_path(@ticket), notice: "Ticket assigned to #{agent.respond_to?(:name) ? agent.name : agent.email}."
+          redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.assigned', name: agent.respond_to?(:name) ? agent.name : agent.email)
         else
           Services::AssignmentService.unassign(@ticket, actor: escalated_current_user)
-          redirect_to admin_ticket_path(@ticket), notice: "Ticket unassigned."
+          redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.unassigned')
         end
       end
 
@@ -114,12 +114,12 @@ module Escalated
           note: params[:note]
         )
 
-        redirect_to admin_ticket_path(@ticket), notice: "Status updated to #{params[:status].humanize}."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.status_updated', status: params[:status].humanize)
       end
 
       def priority
         Services::TicketService.change_priority(@ticket, params[:priority], actor: escalated_current_user)
-        redirect_to admin_ticket_path(@ticket), notice: "Priority updated to #{params[:priority]}."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.priority_updated', priority: params[:priority])
       end
 
       def tags
@@ -131,29 +131,29 @@ module Escalated
           Services::TicketService.remove_tags(@ticket, params[:remove_tag_ids], actor: escalated_current_user)
         end
 
-        redirect_to admin_ticket_path(@ticket), notice: "Tags updated."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.tags_updated')
       end
 
       def department
         dept = Escalated::Department.find(params[:department_id])
         Services::TicketService.change_department(@ticket, dept, actor: escalated_current_user)
-        redirect_to admin_ticket_path(@ticket), notice: "Department changed to #{dept.name}."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.department_updated', name: dept.name)
       end
 
       def apply_macro
         macro = Escalated::Macro.for_agent(escalated_current_user.id).find(params[:macro_id])
         Services::MacroService.apply(macro, @ticket, actor: escalated_current_user)
 
-        redirect_to admin_ticket_path(@ticket), notice: "Macro \"#{macro.name}\" applied."
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.macro_applied', name: macro.name)
       end
 
       def follow
         if @ticket.followed_by?(escalated_current_user.id)
           @ticket.unfollow(escalated_current_user.id)
-          redirect_to admin_ticket_path(@ticket), notice: "Unfollowed ticket."
+          redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.unfollowed')
         else
           @ticket.follow(escalated_current_user.id)
-          redirect_to admin_ticket_path(@ticket), notice: "Following ticket."
+          redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.following')
         end
       end
 
@@ -186,14 +186,14 @@ module Escalated
         reply = @ticket.replies.find(params[:reply_id])
 
         unless reply.is_internal
-          redirect_to admin_ticket_path(@ticket), alert: "Only internal notes can be pinned."
+          redirect_to admin_ticket_path(@ticket), alert: I18n.t('escalated.ticket.only_internal_notes_pinned')
           return
         end
 
         reply.update!(is_pinned: !reply.is_pinned)
 
         redirect_to admin_ticket_path(@ticket),
-                    notice: reply.is_pinned ? "Note pinned." : "Note unpinned."
+                    notice: reply.is_pinned ? I18n.t('escalated.ticket.note_pinned') : I18n.t('escalated.ticket.note_unpinned')
       end
 
       private

--- a/app/controllers/escalated/agent/bulk_actions_controller.rb
+++ b/app/controllers/escalated/agent/bulk_actions_controller.rb
@@ -35,7 +35,7 @@ module Escalated
         end
 
         redirect_back fallback_location: escalated.agent_tickets_path,
-                      notice: "#{success_count} ticket(s) updated."
+                      notice: I18n.t('escalated.bulk.updated', count: success_count)
       end
     end
   end

--- a/app/controllers/escalated/agent/tickets_controller.rb
+++ b/app/controllers/escalated/agent/tickets_controller.rb
@@ -77,7 +77,7 @@ module Escalated
         authorize @ticket, policy_class: Escalated::TicketPolicy
 
         Services::TicketService.update(@ticket, update_params, actor: escalated_current_user)
-        redirect_to agent_ticket_path(@ticket), notice: "Ticket updated."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.updated')
       end
 
       def reply
@@ -93,7 +93,7 @@ module Escalated
           Services::AttachmentService.attach(reply, params[:attachments])
         end
 
-        redirect_to agent_ticket_path(@ticket), notice: "Reply sent."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.reply_sent')
       end
 
       def note
@@ -105,7 +105,7 @@ module Escalated
           is_internal: true
         })
 
-        redirect_to agent_ticket_path(@ticket), notice: "Internal note added."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.note_added')
       end
 
       def assign
@@ -114,10 +114,10 @@ module Escalated
         if params[:agent_id].present?
           agent = Escalated.configuration.user_model.find(params[:agent_id])
           Services::AssignmentService.assign(@ticket, agent, actor: escalated_current_user)
-          redirect_to agent_ticket_path(@ticket), notice: "Ticket assigned to #{agent.respond_to?(:name) ? agent.name : agent.email}."
+          redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.assigned', name: agent.respond_to?(:name) ? agent.name : agent.email)
         else
           Services::AssignmentService.unassign(@ticket, actor: escalated_current_user)
-          redirect_to agent_ticket_path(@ticket), notice: "Ticket unassigned."
+          redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.unassigned')
         end
       end
 
@@ -131,14 +131,14 @@ module Escalated
           note: params[:note]
         )
 
-        redirect_to agent_ticket_path(@ticket), notice: "Status updated to #{params[:status].humanize}."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.status_updated', status: params[:status].humanize)
       end
 
       def priority
         authorize @ticket, policy_class: Escalated::TicketPolicy
 
         Services::TicketService.change_priority(@ticket, params[:priority], actor: escalated_current_user)
-        redirect_to agent_ticket_path(@ticket), notice: "Priority updated to #{params[:priority]}."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.priority_updated', priority: params[:priority])
       end
 
       def tags
@@ -152,7 +152,7 @@ module Escalated
           Services::TicketService.remove_tags(@ticket, params[:remove_tag_ids], actor: escalated_current_user)
         end
 
-        redirect_to agent_ticket_path(@ticket), notice: "Tags updated."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.tags_updated')
       end
 
       def department
@@ -160,7 +160,7 @@ module Escalated
 
         dept = Escalated::Department.find(params[:department_id])
         Services::TicketService.change_department(@ticket, dept, actor: escalated_current_user)
-        redirect_to agent_ticket_path(@ticket), notice: "Department changed to #{dept.name}."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.department_updated', name: dept.name)
       end
 
       def apply_macro
@@ -169,7 +169,7 @@ module Escalated
         macro = Escalated::Macro.for_agent(escalated_current_user.id).find(params[:macro_id])
         Services::MacroService.apply(macro, @ticket, actor: escalated_current_user)
 
-        redirect_to agent_ticket_path(@ticket), notice: "Macro \"#{macro.name}\" applied."
+        redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.macro_applied', name: macro.name)
       end
 
       def follow
@@ -177,10 +177,10 @@ module Escalated
 
         if @ticket.followed_by?(escalated_current_user.id)
           @ticket.unfollow(escalated_current_user.id)
-          redirect_to agent_ticket_path(@ticket), notice: "Unfollowed ticket."
+          redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.unfollowed')
         else
           @ticket.follow(escalated_current_user.id)
-          redirect_to agent_ticket_path(@ticket), notice: "Following ticket."
+          redirect_to agent_ticket_path(@ticket), notice: I18n.t('escalated.ticket.following')
         end
       end
 
@@ -213,14 +213,14 @@ module Escalated
         reply = @ticket.replies.find(params[:reply_id])
 
         unless reply.is_internal
-          redirect_to agent_ticket_path(@ticket), alert: "Only internal notes can be pinned."
+          redirect_to agent_ticket_path(@ticket), alert: I18n.t('escalated.ticket.only_internal_notes_pinned')
           return
         end
 
         reply.update!(is_pinned: !reply.is_pinned)
 
         redirect_to agent_ticket_path(@ticket),
-                    notice: reply.is_pinned ? "Note pinned." : "Note unpinned."
+                    notice: reply.is_pinned ? I18n.t('escalated.ticket.note_pinned') : I18n.t('escalated.ticket.note_unpinned')
       end
 
       private

--- a/app/controllers/escalated/application_controller.rb
+++ b/app/controllers/escalated/application_controller.rb
@@ -58,27 +58,27 @@ module Escalated
 
     def require_agent!
       unless current_user_data&.dig(:is_agent) || current_user_data&.dig(:is_admin)
-        redirect_to main_app.root_path, alert: "Access denied."
+        redirect_to main_app.root_path, alert: I18n.t('escalated.middleware.not_agent')
       end
     end
 
     def require_admin!
       unless current_user_data&.dig(:is_admin)
-        redirect_to main_app.root_path, alert: "Access denied."
+        redirect_to main_app.root_path, alert: I18n.t('escalated.middleware.not_admin')
       end
     end
 
     def user_not_authorized
       render inertia: "Escalated/Error", props: {
         status: 403,
-        message: "You are not authorized to perform this action."
+        message: I18n.t('escalated.middleware.not_authorized')
       }, status: :forbidden
     end
 
     def not_found
       render inertia: "Escalated/Error", props: {
         status: 404,
-        message: "The requested resource was not found."
+        message: I18n.t('escalated.middleware.not_found')
       }, status: :not_found
     end
 

--- a/app/controllers/escalated/customer/satisfaction_ratings_controller.rb
+++ b/app/controllers/escalated/customer/satisfaction_ratings_controller.rb
@@ -6,13 +6,13 @@ module Escalated
       def create
         unless %w[resolved closed].include?(@ticket.status)
           redirect_back fallback_location: escalated.customer_ticket_path(@ticket),
-                        alert: "You can only rate resolved or closed tickets."
+                        alert: I18n.t('escalated.rating.only_resolved_closed')
           return
         end
 
         if @ticket.satisfaction_rating.present?
           redirect_back fallback_location: escalated.customer_ticket_path(@ticket),
-                        alert: "This ticket has already been rated."
+                        alert: I18n.t('escalated.rating.already_rated')
           return
         end
 
@@ -25,7 +25,7 @@ module Escalated
 
         if rating.save
           redirect_back fallback_location: escalated.customer_ticket_path(@ticket),
-                        notice: "Thank you for your feedback!"
+                        notice: I18n.t('escalated.rating.thanks')
         else
           redirect_back fallback_location: escalated.customer_ticket_path(@ticket),
                         alert: rating.errors.full_messages.join(", ")

--- a/app/controllers/escalated/customer/tickets_controller.rb
+++ b/app/controllers/escalated/customer/tickets_controller.rb
@@ -47,7 +47,7 @@ module Escalated
           Services::AttachmentService.attach(ticket, ticket_params[:attachments])
         end
 
-        redirect_to customer_ticket_path(ticket), notice: "Ticket created successfully."
+        redirect_to customer_ticket_path(ticket), notice: I18n.t('escalated.ticket.created')
       rescue Services::AttachmentService::TooManyAttachmentsError,
              Services::AttachmentService::FileTooLargeError,
              Services::AttachmentService::InvalidFileTypeError => e
@@ -83,7 +83,7 @@ module Escalated
           Services::AttachmentService.attach(reply, params[:attachments])
         end
 
-        redirect_to customer_ticket_path(@ticket), notice: "Reply sent."
+        redirect_to customer_ticket_path(@ticket), notice: I18n.t('escalated.ticket.reply_sent')
       rescue Services::AttachmentService::TooManyAttachmentsError,
              Services::AttachmentService::FileTooLargeError,
              Services::AttachmentService::InvalidFileTypeError => e
@@ -94,19 +94,19 @@ module Escalated
         authorize @ticket, policy_class: Escalated::TicketPolicy
 
         unless Escalated.configuration.allow_customer_close
-          redirect_to customer_ticket_path(@ticket), alert: "Customers cannot close tickets."
+          redirect_to customer_ticket_path(@ticket), alert: I18n.t('escalated.ticket.customers_cannot_close')
           return
         end
 
         Services::TicketService.close(@ticket, actor: escalated_current_user)
-        redirect_to customer_ticket_path(@ticket), notice: "Ticket closed."
+        redirect_to customer_ticket_path(@ticket), notice: I18n.t('escalated.ticket.closed')
       end
 
       def reopen
         authorize @ticket, policy_class: Escalated::TicketPolicy
 
         Services::TicketService.reopen(@ticket, actor: escalated_current_user)
-        redirect_to customer_ticket_path(@ticket), notice: "Ticket reopened."
+        redirect_to customer_ticket_path(@ticket), notice: I18n.t('escalated.ticket.reopened')
       end
 
       private

--- a/app/controllers/escalated/guest/tickets_controller.rb
+++ b/app/controllers/escalated/guest/tickets_controller.rb
@@ -49,7 +49,7 @@ module Escalated
           Services::AttachmentService.attach(ticket, guest_ticket_params[:attachments])
         end
 
-        redirect_to "#{escalated_mount_path}/guest/#{guest_token}", notice: "Ticket created successfully."
+        redirect_to "#{escalated_mount_path}/guest/#{guest_token}", notice: I18n.t('escalated.guest.created')
       rescue Services::AttachmentService::TooManyAttachmentsError,
              Services::AttachmentService::FileTooLargeError,
              Services::AttachmentService::InvalidFileTypeError => e
@@ -72,7 +72,7 @@ module Escalated
 
       def reply
         unless @ticket.open?
-          redirect_to "#{escalated_mount_path}/guest/#{params[:token]}", alert: "This ticket is closed."
+          redirect_to "#{escalated_mount_path}/guest/#{params[:token]}", alert: I18n.t('escalated.guest.ticket_closed')
           return
         end
 
@@ -99,7 +99,7 @@ module Escalated
           Services::AttachmentService.attach(reply, params[:attachments])
         end
 
-        redirect_to "#{escalated_mount_path}/guest/#{params[:token]}", notice: "Reply sent."
+        redirect_to "#{escalated_mount_path}/guest/#{params[:token]}", notice: I18n.t('escalated.ticket.reply_sent')
       rescue Services::AttachmentService::TooManyAttachmentsError,
              Services::AttachmentService::FileTooLargeError,
              Services::AttachmentService::InvalidFileTypeError => e
@@ -109,13 +109,13 @@ module Escalated
       def rate
         unless %w[resolved closed].include?(@ticket.status)
           redirect_to "#{escalated_mount_path}/guest/#{params[:token]}",
-                      alert: "You can only rate resolved or closed tickets."
+                      alert: I18n.t('escalated.rating.only_resolved_closed')
           return
         end
 
         if @ticket.satisfaction_rating.present?
           redirect_to "#{escalated_mount_path}/guest/#{params[:token]}",
-                      alert: "This ticket has already been rated."
+                      alert: I18n.t('escalated.rating.already_rated')
           return
         end
 
@@ -127,7 +127,7 @@ module Escalated
 
         if rating.save
           redirect_to "#{escalated_mount_path}/guest/#{params[:token]}",
-                      notice: "Thank you for your feedback!"
+                      notice: I18n.t('escalated.rating.thanks')
         else
           redirect_to "#{escalated_mount_path}/guest/#{params[:token]}",
                       alert: rating.errors.full_messages.join(", ")
@@ -138,14 +138,14 @@ module Escalated
 
       def ensure_guest_tickets_enabled
         unless Escalated::EscalatedSetting.guest_tickets_enabled?
-          render plain: "Guest tickets are not enabled.", status: :not_found
+          render plain: I18n.t('escalated.commands.guest_not_enabled'), status: :not_found
         end
       end
 
       def set_ticket_by_token
         @ticket = Escalated::Ticket.find_by!(guest_token: params[:token])
       rescue ActiveRecord::RecordNotFound
-        render plain: "Ticket not found.", status: :not_found
+        render plain: I18n.t('escalated.commands.ticket_not_found'), status: :not_found
       end
 
       def set_inertia_shared_data
@@ -169,10 +169,10 @@ module Escalated
 
       def validate_guest_params
         errors = {}
-        errors[:name] = "Name is required." if guest_ticket_params[:name].blank?
-        errors[:email] = "Email is required." if guest_ticket_params[:email].blank?
-        errors[:subject] = "Subject is required." if guest_ticket_params[:subject].blank?
-        errors[:description] = "Description is required." if guest_ticket_params[:description].blank?
+        errors[:name] = I18n.t('escalated.validation.name_required') if guest_ticket_params[:name].blank?
+        errors[:email] = I18n.t('escalated.validation.email_required') if guest_ticket_params[:email].blank?
+        errors[:subject] = I18n.t('escalated.validation.subject_required') if guest_ticket_params[:subject].blank?
+        errors[:description] = I18n.t('escalated.validation.description_required') if guest_ticket_params[:description].blank?
         errors
       end
 

--- a/app/controllers/escalated/inbound_controller.rb
+++ b/app/controllers/escalated/inbound_controller.rb
@@ -8,7 +8,7 @@ module Escalated
       adapter = resolve_adapter(params[:adapter])
 
       unless adapter
-        render json: { error: "Unknown adapter: #{params[:adapter]}" }, status: :bad_request
+        render json: { error: I18n.t('escalated.inbound.unknown_adapter', adapter: params[:adapter]) }, status: :bad_request
         return
       end
 
@@ -17,7 +17,7 @@ module Escalated
         Rails.logger.warn(
           "[Escalated::InboundController] Webhook verification failed for adapter: #{params[:adapter]}"
         )
-        render json: { error: "Verification failed" }, status: :unauthorized
+        render json: { error: I18n.t('escalated.inbound.verification_failed') }, status: :unauthorized
         return
       end
 
@@ -54,14 +54,14 @@ module Escalated
       Rails.logger.error(
         "[Escalated::InboundController] Unexpected error: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
       )
-      render json: { error: "Internal error" }, status: :internal_server_error
+      render json: { error: I18n.t('escalated.inbound.internal_error') }, status: :internal_server_error
     end
 
     private
 
     def ensure_inbound_enabled
       unless Escalated.configuration.inbound_email_enabled
-        render json: { error: "Inbound email is disabled" }, status: :not_found
+        render json: { error: I18n.t('escalated.inbound.disabled') }, status: :not_found
       end
     end
 

--- a/app/mailers/escalated/ticket_mailer.rb
+++ b/app/mailers/escalated/ticket_mailer.rb
@@ -6,7 +6,7 @@ module Escalated
 
       mail(
         to: @requester.email,
-        subject: "[#{ticket.reference}] Ticket Created: #{ticket.subject}"
+        subject: I18n.t('escalated.mailer.new_ticket', reference: ticket.reference, subject: ticket.subject)
       )
     end
 
@@ -25,7 +25,7 @@ module Escalated
 
       mail(
         to: recipient,
-        subject: "Re: [#{ticket.reference}] #{ticket.subject}"
+        subject: I18n.t('escalated.mailer.reply', reference: ticket.reference, subject: ticket.subject)
       )
     end
 
@@ -37,7 +37,7 @@ module Escalated
 
       mail(
         to: @assignee.email,
-        subject: "[#{ticket.reference}] Ticket Assigned: #{ticket.subject}"
+        subject: I18n.t('escalated.mailer.assigned', reference: ticket.reference, subject: ticket.subject)
       )
     end
 
@@ -46,7 +46,7 @@ module Escalated
 
       mail(
         to: ticket.requester.email,
-        subject: "[#{ticket.reference}] Status Updated: #{ticket.status.humanize}"
+        subject: I18n.t('escalated.mailer.status_updated', reference: ticket.reference, status: ticket.status.humanize)
       )
     end
 
@@ -61,7 +61,7 @@ module Escalated
 
       mail(
         to: recipients.compact.uniq,
-        subject: "[SLA BREACH] [#{ticket.reference}] #{ticket.subject}"
+        subject: I18n.t('escalated.mailer.sla_breach', reference: ticket.reference, subject: ticket.subject)
       )
     end
 
@@ -77,7 +77,7 @@ module Escalated
 
       mail(
         to: recipients.compact.uniq,
-        subject: "[ESCALATED] [#{ticket.reference}] #{ticket.subject}"
+        subject: I18n.t('escalated.mailer.escalated', reference: ticket.reference, subject: ticket.subject)
       )
     end
 
@@ -86,7 +86,7 @@ module Escalated
 
       mail(
         to: ticket.requester.email,
-        subject: "[#{ticket.reference}] Ticket Resolved: #{ticket.subject}"
+        subject: I18n.t('escalated.mailer.resolved', reference: ticket.reference, subject: ticket.subject)
       )
     end
   end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,111 @@
+de:
+  escalated:
+    ticket:
+      reply_sent: "Antwort gesendet."
+      note_added: "Interne Notiz hinzugefügt."
+      assigned: "Ticket zugewiesen an %{name}."
+      unassigned: "Ticket nicht mehr zugewiesen."
+      status_updated: "Status aktualisiert auf %{status}."
+      priority_updated: "Priorität aktualisiert auf %{priority}."
+      tags_updated: "Tags aktualisiert."
+      department_updated: "Abteilung geändert zu %{name}."
+      macro_applied: "Makro \"%{name}\" angewendet."
+      following: "Ticket wird verfolgt."
+      unfollowed: "Ticket wird nicht mehr verfolgt."
+      only_internal_notes_pinned: "Nur interne Notizen können angeheftet werden."
+      updated: "Ticket aktualisiert."
+      created: "Ticket erfolgreich erstellt."
+      closed: "Ticket geschlossen."
+      reopened: "Ticket wiedereröffnet."
+      customers_cannot_close: "Kunden können Tickets nicht schließen."
+      note_pinned: "Notiz angeheftet."
+      note_unpinned: "Notiz losgelöst."
+    guest:
+      created: "Ticket erfolgreich erstellt."
+      ticket_closed: "Dieses Ticket ist geschlossen."
+    bulk:
+      updated: "%{count} Ticket(s) aktualisiert."
+    rating:
+      only_resolved_closed: "Sie können nur gelöste oder geschlossene Tickets bewerten."
+      already_rated: "Dieses Ticket wurde bereits bewertet."
+      thanks: "Vielen Dank für Ihr Feedback!"
+    admin:
+      canned_response:
+        created: "Vordefinierte Antwort erstellt."
+        updated: "Vordefinierte Antwort aktualisiert."
+        deleted: "Vordefinierte Antwort gelöscht."
+      department:
+        created: "Abteilung erstellt."
+        updated: "Abteilung aktualisiert."
+        deleted: "Abteilung gelöscht."
+      tag:
+        created: "Tag erstellt."
+        updated: "Tag aktualisiert."
+        deleted: "Tag gelöscht."
+      macro:
+        created: "Makro erstellt."
+        updated: "Makro aktualisiert."
+        deleted: "Makro gelöscht."
+      escalation_rule:
+        created: "Eskalationsregel erstellt."
+        updated: "Eskalationsregel aktualisiert."
+        deleted: "Eskalationsregel gelöscht."
+      sla_policy:
+        created: "SLA-Richtlinie erstellt."
+        updated: "SLA-Richtlinie aktualisiert."
+        deleted: "SLA-Richtlinie gelöscht."
+      settings:
+        updated: "Einstellungen erfolgreich aktualisiert."
+      plugin:
+        uploaded: "Plugin erfolgreich hochgeladen. Sie können es jetzt aktivieren."
+        upload_failed: "Plugin-Upload fehlgeschlagen: %{error}"
+        activated: "Plugin erfolgreich aktiviert."
+        activate_failed: "Plugin-Aktivierung fehlgeschlagen: %{error}"
+        deactivated: "Plugin erfolgreich deaktiviert."
+        deactivate_failed: "Plugin-Deaktivierung fehlgeschlagen: %{error}"
+        composer_delete: "Composer-Plugins können nicht gelöscht werden. Entfernen Sie das Paket über Composer."
+        deleted: "Plugin erfolgreich gelöscht."
+        delete_failed: "Plugin-Löschung fehlgeschlagen: %{error}"
+    middleware:
+      not_admin: "Zugriff verweigert."
+      not_agent: "Zugriff verweigert."
+      not_authorized: "Sie sind nicht berechtigt, diese Aktion durchzuführen."
+      not_found: "Die angeforderte Ressource wurde nicht gefunden."
+    inbound:
+      unknown_adapter: "Unbekannter Adapter: %{adapter}"
+      verification_failed: "Überprüfung fehlgeschlagen"
+      internal_error: "Interner Fehler"
+      disabled: "Eingehende E-Mails sind deaktiviert"
+    mailer:
+      new_ticket: "[%{reference}] Ticket erstellt: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Ticket zugewiesen: %{subject}"
+      status_updated: "[%{reference}] Status aktualisiert: %{status}"
+      sla_breach: "[SLA-VERLETZUNG] [%{reference}] %{subject}"
+      escalated: "[ESKALIERT] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Ticket gelöst: %{subject}"
+    validation:
+      name_required: "Name ist erforderlich."
+      email_required: "E-Mail-Adresse ist erforderlich."
+      subject_required: "Betreff ist erforderlich."
+      description_required: "Beschreibung ist erforderlich."
+    commands:
+      install:
+        installing: "Installiert das Escalated Support-Ticket-System"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migrationen kopiert. Führen Sie `rails db:migrate` aus, um sie anzuwenden."
+        inject_user_model: "app/models/user.rb (Escalated-Rollenmethoden)"
+        inject_skip: "Konnte nicht in das User-Modell injizieren: %{error}"
+        inject_manual: "Fügen Sie diese Methoden manuell zu Ihrem User-Modell hinzu:"
+        inject_agent: "escalated_agent? - gibt true für Support-Mitarbeiter zurück"
+        inject_admin: "escalated_admin? - gibt true für Support-Administratoren zurück"
+        inject_agents_scope: "self.escalated_agents - Scope, der alle Mitarbeiter zurückgibt"
+        success: "Escalated erfolgreich installiert!"
+        next_steps: "Nächste Schritte:"
+        step1: "1. Führen Sie `rails db:migrate` aus"
+        step2: "2. Konfigurieren Sie config/initializers/escalated.rb"
+        step3: "3. Fügen Sie die Methoden escalated_agent? und escalated_admin? zu Ihrem User-Modell hinzu"
+        step4: "4. Installieren Sie Vue-Komponenten: kopieren Sie aus vendor/escalated/resources/js/"
+        step5: "5. Richten Sie den Inertia-Seitenresolver ein, um Escalated-Seiten einzubeziehen"
+      guest_not_enabled: "Gast-Tickets sind nicht aktiviert."
+      ticket_not_found: "Ticket nicht gefunden."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,111 @@
+en:
+  escalated:
+    ticket:
+      reply_sent: "Reply sent."
+      note_added: "Internal note added."
+      assigned: "Ticket assigned to %{name}."
+      unassigned: "Ticket unassigned."
+      status_updated: "Status updated to %{status}."
+      priority_updated: "Priority updated to %{priority}."
+      tags_updated: "Tags updated."
+      department_updated: "Department changed to %{name}."
+      macro_applied: "Macro \"%{name}\" applied."
+      following: "Following ticket."
+      unfollowed: "Unfollowed ticket."
+      only_internal_notes_pinned: "Only internal notes can be pinned."
+      updated: "Ticket updated."
+      created: "Ticket created successfully."
+      closed: "Ticket closed."
+      reopened: "Ticket reopened."
+      customers_cannot_close: "Customers cannot close tickets."
+      note_pinned: "Note pinned."
+      note_unpinned: "Note unpinned."
+    guest:
+      created: "Ticket created successfully."
+      ticket_closed: "This ticket is closed."
+    bulk:
+      updated: "%{count} ticket(s) updated."
+    rating:
+      only_resolved_closed: "You can only rate resolved or closed tickets."
+      already_rated: "This ticket has already been rated."
+      thanks: "Thank you for your feedback!"
+    admin:
+      canned_response:
+        created: "Canned response created."
+        updated: "Canned response updated."
+        deleted: "Canned response deleted."
+      department:
+        created: "Department created."
+        updated: "Department updated."
+        deleted: "Department deleted."
+      tag:
+        created: "Tag created."
+        updated: "Tag updated."
+        deleted: "Tag deleted."
+      macro:
+        created: "Macro created."
+        updated: "Macro updated."
+        deleted: "Macro deleted."
+      escalation_rule:
+        created: "Escalation rule created."
+        updated: "Escalation rule updated."
+        deleted: "Escalation rule deleted."
+      sla_policy:
+        created: "SLA Policy created."
+        updated: "SLA Policy updated."
+        deleted: "SLA Policy deleted."
+      settings:
+        updated: "Settings updated successfully."
+      plugin:
+        uploaded: "Plugin uploaded successfully. You can now activate it."
+        upload_failed: "Failed to upload plugin: %{error}"
+        activated: "Plugin activated successfully."
+        activate_failed: "Failed to activate plugin: %{error}"
+        deactivated: "Plugin deactivated successfully."
+        deactivate_failed: "Failed to deactivate plugin: %{error}"
+        composer_delete: "Composer plugins cannot be deleted. Remove the package via Composer instead."
+        deleted: "Plugin deleted successfully."
+        delete_failed: "Failed to delete plugin: %{error}"
+    middleware:
+      not_admin: "Access denied."
+      not_agent: "Access denied."
+      not_authorized: "You are not authorized to perform this action."
+      not_found: "The requested resource was not found."
+    inbound:
+      unknown_adapter: "Unknown adapter: %{adapter}"
+      verification_failed: "Verification failed"
+      internal_error: "Internal error"
+      disabled: "Inbound email is disabled"
+    mailer:
+      new_ticket: "[%{reference}] Ticket Created: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Ticket Assigned: %{subject}"
+      status_updated: "[%{reference}] Status Updated: %{status}"
+      sla_breach: "[SLA BREACH] [%{reference}] %{subject}"
+      escalated: "[ESCALATED] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Ticket Resolved: %{subject}"
+    validation:
+      name_required: "Name is required."
+      email_required: "Email is required."
+      subject_required: "Subject is required."
+      description_required: "Description is required."
+    commands:
+      install:
+        installing: "Installs the Escalated support ticket system"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Copied migrations. Run `rails db:migrate` to apply."
+        inject_user_model: "app/models/user.rb (Escalated role methods)"
+        inject_skip: "Could not inject into User model: %{error}"
+        inject_manual: "Add these methods to your User model manually:"
+        inject_agent: "escalated_agent? - returns true for support agents"
+        inject_admin: "escalated_admin? - returns true for support admins"
+        inject_agents_scope: "self.escalated_agents - scope returning all agents"
+        success: "Escalated installed successfully!"
+        next_steps: "Next steps:"
+        step1: "1. Run `rails db:migrate`"
+        step2: "2. Configure config/initializers/escalated.rb"
+        step3: "3. Add escalated_agent? and escalated_admin? methods to your User model"
+        step4: "4. Install Vue components: copy from vendor/escalated/resources/js/"
+        step5: "5. Set up your Inertia page resolver to include Escalated pages"
+      guest_not_enabled: "Guest tickets are not enabled."
+      ticket_not_found: "Ticket not found."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,111 @@
+es:
+  escalated:
+    ticket:
+      reply_sent: "Respuesta enviada."
+      note_added: "Nota interna añadida."
+      assigned: "Ticket asignado a %{name}."
+      unassigned: "Ticket desasignado."
+      status_updated: "Estado actualizado a %{status}."
+      priority_updated: "Prioridad actualizada a %{priority}."
+      tags_updated: "Etiquetas actualizadas."
+      department_updated: "Departamento cambiado a %{name}."
+      macro_applied: "Macro \"%{name}\" aplicada."
+      following: "Siguiendo ticket."
+      unfollowed: "Dejó de seguir el ticket."
+      only_internal_notes_pinned: "Solo se pueden fijar notas internas."
+      updated: "Ticket actualizado."
+      created: "Ticket creado exitosamente."
+      closed: "Ticket cerrado."
+      reopened: "Ticket reabierto."
+      customers_cannot_close: "Los clientes no pueden cerrar tickets."
+      note_pinned: "Nota fijada."
+      note_unpinned: "Nota desfijada."
+    guest:
+      created: "Ticket creado exitosamente."
+      ticket_closed: "Este ticket está cerrado."
+    bulk:
+      updated: "%{count} ticket(s) actualizado(s)."
+    rating:
+      only_resolved_closed: "Solo puede calificar tickets resueltos o cerrados."
+      already_rated: "Este ticket ya ha sido calificado."
+      thanks: "¡Gracias por sus comentarios!"
+    admin:
+      canned_response:
+        created: "Respuesta predefinida creada."
+        updated: "Respuesta predefinida actualizada."
+        deleted: "Respuesta predefinida eliminada."
+      department:
+        created: "Departamento creado."
+        updated: "Departamento actualizado."
+        deleted: "Departamento eliminado."
+      tag:
+        created: "Etiqueta creada."
+        updated: "Etiqueta actualizada."
+        deleted: "Etiqueta eliminada."
+      macro:
+        created: "Macro creada."
+        updated: "Macro actualizada."
+        deleted: "Macro eliminada."
+      escalation_rule:
+        created: "Regla de escalamiento creada."
+        updated: "Regla de escalamiento actualizada."
+        deleted: "Regla de escalamiento eliminada."
+      sla_policy:
+        created: "Política SLA creada."
+        updated: "Política SLA actualizada."
+        deleted: "Política SLA eliminada."
+      settings:
+        updated: "Configuración actualizada exitosamente."
+      plugin:
+        uploaded: "Plugin cargado exitosamente. Ahora puede activarlo."
+        upload_failed: "Error al cargar el plugin: %{error}"
+        activated: "Plugin activado exitosamente."
+        activate_failed: "Error al activar el plugin: %{error}"
+        deactivated: "Plugin desactivado exitosamente."
+        deactivate_failed: "Error al desactivar el plugin: %{error}"
+        composer_delete: "Los plugins de Composer no se pueden eliminar. Elimine el paquete a través de Composer."
+        deleted: "Plugin eliminado exitosamente."
+        delete_failed: "Error al eliminar el plugin: %{error}"
+    middleware:
+      not_admin: "Acceso denegado."
+      not_agent: "Acceso denegado."
+      not_authorized: "No está autorizado para realizar esta acción."
+      not_found: "El recurso solicitado no fue encontrado."
+    inbound:
+      unknown_adapter: "Adaptador desconocido: %{adapter}"
+      verification_failed: "Verificación fallida"
+      internal_error: "Error interno"
+      disabled: "El correo entrante está deshabilitado"
+    mailer:
+      new_ticket: "[%{reference}] Ticket creado: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Ticket asignado: %{subject}"
+      status_updated: "[%{reference}] Estado actualizado: %{status}"
+      sla_breach: "[INCUMPLIMIENTO SLA] [%{reference}] %{subject}"
+      escalated: "[ESCALADO] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Ticket resuelto: %{subject}"
+    validation:
+      name_required: "El nombre es obligatorio."
+      email_required: "El correo electrónico es obligatorio."
+      subject_required: "El asunto es obligatorio."
+      description_required: "La descripción es obligatoria."
+    commands:
+      install:
+        installing: "Instala el sistema de tickets de soporte Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migraciones copiadas. Ejecute `rails db:migrate` para aplicarlas."
+        inject_user_model: "app/models/user.rb (Métodos de rol de Escalated)"
+        inject_skip: "No se pudo inyectar en el modelo User: %{error}"
+        inject_manual: "Añada estos métodos a su modelo User manualmente:"
+        inject_agent: "escalated_agent? - retorna true para agentes de soporte"
+        inject_admin: "escalated_admin? - retorna true para administradores de soporte"
+        inject_agents_scope: "self.escalated_agents - scope que retorna todos los agentes"
+        success: "¡Escalated instalado exitosamente!"
+        next_steps: "Próximos pasos:"
+        step1: "1. Ejecute `rails db:migrate`"
+        step2: "2. Configure config/initializers/escalated.rb"
+        step3: "3. Añada los métodos escalated_agent? y escalated_admin? a su modelo User"
+        step4: "4. Instale los componentes Vue: copie desde vendor/escalated/resources/js/"
+        step5: "5. Configure el resolvedor de páginas Inertia para incluir páginas de Escalated"
+      guest_not_enabled: "Los tickets de invitado no están habilitados."
+      ticket_not_found: "Ticket no encontrado."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,111 @@
+fr:
+  escalated:
+    ticket:
+      reply_sent: "Réponse envoyée."
+      note_added: "Note interne ajoutée."
+      assigned: "Ticket assigné à %{name}."
+      unassigned: "Ticket désassigné."
+      status_updated: "Statut mis à jour : %{status}."
+      priority_updated: "Priorité mise à jour : %{priority}."
+      tags_updated: "Étiquettes mises à jour."
+      department_updated: "Département changé pour %{name}."
+      macro_applied: "Macro « %{name} » appliquée."
+      following: "Vous suivez le ticket."
+      unfollowed: "Vous ne suivez plus le ticket."
+      only_internal_notes_pinned: "Seules les notes internes peuvent être épinglées."
+      updated: "Ticket mis à jour."
+      created: "Ticket créé avec succès."
+      closed: "Ticket fermé."
+      reopened: "Ticket réouvert."
+      customers_cannot_close: "Les clients ne peuvent pas fermer les tickets."
+      note_pinned: "Note épinglée."
+      note_unpinned: "Note désépinglée."
+    guest:
+      created: "Ticket créé avec succès."
+      ticket_closed: "Ce ticket est fermé."
+    bulk:
+      updated: "%{count} ticket(s) mis à jour."
+    rating:
+      only_resolved_closed: "Vous ne pouvez évaluer que les tickets résolus ou fermés."
+      already_rated: "Ce ticket a déjà été évalué."
+      thanks: "Merci pour vos commentaires !"
+    admin:
+      canned_response:
+        created: "Réponse prédéfinie créée."
+        updated: "Réponse prédéfinie mise à jour."
+        deleted: "Réponse prédéfinie supprimée."
+      department:
+        created: "Département créé."
+        updated: "Département mis à jour."
+        deleted: "Département supprimé."
+      tag:
+        created: "Étiquette créée."
+        updated: "Étiquette mise à jour."
+        deleted: "Étiquette supprimée."
+      macro:
+        created: "Macro créée."
+        updated: "Macro mise à jour."
+        deleted: "Macro supprimée."
+      escalation_rule:
+        created: "Règle d'escalade créée."
+        updated: "Règle d'escalade mise à jour."
+        deleted: "Règle d'escalade supprimée."
+      sla_policy:
+        created: "Politique SLA créée."
+        updated: "Politique SLA mise à jour."
+        deleted: "Politique SLA supprimée."
+      settings:
+        updated: "Paramètres mis à jour avec succès."
+      plugin:
+        uploaded: "Plugin téléchargé avec succès. Vous pouvez maintenant l'activer."
+        upload_failed: "Échec du téléchargement du plugin : %{error}"
+        activated: "Plugin activé avec succès."
+        activate_failed: "Échec de l'activation du plugin : %{error}"
+        deactivated: "Plugin désactivé avec succès."
+        deactivate_failed: "Échec de la désactivation du plugin : %{error}"
+        composer_delete: "Les plugins Composer ne peuvent pas être supprimés. Supprimez le paquet via Composer."
+        deleted: "Plugin supprimé avec succès."
+        delete_failed: "Échec de la suppression du plugin : %{error}"
+    middleware:
+      not_admin: "Accès refusé."
+      not_agent: "Accès refusé."
+      not_authorized: "Vous n'êtes pas autorisé à effectuer cette action."
+      not_found: "La ressource demandée est introuvable."
+    inbound:
+      unknown_adapter: "Adaptateur inconnu : %{adapter}"
+      verification_failed: "Échec de la vérification"
+      internal_error: "Erreur interne"
+      disabled: "Le courrier entrant est désactivé"
+    mailer:
+      new_ticket: "[%{reference}] Ticket créé : %{subject}"
+      reply: "Re : [%{reference}] %{subject}"
+      assigned: "[%{reference}] Ticket assigné : %{subject}"
+      status_updated: "[%{reference}] Statut mis à jour : %{status}"
+      sla_breach: "[VIOLATION SLA] [%{reference}] %{subject}"
+      escalated: "[ESCALADÉ] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Ticket résolu : %{subject}"
+    validation:
+      name_required: "Le nom est obligatoire."
+      email_required: "L'adresse e-mail est obligatoire."
+      subject_required: "L'objet est obligatoire."
+      description_required: "La description est obligatoire."
+    commands:
+      install:
+        installing: "Installe le système de tickets de support Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migrations copiées. Exécutez `rails db:migrate` pour les appliquer."
+        inject_user_model: "app/models/user.rb (Méthodes de rôle Escalated)"
+        inject_skip: "Impossible d'injecter dans le modèle User : %{error}"
+        inject_manual: "Ajoutez ces méthodes à votre modèle User manuellement :"
+        inject_agent: "escalated_agent? - retourne true pour les agents de support"
+        inject_admin: "escalated_admin? - retourne true pour les administrateurs de support"
+        inject_agents_scope: "self.escalated_agents - scope retournant tous les agents"
+        success: "Escalated installé avec succès !"
+        next_steps: "Prochaines étapes :"
+        step1: "1. Exécutez `rails db:migrate`"
+        step2: "2. Configurez config/initializers/escalated.rb"
+        step3: "3. Ajoutez les méthodes escalated_agent? et escalated_admin? à votre modèle User"
+        step4: "4. Installez les composants Vue : copiez depuis vendor/escalated/resources/js/"
+        step5: "5. Configurez le résolveur de pages Inertia pour inclure les pages Escalated"
+      guest_not_enabled: "Les tickets invité ne sont pas activés."
+      ticket_not_found: "Ticket introuvable."

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -6,6 +6,10 @@ module Escalated
       # Allow host app to configure Escalated before boot
     end
 
+    initializer 'escalated.i18n' do
+      config.i18n.load_path += Dir[root.join('config', 'locales', '*.yml')]
+    end
+
     initializer "escalated.assets" do |app|
       # Make engine assets available to host app
       app.config.assets.precompile += %w[escalated_manifest.js] if app.config.respond_to?(:assets)

--- a/lib/generators/escalated/install_generator.rb
+++ b/lib/generators/escalated/install_generator.rb
@@ -8,7 +8,7 @@ module Escalated
 
       source_root File.expand_path("templates", __dir__)
 
-      desc "Installs the Escalated support ticket system"
+      desc I18n.t('escalated.commands.install.installing', default: "Installs the Escalated support ticket system")
 
       def self.next_migration_number(dirname)
         Time.now.strftime("%Y%m%d%H%M%S")
@@ -16,12 +16,12 @@ module Escalated
 
       def copy_initializer
         template "initializer.rb", "config/initializers/escalated.rb"
-        say_status :create, "config/initializers/escalated.rb", :green
+        say_status :create, I18n.t('escalated.commands.install.create_initializer'), :green
       end
 
       def copy_migrations
         rake "escalated:install:migrations"
-        say_status :info, "Copied migrations. Run `rails db:migrate` to apply.", :yellow
+        say_status :info, I18n.t('escalated.commands.install.copy_migrations'), :yellow
       end
 
       def add_user_concern
@@ -49,25 +49,25 @@ module Escalated
 
           RUBY
         end
-        say_status :inject, "app/models/user.rb (Escalated role methods)", :green
+        say_status :inject, I18n.t('escalated.commands.install.inject_user_model'), :green
       rescue StandardError => e
-        say_status :skip, "Could not inject into User model: #{e.message}", :yellow
-        say "  Add these methods to your User model manually:"
-        say "    escalated_agent? - returns true for support agents"
-        say "    escalated_admin? - returns true for support admins"
-        say "    self.escalated_agents - scope returning all agents"
+        say_status :skip, I18n.t('escalated.commands.install.inject_skip', error: e.message), :yellow
+        say "  #{I18n.t('escalated.commands.install.inject_manual')}"
+        say "    #{I18n.t('escalated.commands.install.inject_agent')}"
+        say "    #{I18n.t('escalated.commands.install.inject_admin')}"
+        say "    #{I18n.t('escalated.commands.install.inject_agents_scope')}"
       end
 
       def show_post_install
         say ""
-        say "Escalated installed successfully!", :green
+        say I18n.t('escalated.commands.install.success'), :green
         say ""
-        say "Next steps:"
-        say "  1. Run `rails db:migrate`"
-        say "  2. Configure config/initializers/escalated.rb"
-        say "  3. Add escalated_agent? and escalated_admin? methods to your User model"
-        say "  4. Install Vue components: copy from vendor/escalated/resources/js/"
-        say "  5. Set up your Inertia page resolver to include Escalated pages"
+        say I18n.t('escalated.commands.install.next_steps')
+        say "  #{I18n.t('escalated.commands.install.step1')}"
+        say "  #{I18n.t('escalated.commands.install.step2')}"
+        say "  #{I18n.t('escalated.commands.install.step3')}"
+        say "  #{I18n.t('escalated.commands.install.step4')}"
+        say "  #{I18n.t('escalated.commands.install.step5')}"
         say ""
       end
     end


### PR DESCRIPTION
Replace hardcoded English strings across controllers, mailer, engine, and install generator with Rails I18n.t() translation helper.

- Add YAML locale files for 4 locales (en, es, fr, de)
- Update controllers to use I18n.t() for flash messages and errors
- Update ticket mailer to use I18n.t() for email subjects and content
- Register locale files in engine initializer
- Update install generator to use translated output strings