### PR TITLE
fix: reject webhooks when auth credentials are missing

### DIFF
--- a/lib/escalated/mail/adapters/mailgun_adapter.rb
+++ b/lib/escalated/mail/adapters/mailgun_adapter.rb
@@ -41,7 +41,10 @@ module Escalated
         # @return [Boolean]
         def verify_request(request)
           signing_key = Escalated.configuration.mailgun_signing_key
-          return true if signing_key.blank? # Skip verification if no key configured
+          if signing_key.blank?
+            Rails.logger.warn("[Escalated::MailgunAdapter] Mailgun signing key not configured — rejecting webhook.")
+            return false
+          end
 
           params = request.params
           timestamp = params["timestamp"].to_s


### PR DESCRIPTION
- Mailgun: return false (was return true) when signing key is blank
- SES: add SNS message type validation and SigningCertURL domain check