### PR TITLE
feat: add platform parity with Laravel (phases 1-5)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "tzinfo-data"
+
 group :development, :test do
   gem "sqlite3"
   gem "rspec-rails"

--- a/app/controllers/escalated/admin/articles_controller.rb
+++ b/app/controllers/escalated/admin/articles_controller.rb
@@ -1,0 +1,85 @@
+module Escalated
+  module Admin
+    class ArticlesController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_article, only: [:update, :destroy]
+
+      def index
+        scope = Escalated::Article.includes(:category, :author).recent
+
+        scope = scope.search(params[:search]) if params[:search].present?
+        scope = scope.where(status: params[:status]) if params[:status].present?
+        scope = scope.where(category_id: params[:category_id]) if params[:category_id].present?
+
+        result = paginate(scope)
+
+        render inertia: "Escalated/Admin/Articles/Index", props: {
+          articles: result[:data].map { |a| article_json(a) },
+          meta: result[:meta],
+          filters: {
+            search: params[:search],
+            status: params[:status],
+            category_id: params[:category_id]
+          },
+          categories: Escalated::ArticleCategory.ordered.map { |c| { id: c.id, name: c.name } },
+          statuses: Escalated::Article.statuses.keys
+        }
+      end
+
+      def create
+        article = Escalated::Article.new(article_params)
+        article.author = escalated_current_user
+
+        if article.save
+          redirect_to escalated.admin_articles_path, notice: I18n.t('escalated.admin.article.created')
+        else
+          redirect_back fallback_location: escalated.admin_articles_path,
+                        alert: article.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @article.update(article_params)
+          redirect_to escalated.admin_articles_path, notice: I18n.t('escalated.admin.article.updated')
+        else
+          redirect_back fallback_location: escalated.admin_articles_path,
+                        alert: @article.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @article.destroy!
+        redirect_to escalated.admin_articles_path, notice: I18n.t('escalated.admin.article.deleted')
+      end
+
+      private
+
+      def set_article
+        @article = Escalated::Article.find(params[:id])
+      end
+
+      def article_params
+        params.require(:article).permit(:title, :slug, :body, :status, :category_id)
+      end
+
+      def article_json(article)
+        {
+          id: article.id,
+          title: article.title,
+          slug: article.slug,
+          status: article.status,
+          category: article.category ? {
+            id: article.category.id,
+            name: article.category.name
+          } : nil,
+          author: article.author ? {
+            id: article.author.id,
+            name: article.author.respond_to?(:name) ? article.author.name : article.author.email
+          } : nil,
+          created_at: article.created_at&.iso8601,
+          updated_at: article.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/audit_logs_controller.rb
+++ b/app/controllers/escalated/admin/audit_logs_controller.rb
@@ -1,0 +1,51 @@
+module Escalated
+  module Admin
+    class AuditLogsController < Escalated::ApplicationController
+      before_action :require_admin!
+
+      def index
+        scope = Escalated::AuditLog.includes(:user).recent
+
+        scope = scope.where(user_id: params[:user_id]) if params[:user_id].present?
+        scope = scope.where(action: params[:action]) if params[:action].present?
+        scope = scope.where(auditable_type: params[:auditable_type]) if params[:auditable_type].present?
+        scope = scope.where("created_at >= ?", params[:date_from]) if params[:date_from].present?
+        scope = scope.where("created_at <= ?", params[:date_to].to_time.end_of_day) if params[:date_to].present?
+
+        result = paginate(scope)
+
+        render inertia: "Escalated/Admin/AuditLogs/Index", props: {
+          logs: result[:data].map { |l| log_json(l) },
+          meta: result[:meta],
+          filters: {
+            user_id: params[:user_id],
+            action: params[:action],
+            auditable_type: params[:auditable_type],
+            date_from: params[:date_from],
+            date_to: params[:date_to]
+          }
+        }
+      end
+
+      private
+
+      def log_json(log)
+        {
+          id: log.id,
+          action: log.action,
+          auditable_type: log.auditable_type,
+          auditable_id: log.auditable_id,
+          changes: log.changes,
+          ip_address: log.ip_address,
+          user_agent: log.user_agent,
+          user: log.user ? {
+            id: log.user.id,
+            name: log.user.respond_to?(:name) ? log.user.name : log.user.email,
+            email: log.user.email
+          } : nil,
+          created_at: log.created_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/automations_controller.rb
+++ b/app/controllers/escalated/admin/automations_controller.rb
@@ -1,0 +1,71 @@
+module Escalated
+  module Admin
+    class AutomationsController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_automation, only: [:update, :destroy]
+
+      def index
+        automations = Escalated::Automation.ordered
+
+        render inertia: "Escalated/Admin/Automations/Index", props: {
+          automations: automations.map { |a| automation_json(a) }
+        }
+      end
+
+      def create
+        automation = Escalated::Automation.new(automation_params)
+
+        if automation.save
+          redirect_to escalated.admin_automations_path, notice: I18n.t('escalated.admin.automation.created')
+        else
+          redirect_back fallback_location: escalated.admin_automations_path,
+                        alert: automation.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @automation.update(automation_params)
+          redirect_to escalated.admin_automations_path, notice: I18n.t('escalated.admin.automation.updated')
+        else
+          redirect_back fallback_location: escalated.admin_automations_path,
+                        alert: @automation.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @automation.destroy!
+        redirect_to escalated.admin_automations_path, notice: I18n.t('escalated.admin.automation.deleted')
+      end
+
+      private
+
+      def set_automation
+        @automation = Escalated::Automation.find(params[:id])
+      end
+
+      def automation_params
+        params.require(:automation).permit(
+          :name, :description, :is_active, :run_on,
+          conditions: [:field, :operator, :value],
+          actions: [:type, :value]
+        )
+      end
+
+      def automation_json(automation)
+        {
+          id: automation.id,
+          name: automation.name,
+          description: automation.description,
+          is_active: automation.is_active,
+          run_on: automation.run_on,
+          conditions: automation.conditions,
+          actions: automation.actions,
+          last_run_at: automation.last_run_at&.iso8601,
+          run_count: automation.run_count,
+          created_at: automation.created_at&.iso8601,
+          updated_at: automation.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/business_hours_controller.rb
+++ b/app/controllers/escalated/admin/business_hours_controller.rb
@@ -1,0 +1,88 @@
+module Escalated
+  module Admin
+    class BusinessHoursController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_schedule, only: [:update, :destroy]
+
+      def index
+        schedules = Escalated::BusinessSchedule.includes(:holidays).ordered
+
+        render inertia: "Escalated/Admin/BusinessHours/Index", props: {
+          schedules: schedules.map { |s| schedule_json(s) }
+        }
+      end
+
+      def create
+        schedule = Escalated::BusinessSchedule.new(schedule_params)
+
+        if schedule.save
+          sync_holidays(schedule, holidays_param)
+          redirect_to escalated.admin_business_hours_index_path, notice: I18n.t('escalated.admin.business_hours.created')
+        else
+          redirect_back fallback_location: escalated.admin_business_hours_index_path,
+                        alert: schedule.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @schedule.update(schedule_params)
+          sync_holidays(@schedule, holidays_param)
+          redirect_to escalated.admin_business_hours_index_path, notice: I18n.t('escalated.admin.business_hours.updated')
+        else
+          redirect_back fallback_location: escalated.admin_business_hours_index_path,
+                        alert: @schedule.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @schedule.destroy!
+        redirect_to escalated.admin_business_hours_index_path, notice: I18n.t('escalated.admin.business_hours.deleted')
+      end
+
+      private
+
+      def set_schedule
+        @schedule = Escalated::BusinessSchedule.find(params[:id])
+      end
+
+      def schedule_params
+        params.require(:business_schedule).permit(:name, :timezone, schedule: {})
+      end
+
+      def holidays_param
+        params[:holidays].is_a?(Array) ? params[:holidays] : []
+      end
+
+      def sync_holidays(schedule, holidays_data)
+        schedule.holidays.destroy_all
+
+        holidays_data.each do |holiday|
+          schedule.holidays.create!(
+            name: holiday[:name] || holiday["name"],
+            date: holiday[:date] || holiday["date"]
+          )
+        end
+      end
+
+      def schedule_json(schedule)
+        {
+          id: schedule.id,
+          name: schedule.name,
+          timezone: schedule.timezone,
+          schedule: schedule.schedule,
+          holidays: schedule.holidays.map { |h| holiday_json(h) },
+          created_at: schedule.created_at&.iso8601,
+          updated_at: schedule.updated_at&.iso8601
+        }
+      end
+
+      def holiday_json(holiday)
+        {
+          id: holiday.id,
+          name: holiday.name,
+          date: holiday.date&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/capacity_controller.rb
+++ b/app/controllers/escalated/admin/capacity_controller.rb
@@ -1,0 +1,49 @@
+module Escalated
+  module Admin
+    class CapacityController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_capacity, only: [:update]
+
+      def index
+        capacities = Escalated::AgentCapacity.includes(:agent).ordered
+
+        render inertia: "Escalated/Admin/Capacity/Index", props: {
+          capacities: capacities.map { |c| capacity_json(c) }
+        }
+      end
+
+      def update
+        if @capacity.update(capacity_params)
+          redirect_to escalated.admin_capacity_index_path, notice: I18n.t('escalated.admin.capacity.updated')
+        else
+          redirect_back fallback_location: escalated.admin_capacity_index_path,
+                        alert: @capacity.errors.full_messages.join(", ")
+        end
+      end
+
+      private
+
+      def set_capacity
+        @capacity = Escalated::AgentCapacity.find(params[:id])
+      end
+
+      def capacity_params
+        params.require(:agent_capacity).permit(:max_concurrent)
+      end
+
+      def capacity_json(capacity)
+        {
+          id: capacity.id,
+          max_concurrent: capacity.max_concurrent,
+          current_count: capacity.current_count,
+          agent: capacity.agent ? {
+            id: capacity.agent.id,
+            name: capacity.agent.respond_to?(:name) ? capacity.agent.name : capacity.agent.email,
+            email: capacity.agent.email
+          } : nil,
+          updated_at: capacity.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/custom_fields_controller.rb
+++ b/app/controllers/escalated/admin/custom_fields_controller.rb
@@ -1,0 +1,84 @@
+module Escalated
+  module Admin
+    class CustomFieldsController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_field, only: [:update, :destroy]
+
+      def index
+        fields = Escalated::CustomField.ordered
+
+        render inertia: "Escalated/Admin/CustomFields/Index", props: {
+          fields: fields.map { |f| field_json(f) }
+        }
+      end
+
+      def create
+        field = Escalated::CustomField.new(field_params)
+
+        if field.save
+          redirect_to escalated.admin_custom_fields_path, notice: I18n.t('escalated.admin.custom_field.created')
+        else
+          redirect_back fallback_location: escalated.admin_custom_fields_path,
+                        alert: field.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @field.update(field_params)
+          redirect_to escalated.admin_custom_fields_path, notice: I18n.t('escalated.admin.custom_field.updated')
+        else
+          redirect_back fallback_location: escalated.admin_custom_fields_path,
+                        alert: @field.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @field.destroy!
+        redirect_to escalated.admin_custom_fields_path, notice: I18n.t('escalated.admin.custom_field.deleted')
+      end
+
+      def reorder
+        positions = params[:positions]
+
+        return render json: { error: "positions required" }, status: :unprocessable_entity unless positions.is_a?(Array)
+
+        positions.each_with_index do |field_id, index|
+          Escalated::CustomField.where(id: field_id).update_all(position: index + 1)
+        end
+
+        render json: { success: true }
+      end
+
+      private
+
+      def set_field
+        @field = Escalated::CustomField.find(params[:id])
+      end
+
+      def field_params
+        params.require(:custom_field).permit(
+          :label, :key, :field_type, :applies_to, :position,
+          :is_required, :is_agent_only, :description,
+          options: []
+        )
+      end
+
+      def field_json(field)
+        {
+          id: field.id,
+          label: field.label,
+          key: field.key,
+          field_type: field.field_type,
+          applies_to: field.applies_to,
+          position: field.position,
+          is_required: field.is_required,
+          is_agent_only: field.is_agent_only,
+          description: field.description,
+          options: field.options,
+          created_at: field.created_at&.iso8601,
+          updated_at: field.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/custom_objects_controller.rb
+++ b/app/controllers/escalated/admin/custom_objects_controller.rb
@@ -1,0 +1,112 @@
+module Escalated
+  module Admin
+    class CustomObjectsController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_object_definition, only: [:update, :destroy, :records, :store_record, :update_record, :destroy_record]
+
+      def index
+        definitions = Escalated::CustomObject.ordered
+
+        render inertia: "Escalated/Admin/CustomObjects/Index", props: {
+          objects: definitions.map { |o| object_json(o) }
+        }
+      end
+
+      def create
+        definition = Escalated::CustomObject.new(object_params)
+
+        if definition.save
+          redirect_to escalated.admin_custom_objects_path, notice: I18n.t('escalated.admin.custom_object.created')
+        else
+          redirect_back fallback_location: escalated.admin_custom_objects_path,
+                        alert: definition.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @definition.update(object_params)
+          redirect_to escalated.admin_custom_objects_path, notice: I18n.t('escalated.admin.custom_object.updated')
+        else
+          redirect_back fallback_location: escalated.admin_custom_objects_path,
+                        alert: @definition.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @definition.destroy!
+        redirect_to escalated.admin_custom_objects_path, notice: I18n.t('escalated.admin.custom_object.deleted')
+      end
+
+      def records
+        result = paginate(@definition.records.recent)
+
+        render json: {
+          records: result[:data].map { |r| record_json(r) },
+          meta: result[:meta]
+        }
+      end
+
+      def store_record
+        record = @definition.records.new(
+          data: params[:data] || {},
+          created_by: escalated_current_user.id
+        )
+
+        if record.save
+          render json: record_json(record), status: :created
+        else
+          render json: { error: record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def update_record
+        record = @definition.records.find(params[:record_id])
+
+        if record.update(data: params[:data] || {})
+          render json: record_json(record)
+        else
+          render json: { error: record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy_record
+        record = @definition.records.find(params[:record_id])
+        record.destroy!
+
+        render json: { success: true }
+      end
+
+      private
+
+      def set_object_definition
+        @definition = Escalated::CustomObject.find(params[:id])
+      end
+
+      def object_params
+        params.require(:custom_object).permit(:name, :key, :description, fields: [:name, :type, :required])
+      end
+
+      def object_json(definition)
+        {
+          id: definition.id,
+          name: definition.name,
+          key: definition.key,
+          description: definition.description,
+          fields: definition.fields,
+          record_count: definition.records.count,
+          created_at: definition.created_at&.iso8601,
+          updated_at: definition.updated_at&.iso8601
+        }
+      end
+
+      def record_json(record)
+        {
+          id: record.id,
+          data: record.data,
+          created_at: record.created_at&.iso8601,
+          updated_at: record.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/kb_categories_controller.rb
+++ b/app/controllers/escalated/admin/kb_categories_controller.rb
@@ -1,0 +1,62 @@
+module Escalated
+  module Admin
+    class KbCategoriesController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_category, only: [:update, :destroy]
+
+      def index
+        categories = Escalated::ArticleCategory.ordered
+
+        render inertia: "Escalated/Admin/KbCategories/Index", props: {
+          categories: categories.map { |c| category_json(c) }
+        }
+      end
+
+      def store
+        category = Escalated::ArticleCategory.new(category_params)
+
+        if category.save
+          render json: category_json(category), status: :created
+        else
+          render json: { error: category.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @category.update(category_params)
+          render json: category_json(@category)
+        else
+          render json: { error: @category.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @category.destroy!
+        render json: { success: true }
+      end
+
+      private
+
+      def set_category
+        @category = Escalated::ArticleCategory.find(params[:id])
+      end
+
+      def category_params
+        params.require(:article_category).permit(:name, :description, :slug, :position)
+      end
+
+      def category_json(category)
+        {
+          id: category.id,
+          name: category.name,
+          slug: category.slug,
+          description: category.description,
+          position: category.position,
+          article_count: category.articles.count,
+          created_at: category.created_at&.iso8601,
+          updated_at: category.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/reports_controller.rb
+++ b/app/controllers/escalated/admin/reports_controller.rb
@@ -51,6 +51,30 @@ module Escalated
         }
       end
 
+      def dashboard
+        today = Time.current.beginning_of_day..Time.current.end_of_day
+        this_week = 1.week.ago.beginning_of_day..Time.current.end_of_day
+
+        render inertia: "Escalated/Admin/Reports/Dashboard", props: {
+          today: {
+            created: Escalated::Ticket.where(created_at: today).count,
+            resolved: Escalated::Ticket.where(resolved_at: today).count,
+            closed: Escalated::Ticket.where(closed_at: today).count,
+            first_replies: Escalated::Ticket.where(first_response_at: today).count
+          },
+          this_week: {
+            created: Escalated::Ticket.where(created_at: this_week).count,
+            resolved: Escalated::Ticket.where(resolved_at: this_week).count
+          },
+          open_by_priority: Escalated::Ticket.priorities.keys.each_with_object({}) { |priority, hash|
+            hash[priority] = Escalated::Ticket.by_open.where(priority: priority).count
+          },
+          sla_breaches_today: Escalated::Ticket.where(sla_breached: true).where(updated_at: today).count,
+          unassigned_open: Escalated::Ticket.by_open.unassigned.count,
+          csat_this_week: calculate_csat_stats(1.week.ago.beginning_of_day, Time.current.end_of_day)
+        }
+      end
+
       private
 
       def parse_date(value)

--- a/app/controllers/escalated/admin/roles_controller.rb
+++ b/app/controllers/escalated/admin/roles_controller.rb
@@ -1,0 +1,88 @@
+module Escalated
+  module Admin
+    class RolesController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_role, only: [:update, :destroy]
+
+      def index
+        roles = Escalated::Role.includes(:permissions).ordered
+
+        render inertia: "Escalated/Admin/Roles/Index", props: {
+          roles: roles.map { |r| role_json(r) },
+          permissions: Escalated::Permission.ordered.map { |p| permission_json(p) }
+        }
+      end
+
+      def create
+        role = Escalated::Role.new(role_params)
+
+        if role.save
+          sync_permissions(role, params[:permission_ids])
+          redirect_to escalated.admin_roles_path, notice: I18n.t('escalated.admin.role.created')
+        else
+          redirect_back fallback_location: escalated.admin_roles_path,
+                        alert: role.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @role.update(role_params)
+          sync_permissions(@role, params[:permission_ids])
+          redirect_to escalated.admin_roles_path, notice: I18n.t('escalated.admin.role.updated')
+        else
+          redirect_back fallback_location: escalated.admin_roles_path,
+                        alert: @role.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        if @role.is_system?
+          redirect_back fallback_location: escalated.admin_roles_path,
+                        alert: I18n.t('escalated.admin.role.cannot_delete_system')
+          return
+        end
+
+        @role.destroy!
+        redirect_to escalated.admin_roles_path, notice: I18n.t('escalated.admin.role.deleted')
+      end
+
+      private
+
+      def set_role
+        @role = Escalated::Role.find(params[:id])
+      end
+
+      def role_params
+        params.require(:role).permit(:name, :description)
+      end
+
+      def sync_permissions(role, permission_ids)
+        return unless permission_ids.is_a?(Array)
+
+        role.permissions = Escalated::Permission.where(id: permission_ids)
+      end
+
+      def role_json(role)
+        {
+          id: role.id,
+          name: role.name,
+          description: role.description,
+          is_system: role.is_system?,
+          permissions: role.permissions.map { |p| permission_json(p) },
+          created_at: role.created_at&.iso8601,
+          updated_at: role.updated_at&.iso8601
+        }
+      end
+
+      def permission_json(perm)
+        {
+          id: perm.id,
+          name: perm.name,
+          description: perm.description,
+          resource: perm.resource,
+          action: perm.action
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/settings_controller.rb
+++ b/app/controllers/escalated/admin/settings_controller.rb
@@ -16,6 +16,90 @@ module Escalated
         }
       end
 
+      def two_factor
+        render inertia: "Escalated/Admin/Settings/TwoFactor", props: {
+          two_factor_required: Escalated::EscalatedSetting.get("two_factor_required") == "1",
+          two_factor_grace_period_hours: Escalated::EscalatedSetting.get("two_factor_grace_period_hours").to_i
+        }
+      end
+
+      def two_factor_setup
+        render inertia: "Escalated/Admin/Settings/TwoFactorSetup", props: {
+          otp_secret: ROTP::Base32.random,
+          user_email: escalated_current_user.email
+        }
+      end
+
+      def two_factor_confirm
+        totp = ROTP::TOTP.new(params[:otp_secret])
+
+        unless totp.verify(params[:otp_code].to_s, drift_behind: 30)
+          return redirect_back fallback_location: escalated.admin_settings_two_factor_path,
+                               alert: I18n.t('escalated.admin.two_factor.invalid_code')
+        end
+
+        Escalated::TwoFactor.create_or_update_for(
+          escalated_current_user,
+          otp_secret: params[:otp_secret]
+        )
+
+        redirect_to escalated.admin_settings_two_factor_path, notice: I18n.t('escalated.admin.two_factor.enabled')
+      end
+
+      def two_factor_disable
+        two_factor = Escalated::TwoFactor.find_by(user_id: escalated_current_user.id)
+        two_factor&.destroy!
+
+        redirect_to escalated.admin_settings_two_factor_path, notice: I18n.t('escalated.admin.two_factor.disabled')
+      end
+
+      def sso
+        render inertia: "Escalated/Admin/Settings/Sso", props: {
+          sso_enabled: Escalated::EscalatedSetting.get("sso_enabled") == "1",
+          sso_provider: Escalated::EscalatedSetting.get("sso_provider"),
+          sso_metadata_url: Escalated::EscalatedSetting.get("sso_metadata_url"),
+          sso_client_id: Escalated::EscalatedSetting.get("sso_client_id"),
+          sso_issuer: Escalated::EscalatedSetting.get("sso_issuer")
+        }
+      end
+
+      def update_sso
+        %w[sso_provider sso_metadata_url sso_client_id sso_issuer sso_client_secret].each do |key|
+          next unless params.key?(key)
+
+          Escalated::EscalatedSetting.set(key, params[key].to_s.strip)
+        end
+
+        sso_enabled = params[:sso_enabled].in?(%w[1 true on]) ? "1" : "0"
+        Escalated::EscalatedSetting.set("sso_enabled", sso_enabled)
+
+        redirect_to escalated.admin_settings_sso_path, notice: I18n.t('escalated.admin.settings.updated')
+      end
+
+      def csat
+        render inertia: "Escalated/Admin/Settings/Csat", props: {
+          csat_enabled: Escalated::EscalatedSetting.get("csat_enabled") == "1",
+          csat_send_after_hours: Escalated::EscalatedSetting.get("csat_send_after_hours").to_i,
+          csat_message: Escalated::EscalatedSetting.get("csat_message")
+        }
+      end
+
+      def update_csat
+        csat_enabled = params[:csat_enabled].in?(%w[1 true on]) ? "1" : "0"
+        Escalated::EscalatedSetting.set("csat_enabled", csat_enabled)
+
+        if params[:csat_send_after_hours].present?
+          hours = params[:csat_send_after_hours].to_i
+          Escalated::EscalatedSetting.set("csat_send_after_hours", [0, hours].max.to_s)
+        end
+
+        if params[:csat_message].present?
+          Escalated::EscalatedSetting.set("csat_message", params[:csat_message].to_s.strip)
+        end
+
+        redirect_to escalated.admin_settings_csat_path, notice: I18n.t('escalated.admin.settings.updated')
+      end
+
       def update
         # Boolean settings
         %w[guest_tickets_enabled allow_customer_close inbound_email_enabled].each do |key|

--- a/app/controllers/escalated/admin/side_conversations_controller.rb
+++ b/app/controllers/escalated/admin/side_conversations_controller.rb
@@ -1,0 +1,74 @@
+module Escalated
+  module Admin
+    class SideConversationsController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_ticket
+      before_action :set_conversation, only: [:reply, :close]
+
+      def index
+        conversations = @ticket.side_conversations.includes(:replies).ordered
+
+        render json: conversations.map { |c| conversation_json(c) }
+      end
+
+      def store
+        conversation = @ticket.side_conversations.new(
+          subject: params[:subject],
+          body: params[:body],
+          channel: params[:channel] || "email",
+          created_by: escalated_current_user.id
+        )
+
+        if conversation.save
+          render json: conversation_json(conversation), status: :created
+        else
+          render json: { error: conversation.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      def reply
+        reply = @conversation.replies.create!(
+          body: params[:body],
+          author_id: escalated_current_user.id,
+          direction: "outbound"
+        )
+
+        render json: {
+          id: reply.id,
+          body: reply.body,
+          direction: reply.direction,
+          created_at: reply.created_at&.iso8601
+        }, status: :created
+      end
+
+      def close
+        @conversation.update!(status: "closed", closed_at: Time.current)
+
+        render json: conversation_json(@conversation)
+      end
+
+      private
+
+      def set_ticket
+        @ticket = Escalated::Ticket.find(params[:ticket_id])
+      end
+
+      def set_conversation
+        @conversation = @ticket.side_conversations.find(params[:conversation_id])
+      end
+
+      def conversation_json(conversation)
+        {
+          id: conversation.id,
+          subject: conversation.subject,
+          body: conversation.body,
+          channel: conversation.channel,
+          status: conversation.status,
+          created_at: conversation.created_at&.iso8601,
+          closed_at: conversation.closed_at&.iso8601,
+          replies_count: conversation.replies.count
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/skills_controller.rb
+++ b/app/controllers/escalated/admin/skills_controller.rb
@@ -1,0 +1,62 @@
+module Escalated
+  module Admin
+    class SkillsController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_skill, only: [:update, :destroy]
+
+      def index
+        skills = Escalated::Skill.ordered
+
+        render inertia: "Escalated/Admin/Skills/Index", props: {
+          skills: skills.map { |s| skill_json(s) }
+        }
+      end
+
+      def create
+        skill = Escalated::Skill.new(skill_params)
+
+        if skill.save
+          redirect_to escalated.admin_skills_path, notice: I18n.t('escalated.admin.skill.created')
+        else
+          redirect_back fallback_location: escalated.admin_skills_path,
+                        alert: skill.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @skill.update(skill_params)
+          redirect_to escalated.admin_skills_path, notice: I18n.t('escalated.admin.skill.updated')
+        else
+          redirect_back fallback_location: escalated.admin_skills_path,
+                        alert: @skill.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @skill.destroy!
+        redirect_to escalated.admin_skills_path, notice: I18n.t('escalated.admin.skill.deleted')
+      end
+
+      private
+
+      def set_skill
+        @skill = Escalated::Skill.find(params[:id])
+      end
+
+      def skill_params
+        params.require(:skill).permit(:name, :description)
+      end
+
+      def skill_json(skill)
+        {
+          id: skill.id,
+          name: skill.name,
+          description: skill.description,
+          agent_count: skill.respond_to?(:agent_profiles) ? skill.agent_profiles.count : 0,
+          created_at: skill.created_at&.iso8601,
+          updated_at: skill.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/statuses_controller.rb
+++ b/app/controllers/escalated/admin/statuses_controller.rb
@@ -1,0 +1,75 @@
+module Escalated
+  module Admin
+    class StatusesController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_status, only: [:update, :destroy]
+
+      def index
+        statuses = Escalated::TicketStatus.ordered
+
+        render inertia: "Escalated/Admin/Statuses/Index", props: {
+          statuses: statuses.map { |s| status_json(s) },
+          categories: Escalated::TicketStatus.categories.keys
+        }
+      end
+
+      def create
+        status = Escalated::TicketStatus.new(status_params)
+
+        if status.is_default
+          Escalated::TicketStatus.where(category: status.category, is_default: true).update_all(is_default: false)
+        end
+
+        if status.save
+          redirect_to escalated.admin_statuses_path, notice: I18n.t('escalated.admin.status.created')
+        else
+          redirect_back fallback_location: escalated.admin_statuses_path,
+                        alert: status.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if status_params[:is_default] == "1" || status_params[:is_default] == true
+          Escalated::TicketStatus.where(category: @status.category, is_default: true)
+            .where.not(id: @status.id)
+            .update_all(is_default: false)
+        end
+
+        if @status.update(status_params)
+          redirect_to escalated.admin_statuses_path, notice: I18n.t('escalated.admin.status.updated')
+        else
+          redirect_back fallback_location: escalated.admin_statuses_path,
+                        alert: @status.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @status.destroy!
+        redirect_to escalated.admin_statuses_path, notice: I18n.t('escalated.admin.status.deleted')
+      end
+
+      private
+
+      def set_status
+        @status = Escalated::TicketStatus.find(params[:id])
+      end
+
+      def status_params
+        params.require(:ticket_status).permit(:label, :category, :color, :position, :is_default)
+      end
+
+      def status_json(status)
+        {
+          id: status.id,
+          label: status.label,
+          category: status.category,
+          color: status.color,
+          position: status.position,
+          is_default: status.is_default,
+          created_at: status.created_at&.iso8601,
+          updated_at: status.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/ticket_links_controller.rb
+++ b/app/controllers/escalated/admin/ticket_links_controller.rb
@@ -1,0 +1,63 @@
+module Escalated
+  module Admin
+    class TicketLinksController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_ticket
+
+      def index
+        links = @ticket.ticket_links.includes(:linked_ticket)
+
+        render json: links.map { |l| link_json(l) }
+      end
+
+      def store
+        linked_ticket = Escalated::Ticket.find_by(id: params[:linked_ticket_id])
+
+        return render json: { error: "Ticket not found" }, status: :not_found unless linked_ticket
+        return render json: { error: "Cannot link a ticket to itself" }, status: :unprocessable_entity if linked_ticket.id == @ticket.id
+
+        existing = Escalated::TicketLink.where(ticket_id: @ticket.id, linked_ticket_id: linked_ticket.id)
+          .or(Escalated::TicketLink.where(ticket_id: linked_ticket.id, linked_ticket_id: @ticket.id))
+          .exists?
+
+        return render json: { error: "Link already exists" }, status: :unprocessable_entity if existing
+
+        link = Escalated::TicketLink.create!(
+          ticket: @ticket,
+          linked_ticket: linked_ticket,
+          link_type: params[:link_type] || "related"
+        )
+
+        render json: link_json(link), status: :created
+      end
+
+      def destroy
+        link = @ticket.ticket_links.find(params[:link_id])
+        link.destroy!
+
+        render json: { success: true }
+      end
+
+      private
+
+      def set_ticket
+        @ticket = Escalated::Ticket.find(params[:ticket_id])
+      end
+
+      def link_json(link)
+        {
+          id: link.id,
+          link_type: link.link_type,
+          linked_ticket: {
+            id: link.linked_ticket.id,
+            reference: link.linked_ticket.reference,
+            subject: link.linked_ticket.subject,
+            status: link.linked_ticket.status,
+            priority: link.linked_ticket.priority
+          },
+          created_at: link.created_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/ticket_merges_controller.rb
+++ b/app/controllers/escalated/admin/ticket_merges_controller.rb
@@ -1,0 +1,52 @@
+module Escalated
+  module Admin
+    class TicketMergesController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_ticket
+
+      def search
+        query = params[:q].to_s.strip
+
+        return render json: [] if query.blank?
+
+        tickets = Escalated::Ticket.search(query)
+          .where.not(id: @ticket.id)
+          .limit(10)
+          .map do |t|
+            {
+              id: t.id,
+              reference: t.reference,
+              subject: t.subject,
+              status: t.status,
+              requester: t.requester ? {
+                id: t.requester.id,
+                name: t.requester.respond_to?(:name) ? t.requester.name : t.requester.email
+              } : nil
+            }
+          end
+
+        render json: tickets
+      end
+
+      def merge
+        target_reference = params[:target_reference].to_s.strip
+        target = Escalated::Ticket.find_by(reference: target_reference)
+
+        return render json: { error: "Target ticket not found" }, status: :not_found unless target
+        return render json: { error: "Cannot merge a ticket into itself" }, status: :unprocessable_entity if target.id == @ticket.id
+
+        Services::TicketMergeService.merge(@ticket, target, merged_by: escalated_current_user)
+
+        render json: { success: true, target_id: target.id, target_reference: target.reference }
+      rescue Services::TicketMergeService::Error => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+
+      private
+
+      def set_ticket
+        @ticket = Escalated::Ticket.find(params[:ticket_id])
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/webhooks_controller.rb
+++ b/app/controllers/escalated/admin/webhooks_controller.rb
@@ -1,0 +1,99 @@
+module Escalated
+  module Admin
+    class WebhooksController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_webhook, only: [:update, :destroy, :deliveries]
+
+      def index
+        webhooks = Escalated::Webhook.ordered
+
+        render inertia: "Escalated/Admin/Webhooks/Index", props: {
+          webhooks: webhooks.map { |w| webhook_json(w) }
+        }
+      end
+
+      def create
+        webhook = Escalated::Webhook.new(webhook_params)
+
+        if webhook.save
+          redirect_to escalated.admin_webhooks_path, notice: I18n.t('escalated.admin.webhook.created')
+        else
+          redirect_back fallback_location: escalated.admin_webhooks_path,
+                        alert: webhook.errors.full_messages.join(", ")
+        end
+      end
+
+      def update
+        if @webhook.update(webhook_params)
+          redirect_to escalated.admin_webhooks_path, notice: I18n.t('escalated.admin.webhook.updated')
+        else
+          redirect_back fallback_location: escalated.admin_webhooks_path,
+                        alert: @webhook.errors.full_messages.join(", ")
+        end
+      end
+
+      def destroy
+        @webhook.destroy!
+        redirect_to escalated.admin_webhooks_path, notice: I18n.t('escalated.admin.webhook.deleted')
+      end
+
+      def deliveries
+        result = paginate(@webhook.deliveries.recent)
+
+        render inertia: "Escalated/Admin/Webhooks/Deliveries", props: {
+          webhook: webhook_json(@webhook),
+          deliveries: result[:data].map { |d| delivery_json(d) },
+          meta: result[:meta]
+        }
+      end
+
+      def retry_delivery
+        delivery = Escalated::WebhookDelivery.find(params[:delivery_id])
+
+        Services::WebhookService.retry(delivery)
+
+        redirect_back fallback_location: escalated.admin_webhooks_path,
+                      notice: I18n.t('escalated.admin.webhook.delivery_retried')
+      rescue ActiveRecord::RecordNotFound
+        redirect_back fallback_location: escalated.admin_webhooks_path,
+                      alert: I18n.t('escalated.middleware.not_found')
+      end
+
+      private
+
+      def set_webhook
+        @webhook = Escalated::Webhook.find(params[:id])
+      end
+
+      def webhook_params
+        params.require(:webhook).permit(:url, :secret, :is_active, events: [])
+      end
+
+      def webhook_json(webhook)
+        {
+          id: webhook.id,
+          url: webhook.url,
+          is_active: webhook.is_active,
+          events: webhook.events,
+          deliveries_count: webhook.deliveries.count,
+          last_delivery_at: webhook.deliveries.recent.first&.created_at&.iso8601,
+          created_at: webhook.created_at&.iso8601,
+          updated_at: webhook.updated_at&.iso8601
+        }
+      end
+
+      def delivery_json(delivery)
+        {
+          id: delivery.id,
+          event: delivery.event,
+          status_code: delivery.status_code,
+          success: delivery.success?,
+          request_body: delivery.request_body,
+          response_body: delivery.response_body,
+          duration_ms: delivery.duration_ms,
+          created_at: delivery.created_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/models/escalated/agent_capacity.rb
+++ b/app/models/escalated/agent_capacity.rb
@@ -1,0 +1,19 @@
+module Escalated
+  class AgentCapacity < ApplicationRecord
+    self.table_name = Escalated.table_name("agent_capacity")
+
+    belongs_to :user, class_name: Escalated.configuration.user_class
+
+    validates :user_id, uniqueness: { scope: :channel }
+
+    def load_percentage
+      return 0 if max_concurrent.to_i.zero?
+
+      ((current_count.to_f / max_concurrent) * 100).round
+    end
+
+    def has_capacity?
+      current_count < max_concurrent
+    end
+  end
+end

--- a/app/models/escalated/agent_profile.rb
+++ b/app/models/escalated/agent_profile.rb
@@ -1,0 +1,21 @@
+module Escalated
+  class AgentProfile < ApplicationRecord
+    self.table_name = Escalated.table_name("agent_profiles")
+
+    belongs_to :user, class_name: Escalated.configuration.user_class
+
+    validates :user_id, uniqueness: true
+
+    def light_agent?
+      agent_type == "light"
+    end
+
+    def full_agent?
+      agent_type == "full"
+    end
+
+    def self.for_user(user_id)
+      find_by(user_id: user_id)
+    end
+  end
+end

--- a/app/models/escalated/agent_skill.rb
+++ b/app/models/escalated/agent_skill.rb
@@ -1,0 +1,10 @@
+module Escalated
+  class AgentSkill < ApplicationRecord
+    self.table_name = Escalated.table_name("agent_skills")
+
+    belongs_to :user, class_name: Escalated.configuration.user_class
+    belongs_to :skill, class_name: "Escalated::Skill"
+
+    validates :user_id, uniqueness: { scope: :skill_id }
+  end
+end

--- a/app/models/escalated/article.rb
+++ b/app/models/escalated/article.rb
@@ -1,0 +1,32 @@
+module Escalated
+  class Article < ApplicationRecord
+    self.table_name = Escalated.table_name("articles")
+
+    belongs_to :category, class_name: "Escalated::ArticleCategory", optional: true
+    belongs_to :author, class_name: Escalated.configuration.user_class, optional: true
+
+    validates :title, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    scope :published, -> { where(status: "published") }
+    scope :draft, -> { where(status: "draft") }
+    scope :search, ->(term) { where("title LIKE ? OR body LIKE ?", "%#{term}%", "%#{term}%") }
+    scope :recent, -> { order(created_at: :desc) }
+
+    def increment_views!
+      increment!(:view_count)
+    end
+
+    def mark_helpful!
+      increment!(:helpful_count)
+    end
+
+    def mark_not_helpful!
+      increment!(:not_helpful_count)
+    end
+
+    def to_s
+      title
+    end
+  end
+end

--- a/app/models/escalated/article_category.rb
+++ b/app/models/escalated/article_category.rb
@@ -1,0 +1,19 @@
+module Escalated
+  class ArticleCategory < ApplicationRecord
+    self.table_name = Escalated.table_name("article_categories")
+
+    belongs_to :parent, class_name: "Escalated::ArticleCategory", optional: true
+    has_many :children,
+             class_name: "Escalated::ArticleCategory",
+             foreign_key: :parent_id,
+             dependent: :nullify
+    has_many :articles, class_name: "Escalated::Article", foreign_key: :category_id, dependent: :nullify
+
+    scope :roots, -> { where(parent_id: nil) }
+    scope :ordered, -> { order(position: :asc, name: :asc) }
+
+    def to_s
+      name
+    end
+  end
+end

--- a/app/models/escalated/audit_log.rb
+++ b/app/models/escalated/audit_log.rb
@@ -1,0 +1,12 @@
+module Escalated
+  class AuditLog < ApplicationRecord
+    self.table_name = Escalated.table_name("audit_logs")
+
+    belongs_to :user, class_name: Escalated.configuration.user_class, optional: true
+    belongs_to :auditable, polymorphic: true
+
+    scope :recent, -> { order(created_at: :desc) }
+    scope :by_action, ->(action) { where(action: action) }
+    scope :by_user, ->(user_id) { where(user_id: user_id) }
+  end
+end

--- a/app/models/escalated/automation.rb
+++ b/app/models/escalated/automation.rb
@@ -1,0 +1,13 @@
+module Escalated
+  class Automation < ApplicationRecord
+    self.table_name = Escalated.table_name("automations")
+
+    validates :name, presence: true
+
+    scope :active, -> { where(active: true).order(position: :asc) }
+
+    def to_s
+      name
+    end
+  end
+end

--- a/app/models/escalated/business_schedule.rb
+++ b/app/models/escalated/business_schedule.rb
@@ -1,0 +1,11 @@
+module Escalated
+  class BusinessSchedule < ApplicationRecord
+    self.table_name = Escalated.table_name("business_schedules")
+
+    has_many :holidays, class_name: "Escalated::Holiday", foreign_key: :schedule_id, dependent: :destroy
+
+    def to_s
+      name
+    end
+  end
+end

--- a/app/models/escalated/custom_field.rb
+++ b/app/models/escalated/custom_field.rb
@@ -1,0 +1,29 @@
+module Escalated
+  class CustomField < ApplicationRecord
+    self.table_name = Escalated.table_name("custom_fields")
+
+    FIELD_TYPES = %w[text textarea select multi_select checkbox date number].freeze
+    CONTEXTS = %w[ticket user organization].freeze
+
+    has_many :values, class_name: "Escalated::CustomFieldValue", dependent: :destroy
+
+    validates :name, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    before_validation :generate_slug, if: -> { slug.blank? }
+
+    scope :ordered, -> { order(position: :asc) }
+    scope :active, -> { where(active: true) }
+    scope :for_context, ->(ctx) { where(context: ctx) }
+
+    def to_s
+      name
+    end
+
+    private
+
+    def generate_slug
+      self.slug = name.to_s.parameterize(separator: "_")
+    end
+  end
+end

--- a/app/models/escalated/custom_field_value.rb
+++ b/app/models/escalated/custom_field_value.rb
@@ -1,0 +1,12 @@
+module Escalated
+  class CustomFieldValue < ApplicationRecord
+    self.table_name = Escalated.table_name("custom_field_values")
+
+    belongs_to :custom_field, class_name: "Escalated::CustomField"
+    belongs_to :entity, polymorphic: true
+
+    def to_s
+      "#{custom_field.name}: #{value}"
+    end
+  end
+end

--- a/app/models/escalated/custom_object.rb
+++ b/app/models/escalated/custom_object.rb
@@ -1,0 +1,17 @@
+module Escalated
+  class CustomObject < ApplicationRecord
+    self.table_name = Escalated.table_name("custom_objects")
+
+    has_many :records,
+             class_name: "Escalated::CustomObjectRecord",
+             foreign_key: :object_id,
+             dependent: :destroy
+
+    validates :name, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    def to_s
+      name
+    end
+  end
+end

--- a/app/models/escalated/custom_object_record.rb
+++ b/app/models/escalated/custom_object_record.rb
@@ -1,0 +1,7 @@
+module Escalated
+  class CustomObjectRecord < ApplicationRecord
+    self.table_name = Escalated.table_name("custom_object_records")
+
+    belongs_to :object, class_name: "Escalated::CustomObject"
+  end
+end

--- a/app/models/escalated/holiday.rb
+++ b/app/models/escalated/holiday.rb
@@ -1,0 +1,14 @@
+module Escalated
+  class Holiday < ApplicationRecord
+    self.table_name = Escalated.table_name("holidays")
+
+    belongs_to :schedule, class_name: "Escalated::BusinessSchedule"
+
+    validates :name, presence: true
+    validates :date, presence: true
+
+    def to_s
+      "#{name} (#{date})"
+    end
+  end
+end

--- a/app/models/escalated/permission.rb
+++ b/app/models/escalated/permission.rb
@@ -1,0 +1,18 @@
+module Escalated
+  class Permission < ApplicationRecord
+    self.table_name = Escalated.table_name("permissions")
+
+    has_and_belongs_to_many :roles,
+                            join_table: Escalated.table_name("role_permissions"),
+                            class_name: "Escalated::Role"
+
+    validates :name, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    scope :ordered, -> { order(group: :asc, name: :asc) }
+
+    def to_s
+      name
+    end
+  end
+end

--- a/app/models/escalated/reply.rb
+++ b/app/models/escalated/reply.rb
@@ -3,7 +3,7 @@ module Escalated
     self.table_name = Escalated.table_name("replies")
 
     belongs_to :ticket, class_name: "Escalated::Ticket"
-    belongs_to :author, polymorphic: true
+    belongs_to :author, polymorphic: true, optional: true
     has_many :attachments, as: :attachable, dependent: :destroy, class_name: "Escalated::Attachment"
 
     validates :body, presence: true

--- a/app/models/escalated/role.rb
+++ b/app/models/escalated/role.rb
@@ -1,0 +1,33 @@
+module Escalated
+  class Role < ApplicationRecord
+    self.table_name = Escalated.table_name("roles")
+
+    has_and_belongs_to_many :permissions,
+                            join_table: Escalated.table_name("role_permissions"),
+                            class_name: "Escalated::Permission"
+    has_and_belongs_to_many :users,
+                            join_table: Escalated.table_name("role_users"),
+                            class_name: Escalated.configuration.user_class,
+                            foreign_key: :role_id,
+                            association_foreign_key: :user_id
+
+    validates :name, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    before_validation :generate_slug, if: -> { slug.blank? }
+
+    def has_permission?(slug)
+      permissions.exists?(slug: slug)
+    end
+
+    def to_s
+      name
+    end
+
+    private
+
+    def generate_slug
+      self.slug = name.to_s.parameterize(separator: "_")
+    end
+  end
+end

--- a/app/models/escalated/side_conversation.rb
+++ b/app/models/escalated/side_conversation.rb
@@ -1,0 +1,15 @@
+module Escalated
+  class SideConversation < ApplicationRecord
+    self.table_name = Escalated.table_name("side_conversations")
+
+    belongs_to :ticket, class_name: "Escalated::Ticket"
+    belongs_to :created_by, class_name: Escalated.configuration.user_class, optional: true
+    has_many :replies, class_name: "Escalated::SideConversationReply", dependent: :destroy
+
+    scope :open, -> { where(status: "open") }
+
+    def to_s
+      "Side conversation: #{subject}"
+    end
+  end
+end

--- a/app/models/escalated/side_conversation_reply.rb
+++ b/app/models/escalated/side_conversation_reply.rb
@@ -1,0 +1,14 @@
+module Escalated
+  class SideConversationReply < ApplicationRecord
+    self.table_name = Escalated.table_name("side_conversation_replies")
+
+    belongs_to :side_conversation, class_name: "Escalated::SideConversation"
+    belongs_to :author, class_name: Escalated.configuration.user_class, optional: true
+
+    validates :body, presence: true
+
+    def to_s
+      "Reply on #{side_conversation.subject}"
+    end
+  end
+end

--- a/app/models/escalated/skill.rb
+++ b/app/models/escalated/skill.rb
@@ -1,0 +1,26 @@
+module Escalated
+  class Skill < ApplicationRecord
+    self.table_name = Escalated.table_name("skills")
+
+    has_many :agent_skills, class_name: "Escalated::AgentSkill", dependent: :destroy
+    has_many :agents,
+             through: :agent_skills,
+             source: :user,
+             class_name: Escalated.configuration.user_class
+
+    validates :name, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    before_validation :generate_slug, if: -> { slug.blank? }
+
+    def to_s
+      name
+    end
+
+    private
+
+    def generate_slug
+      self.slug = name.to_s.parameterize(separator: "_")
+    end
+  end
+end

--- a/app/models/escalated/ticket.rb
+++ b/app/models/escalated/ticket.rb
@@ -23,6 +23,16 @@ module Escalated
     has_one :satisfaction_rating, class_name: "Escalated::SatisfactionRating", dependent: :destroy
     has_many :pinned_notes, -> { where(is_internal: true, is_pinned: true) },
              class_name: "Escalated::Reply"
+    has_many :links_as_parent,
+             class_name: "Escalated::TicketLink",
+             foreign_key: :parent_ticket_id,
+             dependent: :destroy
+    has_many :links_as_child,
+             class_name: "Escalated::TicketLink",
+             foreign_key: :child_ticket_id,
+             dependent: :destroy
+    belongs_to :merged_into, class_name: "Escalated::Ticket", optional: true
+    has_many :side_conversations, class_name: "Escalated::SideConversation", dependent: :destroy
 
     enum :status, {
       open: 0,

--- a/app/models/escalated/ticket_link.rb
+++ b/app/models/escalated/ticket_link.rb
@@ -1,0 +1,13 @@
+module Escalated
+  class TicketLink < ApplicationRecord
+    self.table_name = Escalated.table_name("ticket_links")
+
+    LINK_TYPES = %w[problem_incident parent_child related].freeze
+
+    belongs_to :parent_ticket, class_name: "Escalated::Ticket"
+    belongs_to :child_ticket, class_name: "Escalated::Ticket"
+
+    validates :link_type, presence: true, inclusion: { in: LINK_TYPES }
+    validates :parent_ticket_id, uniqueness: { scope: [:child_ticket_id, :link_type] }
+  end
+end

--- a/app/models/escalated/ticket_status.rb
+++ b/app/models/escalated/ticket_status.rb
@@ -1,0 +1,25 @@
+module Escalated
+  class TicketStatus < ApplicationRecord
+    self.table_name = Escalated.table_name("ticket_statuses")
+
+    CATEGORIES = %w[new open pending on_hold solved].freeze
+
+    validates :label, presence: true
+    validates :slug, presence: true, uniqueness: true
+
+    before_validation :generate_slug, if: -> { slug.blank? }
+
+    scope :ordered, -> { order(category: :asc, position: :asc) }
+    scope :by_category, ->(cat) { where(category: cat) }
+
+    def to_s
+      label
+    end
+
+    private
+
+    def generate_slug
+      self.slug = label.to_s.parameterize(separator: "_")
+    end
+  end
+end

--- a/app/models/escalated/two_factor.rb
+++ b/app/models/escalated/two_factor.rb
@@ -1,0 +1,13 @@
+module Escalated
+  class TwoFactor < ApplicationRecord
+    self.table_name = Escalated.table_name("two_factors")
+
+    belongs_to :user, class_name: Escalated.configuration.user_class
+
+    validates :user_id, uniqueness: true
+
+    def confirmed?
+      confirmed_at.present?
+    end
+  end
+end

--- a/app/models/escalated/webhook.rb
+++ b/app/models/escalated/webhook.rb
@@ -1,0 +1,19 @@
+module Escalated
+  class Webhook < ApplicationRecord
+    self.table_name = Escalated.table_name("webhooks")
+
+    has_many :deliveries, class_name: "Escalated::WebhookDelivery", dependent: :destroy
+
+    validates :url, presence: true
+
+    scope :active, -> { where(active: true) }
+
+    def subscribed_to?(event)
+      Array(events).include?(event.to_s)
+    end
+
+    def to_s
+      url
+    end
+  end
+end

--- a/app/models/escalated/webhook_delivery.rb
+++ b/app/models/escalated/webhook_delivery.rb
@@ -1,0 +1,11 @@
+module Escalated
+  class WebhookDelivery < ApplicationRecord
+    self.table_name = Escalated.table_name("webhook_deliveries")
+
+    belongs_to :webhook, class_name: "Escalated::Webhook"
+
+    def success?
+      response_code.to_i.between?(200, 299)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,8 +70,70 @@ Escalated::Engine.routes.draw do
       end
     end
     get :reports, to: "reports#index"
+    get "reports/dashboard", to: "reports#dashboard", as: :reports_dashboard
     get :settings, to: "settings#index"
     post :settings, to: "settings#update"
+
+    # Phase 1
+    resources :statuses, only: [:index, :create, :update, :destroy]
+    resources :business_hours, only: [:index, :create, :update, :destroy]
+    resources :roles, only: [:index, :create, :update, :destroy]
+    resources :audit_logs, only: [:index]
+
+    # Phase 2
+    resources :custom_fields, only: [:index, :create, :update, :destroy] do
+      collection do
+        post :reorder
+      end
+    end
+    resources :tickets, only: [] do
+      member do
+        get :links, to: "ticket_links#index"
+        post :store_link, to: "ticket_links#store"
+        delete "links/:link_id", to: "ticket_links#destroy", as: :destroy_link
+        get :merge_search, to: "ticket_merges#search"
+        post :merge, to: "ticket_merges#merge"
+        get :side_conversations, to: "side_conversations#index"
+        post :store_side_conversation, to: "side_conversations#store"
+        post "side_conversations/:conversation_id/reply", to: "side_conversations#reply", as: :side_conversation_reply
+        post "side_conversations/:conversation_id/close", to: "side_conversations#close", as: :side_conversation_close
+      end
+    end
+    resources :articles, only: [:index, :create, :update, :destroy]
+    resources :kb_categories, only: [:index, :create, :update, :destroy]
+
+    # Phase 3
+    resources :skills, only: [:index, :create, :update, :destroy]
+    resources :capacity, only: [:index, :update]
+
+    # Phase 4
+    resources :webhooks, only: [:index, :create, :update, :destroy] do
+      member do
+        get :deliveries
+      end
+      collection do
+        post "deliveries/:delivery_id/retry", action: :retry_delivery, as: :retry_delivery
+      end
+    end
+    resources :automations, only: [:index, :create, :update, :destroy]
+
+    # Phase 5
+    get "settings/two_factor", to: "settings#two_factor", as: :settings_two_factor
+    post "settings/two_factor/setup", to: "settings#two_factor_setup", as: :settings_two_factor_setup
+    post "settings/two_factor/confirm", to: "settings#two_factor_confirm", as: :settings_two_factor_confirm
+    post "settings/two_factor/disable", to: "settings#two_factor_disable", as: :settings_two_factor_disable
+    get "settings/sso", to: "settings#sso", as: :settings_sso
+    post "settings/sso", to: "settings#update_sso", as: :settings_update_sso
+    get "settings/csat", to: "settings#csat", as: :settings_csat
+    post "settings/csat", to: "settings#update_csat", as: :settings_update_csat
+    resources :custom_objects, only: [:index, :create, :update, :destroy] do
+      member do
+        get :records
+        post :store_record
+        put "records/:record_id", action: :update_record, as: :update_record
+        delete "records/:record_id", action: :destroy_record, as: :destroy_record
+      end
+    end
   end
 
   # Guest routes (no authentication required)

--- a/db/migrate/015_create_escalated_satisfaction_ratings.rb
+++ b/db/migrate/015_create_escalated_satisfaction_ratings.rb
@@ -12,7 +12,8 @@ class CreateEscalatedSatisfactionRatings < ActiveRecord::Migration[7.0]
       t.datetime :created_at
     end
 
-    add_index Escalated.table_name("satisfaction_ratings"), [:rated_by_type, :rated_by_id]
+    add_index Escalated.table_name("satisfaction_ratings"), [:rated_by_type, :rated_by_id],
+              name: "idx_escalated_sat_ratings_rated_by"
     add_index Escalated.table_name("satisfaction_ratings"),
               :ticket_id,
               unique: true,

--- a/db/migrate/019_create_escalated_audit_logs.rb
+++ b/db/migrate/019_create_escalated_audit_logs.rb
@@ -1,0 +1,21 @@
+class CreateEscalatedAuditLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("audit_logs") do |t|
+      t.bigint :user_id, null: true
+      t.string :action, null: false
+      t.string :auditable_type
+      t.bigint :auditable_id
+      t.json :old_values
+      t.json :new_values
+      t.string :ip_address
+      t.string :user_agent, limit: 500
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("audit_logs"), [:auditable_type, :auditable_id]
+    add_index Escalated.table_name("audit_logs"), :user_id
+    add_index Escalated.table_name("audit_logs"), :action
+    add_index Escalated.table_name("audit_logs"), :created_at
+  end
+end

--- a/db/migrate/020_create_escalated_ticket_statuses.rb
+++ b/db/migrate/020_create_escalated_ticket_statuses.rb
@@ -1,0 +1,19 @@
+class CreateEscalatedTicketStatuses < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("ticket_statuses") do |t|
+      t.string :label, null: false
+      t.string :slug, null: false
+      t.string :category
+      t.string :color, default: "#6b7280"
+      t.text :description
+      t.integer :position, default: 0, null: false
+      t.boolean :is_default, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("ticket_statuses"), :slug, unique: true
+    add_index Escalated.table_name("ticket_statuses"), :category
+    add_index Escalated.table_name("ticket_statuses"), :position
+  end
+end

--- a/db/migrate/021_create_escalated_business_schedules.rb
+++ b/db/migrate/021_create_escalated_business_schedules.rb
@@ -1,0 +1,29 @@
+class CreateEscalatedBusinessSchedules < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("business_schedules") do |t|
+      t.string :name, null: false
+      t.string :timezone, null: false, default: "UTC"
+      t.boolean :is_default, default: false, null: false
+      t.json :schedule
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("business_schedules"), :is_default
+
+    create_table Escalated.table_name("holidays") do |t|
+      t.bigint :schedule_id, null: false
+      t.string :name, null: false
+      t.date :date, null: false
+      t.boolean :recurring, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("holidays"), :schedule_id
+    add_index Escalated.table_name("holidays"), :date
+    add_foreign_key Escalated.table_name("holidays"),
+                    Escalated.table_name("business_schedules"),
+                    column: :schedule_id
+  end
+end

--- a/db/migrate/022_create_escalated_roles_and_permissions.rb
+++ b/db/migrate/022_create_escalated_roles_and_permissions.rb
@@ -1,0 +1,46 @@
+class CreateEscalatedRolesAndPermissions < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("permissions") do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.string :group
+      t.text :description
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("permissions"), :slug, unique: true
+    add_index Escalated.table_name("permissions"), :group
+
+    create_table Escalated.table_name("roles") do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :description
+      t.boolean :is_system, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("roles"), :slug, unique: true
+
+    create_table Escalated.table_name("role_permissions"), id: false do |t|
+      t.bigint :role_id, null: false
+      t.bigint :permission_id, null: false
+    end
+
+    add_index Escalated.table_name("role_permissions"),
+              [:role_id, :permission_id],
+              unique: true,
+              name: "idx_escalated_role_permissions_unique"
+
+    create_table Escalated.table_name("role_users"), id: false do |t|
+      t.bigint :role_id, null: false
+      t.bigint :user_id, null: false
+    end
+
+    add_index Escalated.table_name("role_users"),
+              [:role_id, :user_id],
+              unique: true,
+              name: "idx_escalated_role_users_unique"
+  end
+end

--- a/db/migrate/023_create_escalated_custom_fields.rb
+++ b/db/migrate/023_create_escalated_custom_fields.rb
@@ -1,0 +1,40 @@
+class CreateEscalatedCustomFields < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("custom_fields") do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.string :field_type, null: false
+      t.string :context, null: false, default: "ticket"
+      t.json :options
+      t.boolean :required, default: false, null: false
+      t.string :placeholder
+      t.text :description
+      t.json :validation_rules
+      t.json :conditions
+      t.integer :position, default: 0, null: false
+      t.boolean :active, default: true, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("custom_fields"), :slug, unique: true
+    add_index Escalated.table_name("custom_fields"), :context
+    add_index Escalated.table_name("custom_fields"), :active
+    add_index Escalated.table_name("custom_fields"), :position
+
+    create_table Escalated.table_name("custom_field_values") do |t|
+      t.bigint :custom_field_id, null: false
+      t.string :entity_type, null: false
+      t.bigint :entity_id, null: false
+      t.text :value
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("custom_field_values"), :custom_field_id
+    add_index Escalated.table_name("custom_field_values"), [:entity_type, :entity_id]
+    add_foreign_key Escalated.table_name("custom_field_values"),
+                    Escalated.table_name("custom_fields"),
+                    column: :custom_field_id
+  end
+end

--- a/db/migrate/024_add_type_and_merged_into_to_tickets.rb
+++ b/db/migrate/024_add_type_and_merged_into_to_tickets.rb
@@ -1,0 +1,9 @@
+class AddTypeAndMergedIntoToTickets < ActiveRecord::Migration[7.0]
+  def change
+    add_column Escalated.table_name("tickets"), :ticket_type, :string, default: "question"
+    add_column Escalated.table_name("tickets"), :merged_into_id, :bigint, null: true
+
+    add_index Escalated.table_name("tickets"), :ticket_type
+    add_index Escalated.table_name("tickets"), :merged_into_id
+  end
+end

--- a/db/migrate/025_create_escalated_ticket_links.rb
+++ b/db/migrate/025_create_escalated_ticket_links.rb
@@ -1,0 +1,18 @@
+class CreateEscalatedTicketLinks < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("ticket_links") do |t|
+      t.bigint :parent_ticket_id, null: false
+      t.bigint :child_ticket_id, null: false
+      t.string :link_type, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("ticket_links"),
+              [:parent_ticket_id, :child_ticket_id, :link_type],
+              unique: true,
+              name: "idx_escalated_ticket_links_unique"
+    add_index Escalated.table_name("ticket_links"), :parent_ticket_id
+    add_index Escalated.table_name("ticket_links"), :child_ticket_id
+  end
+end

--- a/db/migrate/026_create_escalated_side_conversations.rb
+++ b/db/migrate/026_create_escalated_side_conversations.rb
@@ -1,0 +1,33 @@
+class CreateEscalatedSideConversations < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("side_conversations") do |t|
+      t.bigint :ticket_id, null: false
+      t.string :subject, null: false
+      t.string :channel, default: "email"
+      t.string :status, default: "open", null: false
+      t.bigint :created_by_id
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("side_conversations"), :ticket_id
+    add_index Escalated.table_name("side_conversations"), :status
+    add_foreign_key Escalated.table_name("side_conversations"),
+                    Escalated.table_name("tickets"),
+                    column: :ticket_id
+
+    create_table Escalated.table_name("side_conversation_replies") do |t|
+      t.bigint :side_conversation_id, null: false
+      t.text :body, null: false
+      t.bigint :author_id
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("side_conversation_replies"), :side_conversation_id,
+              name: "idx_esc_side_conv_replies_on_conv_id"
+    add_foreign_key Escalated.table_name("side_conversation_replies"),
+                    Escalated.table_name("side_conversations"),
+                    column: :side_conversation_id
+  end
+end

--- a/db/migrate/027_create_escalated_knowledge_base.rb
+++ b/db/migrate/027_create_escalated_knowledge_base.rb
@@ -1,0 +1,38 @@
+class CreateEscalatedKnowledgeBase < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("article_categories") do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.bigint :parent_id
+      t.integer :position, default: 0, null: false
+      t.text :description
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("article_categories"), :slug, unique: true
+    add_index Escalated.table_name("article_categories"), :parent_id
+    add_index Escalated.table_name("article_categories"), :position
+
+    create_table Escalated.table_name("articles") do |t|
+      t.bigint :category_id
+      t.string :title, null: false
+      t.string :slug, null: false
+      t.text :body
+      t.string :status, default: "draft", null: false
+      t.bigint :author_id
+      t.integer :view_count, default: 0, null: false
+      t.integer :helpful_count, default: 0, null: false
+      t.integer :not_helpful_count, default: 0, null: false
+      t.datetime :published_at
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("articles"), :slug, unique: true
+    add_index Escalated.table_name("articles"), :category_id
+    add_index Escalated.table_name("articles"), :status
+    add_index Escalated.table_name("articles"), :author_id
+    add_index Escalated.table_name("articles"), :published_at
+  end
+end

--- a/db/migrate/028_create_escalated_agent_tables.rb
+++ b/db/migrate/028_create_escalated_agent_tables.rb
@@ -1,0 +1,47 @@
+class CreateEscalatedAgentTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("agent_profiles") do |t|
+      t.bigint :user_id, null: false
+      t.string :agent_type, default: "full", null: false
+      t.integer :max_tickets
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("agent_profiles"), :user_id, unique: true
+
+    create_table Escalated.table_name("skills") do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("skills"), :slug, unique: true
+
+    create_table Escalated.table_name("agent_skills"), id: false do |t|
+      t.bigint :user_id, null: false
+      t.bigint :skill_id, null: false
+      t.integer :proficiency, default: 1, null: false
+    end
+
+    add_index Escalated.table_name("agent_skills"),
+              [:user_id, :skill_id],
+              unique: true,
+              name: "idx_escalated_agent_skills_unique"
+
+    create_table Escalated.table_name("agent_capacity") do |t|
+      t.bigint :user_id, null: false
+      t.string :channel, default: "default", null: false
+      t.integer :max_concurrent, default: 10, null: false
+      t.integer :current_count, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("agent_capacity"),
+              [:user_id, :channel],
+              unique: true,
+              name: "idx_escalated_agent_capacity_unique"
+  end
+end

--- a/db/migrate/029_create_escalated_webhooks.rb
+++ b/db/migrate/029_create_escalated_webhooks.rb
@@ -1,0 +1,34 @@
+class CreateEscalatedWebhooks < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("webhooks") do |t|
+      t.string :url, null: false
+      t.json :events
+      t.string :secret
+      t.boolean :active, default: true, null: false
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("webhooks"), :active
+
+    create_table Escalated.table_name("webhook_deliveries") do |t|
+      t.bigint :webhook_id, null: false
+      t.string :event, null: false
+      t.json :payload
+      t.integer :response_code
+      t.text :response_body
+      t.integer :attempts, default: 0, null: false
+      t.datetime :delivered_at
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("webhook_deliveries"), :webhook_id
+    add_index Escalated.table_name("webhook_deliveries"), :event
+    add_index Escalated.table_name("webhook_deliveries"), :delivered_at
+    add_foreign_key Escalated.table_name("webhook_deliveries"),
+                    Escalated.table_name("webhooks"),
+                    column: :webhook_id,
+                    on_delete: :cascade
+  end
+end

--- a/db/migrate/030_create_escalated_automations.rb
+++ b/db/migrate/030_create_escalated_automations.rb
@@ -1,0 +1,17 @@
+class CreateEscalatedAutomations < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("automations") do |t|
+      t.string :name, null: false
+      t.json :conditions
+      t.json :actions
+      t.boolean :active, default: true, null: false
+      t.integer :position, default: 0, null: false
+      t.datetime :last_run_at
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("automations"), :active
+    add_index Escalated.table_name("automations"), :position
+  end
+end

--- a/db/migrate/031_create_escalated_two_factor.rb
+++ b/db/migrate/031_create_escalated_two_factor.rb
@@ -1,0 +1,14 @@
+class CreateEscalatedTwoFactor < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("two_factors") do |t|
+      t.bigint :user_id, null: false
+      t.text :secret
+      t.json :recovery_codes
+      t.datetime :confirmed_at
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("two_factors"), :user_id, unique: true
+  end
+end

--- a/db/migrate/032_create_escalated_custom_objects.rb
+++ b/db/migrate/032_create_escalated_custom_objects.rb
@@ -1,0 +1,26 @@
+class CreateEscalatedCustomObjects < ActiveRecord::Migration[7.0]
+  def change
+    create_table Escalated.table_name("custom_objects") do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.json :fields_schema
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("custom_objects"), :slug, unique: true
+
+    create_table Escalated.table_name("custom_object_records") do |t|
+      t.bigint :object_id, null: false
+      t.json :data
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name("custom_object_records"), :object_id
+    add_foreign_key Escalated.table_name("custom_object_records"),
+                    Escalated.table_name("custom_objects"),
+                    column: :object_id,
+                    on_delete: :cascade
+  end
+end

--- a/lib/escalated/services/automation_runner.rb
+++ b/lib/escalated/services/automation_runner.rb
@@ -1,0 +1,68 @@
+module Escalated
+  module Services
+    class AutomationRunner
+      def run
+        affected = 0
+
+        Escalated::Automation.active.each do |automation|
+          tickets = find_matching_tickets(automation)
+          tickets.each do |ticket|
+            execute_actions(automation, ticket)
+            affected += 1
+          end
+          automation.update!(last_run_at: Time.current)
+        end
+
+        affected
+      end
+
+      private
+
+      def find_matching_tickets(automation)
+        scope = Escalated::Ticket.where(status: [:open, :in_progress, :waiting_on_customer, :waiting_on_agent, :escalated, :reopened])
+
+        (automation.conditions || []).each do |condition|
+          field = condition["field"]
+          value = condition["value"]
+
+          case field
+          when "hours_since_created"
+            scope = scope.where("created_at <= ?", value.to_i.hours.ago)
+          when "hours_since_updated"
+            scope = scope.where("updated_at <= ?", value.to_i.hours.ago)
+          when "status"
+            scope = scope.where(status: value)
+          when "priority"
+            scope = scope.where(priority: value)
+          when "assigned"
+            scope = value == "unassigned" ? scope.where(assigned_to: nil) : scope.where.not(assigned_to: nil)
+          end
+        end
+
+        scope
+      end
+
+      def execute_actions(automation, ticket)
+        (automation.actions || []).each do |action|
+          type = action["type"]
+          value = action["value"]
+
+          begin
+            case type
+            when "change_status" then ticket.update!(status: value)
+            when "assign" then ticket.update!(assigned_to: value.to_i)
+            when "add_tag"
+              tag = Escalated::Tag.find_by(name: value)
+              ticket.tags << tag if tag && !ticket.tags.include?(tag)
+            when "change_priority" then ticket.update!(priority: value)
+            when "add_note"
+              Escalated::Reply.create!(ticket: ticket, body: value, is_internal: true, is_system: true, is_pinned: false)
+            end
+          rescue => e
+            Rails.logger.warn("Escalated automation action failed: automation=#{automation.id} ticket=#{ticket.id} action=#{type} error=#{e.message}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/escalated/services/business_hours_calculator.rb
+++ b/lib/escalated/services/business_hours_calculator.rb
@@ -1,0 +1,83 @@
+module Escalated
+  module Services
+    class BusinessHoursCalculator
+      def within_business_hours?(dt, schedule)
+        tz = ActiveSupport::TimeZone[schedule.timezone]
+        dt_local = dt.in_time_zone(tz)
+        return false if holiday?(dt_local, schedule)
+
+        day_schedule = get_day_schedule(dt_local, schedule)
+        return false unless day_schedule&.dig("start") && day_schedule&.dig("end")
+
+        time_str = dt_local.strftime("%H:%M")
+        day_schedule["start"] <= time_str && time_str < day_schedule["end"]
+      end
+
+      def add_business_hours(start, hours, schedule)
+        tz = ActiveSupport::TimeZone[schedule.timezone]
+        current = start.in_time_zone(tz)
+        remaining_minutes = hours * 60
+        max_iterations = 365
+
+        while remaining_minutes > 0 && max_iterations > 0
+          max_iterations -= 1
+
+          if holiday?(current, schedule)
+            current = (current + 1.day).beginning_of_day
+            next
+          end
+
+          day_schedule = get_day_schedule(current, schedule)
+
+          unless day_schedule&.dig("start") && day_schedule&.dig("end")
+            current = (current + 1.day).beginning_of_day
+            next
+          end
+
+          start_parts = day_schedule["start"].split(":")
+          end_parts = day_schedule["end"].split(":")
+          day_start = current.change(hour: start_parts[0].to_i, min: start_parts[1].to_i)
+          day_end = current.change(hour: end_parts[0].to_i, min: end_parts[1].to_i)
+
+          current = day_start if current < day_start
+
+          if current >= day_end
+            current = (current + 1.day).beginning_of_day
+            next
+          end
+
+          available_minutes = (day_end - current) / 60
+
+          if remaining_minutes <= available_minutes
+            current += remaining_minutes.minutes
+            remaining_minutes = 0
+          else
+            remaining_minutes -= available_minutes
+            current = (current + 1.day).beginning_of_day
+          end
+        end
+
+        current.utc
+      end
+
+      private
+
+      def get_day_schedule(dt_local, schedule)
+        day_name = dt_local.strftime("%A").downcase
+        (schedule.schedule || {})[day_name]
+      end
+
+      def holiday?(dt_local, schedule)
+        schedule.holidays.each do |holiday|
+          if holiday.recurring
+            return true if dt_local.month == holiday.date.month && dt_local.day == holiday.date.day
+          else
+            return true if dt_local.to_date == holiday.date
+          end
+        end
+
+        false
+      end
+    end
+  end
+end

--- a/lib/escalated/services/capacity_service.rb
+++ b/lib/escalated/services/capacity_service.rb
@@ -1,0 +1,36 @@
+module Escalated
+  module Services
+    class CapacityService
+      def can_accept_ticket?(user_id, channel: "default")
+        capacity = Escalated::AgentCapacity.find_or_create_by(user_id: user_id, channel: channel) do |c|
+          c.max_concurrent = 10
+          c.current_count = 0
+        end
+
+        capacity.has_capacity?
+      end
+
+      def increment_load(user_id, channel: "default")
+        capacity = Escalated::AgentCapacity.find_or_create_by(user_id: user_id, channel: channel) do |c|
+          c.max_concurrent = 10
+          c.current_count = 0
+        end
+
+        capacity.increment!(:current_count)
+      end
+
+      def decrement_load(user_id, channel: "default")
+        capacity = Escalated::AgentCapacity.find_or_create_by(user_id: user_id, channel: channel) do |c|
+          c.max_concurrent = 10
+          c.current_count = 0
+        end
+
+        capacity.decrement!(:current_count) if capacity.current_count > 0
+      end
+
+      def all_capacities
+        Escalated::AgentCapacity.includes(:user).all
+      end
+    end
+  end
+end

--- a/lib/escalated/services/reporting_service.rb
+++ b/lib/escalated/services/reporting_service.rb
@@ -1,0 +1,69 @@
+module Escalated
+  module Services
+    class ReportingService
+      def ticket_volume_by_date(start_date, end_date)
+        Escalated::Ticket.where(created_at: start_date..end_date)
+          .group("DATE(created_at)")
+          .order("DATE(created_at)")
+          .count
+          .map { |date, count| { date: date.to_s, count: count } }
+      end
+
+      def tickets_by_status
+        Escalated::Ticket.group(:status).count.map { |status, count| { status: status, count: count } }
+      end
+
+      def tickets_by_priority
+        Escalated::Ticket.group(:priority).count.map { |priority, count| { priority: priority, count: count } }
+      end
+
+      def average_response_time(start_date, end_date)
+        tickets = Escalated::Ticket.where(created_at: start_date..end_date)
+        total = 0.0
+        count = 0
+
+        tickets.find_each do |ticket|
+          first_reply = ticket.replies.where(is_internal: false).order(:created_at).first
+
+          if first_reply
+            total += (first_reply.created_at - ticket.created_at) / 3600.0
+            count += 1
+          end
+        end
+
+        count > 0 ? (total / count).round(2) : 0.0
+      end
+
+      def average_resolution_time(start_date, end_date)
+        tickets = Escalated::Ticket.where(created_at: start_date..end_date, status: [:resolved, :closed])
+        total = 0.0
+        count = 0
+
+        tickets.find_each do |ticket|
+          total += (ticket.updated_at - ticket.created_at) / 3600.0
+          count += 1
+        end
+
+        count > 0 ? (total / count).round(2) : 0.0
+      end
+
+      def agent_performance(start_date, end_date)
+        user_class = Escalated.configuration.user_class.constantize
+        agents = user_class.joins(:escalated_assigned_tickets)
+          .where(Escalated.table_name("tickets") => { created_at: start_date..end_date })
+          .distinct
+
+        agents.map do |agent|
+          tickets = Escalated::Ticket.where(assigned_to: agent.id, created_at: start_date..end_date)
+
+          {
+            agent_id: agent.id,
+            agent_name: agent.try(:name) || agent.try(:email),
+            total_tickets: tickets.count,
+            resolved_tickets: tickets.where(status: [:resolved, :closed]).count
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/escalated/services/skill_routing_service.rb
+++ b/lib/escalated/services/skill_routing_service.rb
@@ -1,0 +1,24 @@
+module Escalated
+  module Services
+    class SkillRoutingService
+      def find_matching_agents(ticket)
+        tag_names = ticket.tags.pluck(:name)
+        return Escalated.configuration.user_class.constantize.none if tag_names.empty?
+
+        skill_ids = Escalated::Skill.where(name: tag_names).pluck(:id)
+        return Escalated.configuration.user_class.constantize.none if skill_ids.empty?
+
+        agent_user_ids = Escalated::AgentSkill.where(skill_id: skill_ids).distinct.pluck(:user_id)
+        return Escalated.configuration.user_class.constantize.none if agent_user_ids.empty?
+
+        user_class = Escalated.configuration.user_class.constantize
+        user_class.where(id: agent_user_ids)
+          .left_joins(:escalated_assigned_tickets)
+          .where.not(Escalated.table_name("tickets") => { status: [:resolved, :closed] })
+          .or(user_class.where(id: agent_user_ids).left_joins(:escalated_assigned_tickets).where(Escalated.table_name("tickets") => { id: nil }))
+          .group(:id)
+          .order(Arel.sql("COUNT(#{Escalated.table_name("tickets")}.id) ASC"))
+      end
+    end
+  end
+end

--- a/lib/escalated/services/sso_service.rb
+++ b/lib/escalated/services/sso_service.rb
@@ -1,0 +1,41 @@
+module Escalated
+  module Services
+    class SsoService
+      CONFIG_KEYS = %w[sso_provider sso_entity_id sso_url sso_certificate sso_attr_email sso_attr_name sso_attr_role sso_jwt_secret sso_jwt_algorithm].freeze
+      DEFAULTS = {
+        "sso_provider" => "none",
+        "sso_entity_id" => "",
+        "sso_url" => "",
+        "sso_certificate" => "",
+        "sso_attr_email" => "email",
+        "sso_attr_name" => "name",
+        "sso_attr_role" => "role",
+        "sso_jwt_secret" => "",
+        "sso_jwt_algorithm" => "HS256"
+      }.freeze
+
+      def get_config
+        CONFIG_KEYS.each_with_object({}) do |key, hash|
+          setting = Escalated::EscalatedSetting.find_by(key: key)
+          hash[key] = setting&.value || DEFAULTS[key]
+        end
+      end
+
+      def save_config(data)
+        CONFIG_KEYS.each do |key|
+          next unless data.key?(key)
+
+          Escalated::EscalatedSetting.find_or_initialize_by(key: key).update!(value: data[key])
+        end
+      end
+
+      def enabled?
+        provider != "none"
+      end
+
+      def provider
+        Escalated::EscalatedSetting.find_by(key: "sso_provider")&.value || "none"
+      end
+    end
+  end
+end

--- a/lib/escalated/services/ticket_merge_service.rb
+++ b/lib/escalated/services/ticket_merge_service.rb
@@ -1,0 +1,33 @@
+module Escalated
+  module Services
+    class TicketMergeService
+      def merge(source, target, merged_by_user_id: nil)
+        ActiveRecord::Base.transaction do
+          # Move all replies from source to target
+          Escalated::Reply.where(ticket: source).update_all(ticket_id: target.id)
+
+          # System note on target
+          Escalated::Reply.create!(
+            ticket: target,
+            body: "Ticket #{source.reference} was merged into this ticket.",
+            is_internal: true,
+            is_system: true,
+            is_pinned: false
+          )
+
+          # System note on source
+          Escalated::Reply.create!(
+            ticket: source,
+            body: "This ticket was merged into #{target.reference}.",
+            is_internal: true,
+            is_system: true,
+            is_pinned: false
+          )
+
+          # Close source and set merged_into
+          source.update!(status: :closed, merged_into: target)
+        end
+      end
+    end
+  end
+end

--- a/lib/escalated/services/two_factor_service.rb
+++ b/lib/escalated/services/two_factor_service.rb
@@ -1,0 +1,49 @@
+require "openssl"
+
+module Escalated
+  module Services
+    class TwoFactorService
+      PERIOD = 30
+      DIGITS = 6
+
+      def generate_secret
+        chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        (0...16).map { chars[SecureRandom.random_number(32)] }.join
+      end
+
+      def generate_qr_uri(secret, email)
+        issuer = Rails.application.class.module_parent_name rescue "Escalated"
+        "otpauth://totp/#{issuer}:#{email}?secret=#{secret}&issuer=#{issuer}&algorithm=SHA1&digits=#{DIGITS}&period=#{PERIOD}"
+      end
+
+      def verify(secret, code)
+        current_time = Time.now.to_i
+        (-1..1).any? { |offset| generate_totp(secret, (current_time / PERIOD) + offset) == code }
+      end
+
+      def generate_recovery_codes
+        8.times.map { "#{SecureRandom.hex(4).upcase}-#{SecureRandom.hex(4).upcase}" }
+      end
+
+      private
+
+      def generate_totp(secret, time_step)
+        key = base32_decode(secret)
+        msg = [time_step].pack("Q>")
+        hmac = OpenSSL::HMAC.digest("SHA1", key, msg)
+        offset = hmac[-1].ord & 0x0F
+        code = (hmac[offset].ord & 0x7F) << 24 |
+               (hmac[offset + 1].ord & 0xFF) << 16 |
+               (hmac[offset + 2].ord & 0xFF) << 8 |
+               (hmac[offset + 3].ord & 0xFF)
+        (code % (10**DIGITS)).to_s.rjust(DIGITS, "0")
+      end
+
+      def base32_decode(input)
+        alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        bits = input.upcase.chars.map { |c| alphabet.index(c).to_s(2).rjust(5, "0") }.join
+        bits.scan(/.{8}/).map { |b| b.to_i(2).chr }.join
+      end
+    end
+  end
+end

--- a/lib/escalated/services/webhook_dispatcher.rb
+++ b/lib/escalated/services/webhook_dispatcher.rb
@@ -1,0 +1,52 @@
+require "net/http"
+require "json"
+require "openssl"
+
+module Escalated
+  module Services
+    class WebhookDispatcher
+      MAX_ATTEMPTS = 3
+
+      def dispatch(event, payload)
+        Escalated::Webhook.active.each do |webhook|
+          send_webhook(webhook, event, payload) if webhook.subscribed_to?(event)
+        end
+      end
+
+      def send_webhook(webhook, event, payload, attempt: 1)
+        body = { event: event, payload: payload, timestamp: Time.current.iso8601 }.to_json
+        headers = { "Content-Type" => "application/json", "X-Escalated-Event" => event }
+
+        if webhook.secret.present?
+          signature = OpenSSL::HMAC.hexdigest("SHA256", webhook.secret, body)
+          headers["X-Escalated-Signature"] = signature
+        end
+
+        delivery = Escalated::WebhookDelivery.create!(webhook: webhook, event: event, payload: payload, attempts: attempt)
+
+        begin
+          uri = URI.parse(webhook.url)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = uri.scheme == "https"
+          http.open_timeout = 10
+          http.read_timeout = 10
+          request = Net::HTTP::Post.new(uri.path, headers)
+          request.body = body
+          response = http.request(request)
+          delivery.update!(response_code: response.code.to_i, response_body: response.body&.first(2000), delivered_at: Time.current, attempts: attempt)
+          send_webhook(webhook, event, payload, attempt: attempt + 1) if !delivery.success? && attempt < MAX_ATTEMPTS
+        rescue => e
+          delivery.update!(response_code: 0, response_body: e.message, attempts: attempt)
+          Rails.logger.warn("Escalated webhook delivery failed: #{e.message}")
+          send_webhook(webhook, event, payload, attempt: attempt + 1) if attempt < MAX_ATTEMPTS
+        end
+      end
+
+      def retry_delivery(delivery)
+        return unless delivery.webhook
+
+        send_webhook(delivery.webhook, delivery.event, delivery.payload || {})
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -4,6 +4,11 @@ class User < ApplicationRecord
            as: :requester,
            dependent: :nullify
 
+  has_many :escalated_assigned_tickets,
+           class_name: "Escalated::Ticket",
+           foreign_key: :assigned_to,
+           dependent: :nullify
+
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -14,6 +14,7 @@ require "escalated"
 
 module Dummy
   class Application < Rails::Application
+    config.root = File.expand_path("../..", __FILE__)
     config.load_defaults Rails::VERSION::STRING.to_f
     config.eager_load = false
 

--- a/spec/factories/agent_capacities.rb
+++ b/spec/factories/agent_capacities.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :escalated_agent_capacity, class: "Escalated::AgentCapacity" do
+    max_concurrent { 5 }
+    current_count { 0 }
+    channel { "default" }
+    association :user, factory: :user
+
+    trait :at_capacity do
+      current_count { 5 }
+    end
+
+    trait :high_capacity do
+      max_concurrent { 20 }
+    end
+
+    trait :busy do
+      max_concurrent { 5 }
+      current_count { rand(3..5) }
+    end
+  end
+end

--- a/spec/factories/agent_profiles.rb
+++ b/spec/factories/agent_profiles.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :escalated_agent_profile, class: "Escalated::AgentProfile" do
+    association :user, factory: :user
+    agent_type { "full" }
+    max_tickets { 10 }
+
+    trait :light do
+      agent_type { "light" }
+    end
+  end
+end

--- a/spec/factories/article_categories.rb
+++ b/spec/factories/article_categories.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :escalated_article_category, class: "Escalated::ArticleCategory" do
+    name { Faker::Commerce.unique.department(max: 1) }
+    slug { name&.parameterize }
+    description { Faker::Lorem.sentence }
+    position { rand(1..20) }
+
+    trait :with_articles do
+      after(:create) do |category|
+        create_list(:escalated_article, 3, category: category)
+      end
+    end
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,22 @@
+FactoryBot.define do
+  factory :escalated_article, class: "Escalated::Article" do
+    title { Faker::Lorem.unique.sentence(word_count: 5) }
+    slug { title&.parameterize }
+    body { Faker::Lorem.paragraphs(number: 3).join("\n\n") }
+    status { "draft" }
+    association :category, factory: :escalated_article_category
+    association :author, factory: :user
+
+    trait :published do
+      status { "published" }
+    end
+
+    trait :archived do
+      status { "archived" }
+    end
+
+    trait :without_category do
+      category { nil }
+    end
+  end
+end

--- a/spec/factories/audit_logs.rb
+++ b/spec/factories/audit_logs.rb
@@ -1,0 +1,30 @@
+FactoryBot.define do
+  factory :escalated_audit_log, class: "Escalated::AuditLog" do
+    action { %w[create update destroy login logout].sample }
+    association :auditable, factory: :escalated_ticket
+    old_values { { "status" => "open" } }
+    new_values { { "status" => "in_progress" } }
+    ip_address { Faker::Internet.ip_v4_address }
+    user_agent { Faker::Internet.user_agent }
+    association :user, factory: :user
+
+    trait :ticket_action do
+      auditable_type { "Escalated::Ticket" }
+      action { %w[create update status_change assignment].sample }
+    end
+
+    trait :login do
+      action { "login" }
+      auditable_type { nil }
+      auditable_id { nil }
+      old_values { {} }
+      new_values { {} }
+    end
+
+    trait :destroy_action do
+      action { "destroy" }
+      old_values { {} }
+      new_values { {} }
+    end
+  end
+end

--- a/spec/factories/automations.rb
+++ b/spec/factories/automations.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+  factory :escalated_automation, class: "Escalated::Automation" do
+    name { "#{Faker::Hacker.verb.capitalize} Automation" }
+    active { true }
+    position { rand(1..20) }
+
+    conditions do
+      [
+        { "field" => "status", "operator" => "equals", "value" => "open" },
+        { "field" => "priority", "operator" => "equals", "value" => "urgent" }
+      ]
+    end
+
+    actions do
+      [
+        { "type" => "assign_department", "value" => "support" },
+        { "type" => "add_tag", "value" => "auto-assigned" }
+      ]
+    end
+
+    trait :inactive do
+      active { false }
+    end
+
+    trait :with_notification do
+      actions do
+        [
+          { "type" => "send_notification", "value" => "admin@example.com" },
+          { "type" => "change_priority", "value" => "high" }
+        ]
+      end
+    end
+  end
+end

--- a/spec/factories/business_schedules.rb
+++ b/spec/factories/business_schedules.rb
@@ -1,0 +1,48 @@
+FactoryBot.define do
+  factory :escalated_business_schedule, class: "Escalated::BusinessSchedule" do
+    name { "#{Faker::Company.name} Hours" }
+    timezone { "UTC" }
+
+    schedule do
+      {
+        "monday" => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
+        "tuesday" => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
+        "wednesday" => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
+        "thursday" => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
+        "friday" => { "enabled" => true, "start" => "09:00", "end" => "17:00" },
+        "saturday" => { "enabled" => false, "start" => "09:00", "end" => "17:00" },
+        "sunday" => { "enabled" => false, "start" => "09:00", "end" => "17:00" }
+      }
+    end
+
+    trait :with_holidays do
+      after(:create) do |schedule|
+        create_list(:escalated_holiday, 2, schedule: schedule)
+      end
+    end
+
+    trait :us_eastern do
+      timezone { "America/New_York" }
+    end
+
+    trait :extended_hours do
+      schedule do
+        {
+          "monday" => { "enabled" => true, "start" => "08:00", "end" => "20:00" },
+          "tuesday" => { "enabled" => true, "start" => "08:00", "end" => "20:00" },
+          "wednesday" => { "enabled" => true, "start" => "08:00", "end" => "20:00" },
+          "thursday" => { "enabled" => true, "start" => "08:00", "end" => "20:00" },
+          "friday" => { "enabled" => true, "start" => "08:00", "end" => "20:00" },
+          "saturday" => { "enabled" => true, "start" => "10:00", "end" => "16:00" },
+          "sunday" => { "enabled" => false, "start" => "09:00", "end" => "17:00" }
+        }
+      end
+    end
+  end
+
+  factory :escalated_holiday, class: "Escalated::Holiday" do
+    name { Faker::Lorem.word.capitalize }
+    date { Faker::Date.forward(days: 365) }
+    association :schedule, factory: :escalated_business_schedule
+  end
+end

--- a/spec/factories/custom_fields.rb
+++ b/spec/factories/custom_fields.rb
@@ -1,0 +1,40 @@
+FactoryBot.define do
+  factory :escalated_custom_field, class: "Escalated::CustomField" do
+    name { Faker::Lorem.unique.words(number: 2).map(&:capitalize).join(" ") }
+    field_type { "text" }
+    context { "ticket" }
+    position { rand(1..20) }
+    required { false }
+    description { Faker::Lorem.sentence }
+    options { [] }
+
+    trait :required do
+      required { true }
+    end
+
+    trait :select do
+      field_type { "select" }
+      options { ["Option A", "Option B", "Option C"] }
+    end
+
+    trait :checkbox do
+      field_type { "checkbox" }
+    end
+
+    trait :date do
+      field_type { "date" }
+    end
+
+    trait :number do
+      field_type { "number" }
+    end
+
+    trait :for_user do
+      context { "user" }
+    end
+
+    trait :for_organization do
+      context { "organization" }
+    end
+  end
+end

--- a/spec/factories/custom_objects.rb
+++ b/spec/factories/custom_objects.rb
@@ -1,0 +1,36 @@
+FactoryBot.define do
+  factory :escalated_custom_object, class: "Escalated::CustomObject" do
+    name { Faker::Commerce.unique.product_name }
+    slug { name&.parameterize(separator: "_") }
+
+    fields_schema do
+      [
+        { "name" => "name", "type" => "text", "required" => true },
+        { "name" => "value", "type" => "text", "required" => false }
+      ]
+    end
+
+    trait :with_records do
+      after(:create) do |definition|
+        create_list(:escalated_custom_object_record, 3, object: definition)
+      end
+    end
+
+    trait :complex_schema do
+      fields_schema do
+        [
+          { "name" => "name", "type" => "text", "required" => true },
+          { "name" => "email", "type" => "email", "required" => false },
+          { "name" => "priority", "type" => "dropdown", "required" => false, "options" => %w[low medium high] },
+          { "name" => "is_active", "type" => "boolean", "required" => false },
+          { "name" => "created_date", "type" => "date", "required" => false }
+        ]
+      end
+    end
+  end
+
+  factory :escalated_custom_object_record, class: "Escalated::CustomObjectRecord" do
+    data { { "name" => Faker::Company.name, "value" => Faker::Lorem.word } }
+    association :object, factory: :escalated_custom_object
+  end
+end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+  factory :escalated_role, class: "Escalated::Role" do
+    name { Faker::Job.unique.title }
+    description { Faker::Lorem.sentence }
+    is_system { false }
+
+    trait :system do
+      is_system { true }
+    end
+
+    trait :agent_role do
+      name { "Agent" }
+      is_system { true }
+    end
+
+    trait :admin_role do
+      name { "Administrator" }
+      is_system { true }
+    end
+
+    trait :with_permissions do
+      after(:create) do |role|
+        create_list(:escalated_permission, 3, roles: [role])
+      end
+    end
+  end
+
+  factory :escalated_permission, class: "Escalated::Permission" do
+    name { "#{Faker::Hacker.verb.capitalize} #{Faker::Hacker.noun}" }
+    slug { name&.parameterize(separator: "_") }
+    description { Faker::Lorem.sentence }
+    group { %w[tickets departments users reports settings].sample }
+  end
+end

--- a/spec/factories/side_conversations.rb
+++ b/spec/factories/side_conversations.rb
@@ -1,0 +1,37 @@
+FactoryBot.define do
+  factory :escalated_side_conversation, class: "Escalated::SideConversation" do
+    subject { Faker::Lorem.sentence(word_count: 5) }
+    channel { "email" }
+    status { "open" }
+    association :ticket, factory: :escalated_ticket
+    association :created_by, factory: :user
+
+    trait :closed do
+      status { "closed" }
+    end
+
+    trait :via_slack do
+      channel { "slack" }
+    end
+
+    trait :via_phone do
+      channel { "phone" }
+    end
+
+    trait :with_replies do
+      after(:create) do |conversation|
+        create_list(:escalated_side_conversation_reply, 2, side_conversation: conversation)
+      end
+    end
+  end
+
+  factory :escalated_side_conversation_reply, class: "Escalated::SideConversationReply" do
+    body { Faker::Lorem.paragraph(sentence_count: 2) }
+    association :side_conversation, factory: :escalated_side_conversation
+    association :author, factory: :user
+
+    trait :inbound do
+      # no direction column; trait kept for compatibility
+    end
+  end
+end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :escalated_skill, class: "Escalated::Skill" do
+    name { Faker::Job.unique.field }
+
+    trait :with_agents do
+      after(:create) do |skill|
+        users = create_list(:user, 2)
+        users.each do |user|
+          Escalated::AgentSkill.create!(user: user, skill: skill)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/ticket_links.rb
+++ b/spec/factories/ticket_links.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :escalated_ticket_link, class: "Escalated::TicketLink" do
+    link_type { "related" }
+    association :parent_ticket, factory: :escalated_ticket
+    association :child_ticket, factory: :escalated_ticket
+
+    trait :problem_incident do
+      link_type { "problem_incident" }
+    end
+
+    trait :parent_child do
+      link_type { "parent_child" }
+    end
+  end
+end

--- a/spec/factories/ticket_statuses.rb
+++ b/spec/factories/ticket_statuses.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :escalated_ticket_status, class: "Escalated::TicketStatus" do
+    label { Faker::Lorem.unique.word.capitalize }
+    category { %w[open pending resolved closed].sample }
+    color { Faker::Color.hex_color }
+    position { rand(1..20) }
+    is_default { false }
+
+    trait :default do
+      is_default { true }
+    end
+
+    trait :open_category do
+      category { "open" }
+    end
+
+    trait :pending_category do
+      category { "pending" }
+    end
+
+    trait :resolved_category do
+      category { "resolved" }
+    end
+
+    trait :closed_category do
+      category { "closed" }
+    end
+  end
+end

--- a/spec/factories/two_factors.rb
+++ b/spec/factories/two_factors.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :escalated_two_factor, class: "Escalated::TwoFactor" do
+    secret { SecureRandom.base64(20) }
+    recovery_codes { Array.new(8) { SecureRandom.hex(4) } }
+    confirmed_at { 1.day.ago }
+    association :user, factory: :user
+
+    trait :unconfirmed do
+      confirmed_at { nil }
+    end
+
+    trait :recently_confirmed do
+      confirmed_at { 1.hour.ago }
+    end
+  end
+end

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -1,0 +1,47 @@
+FactoryBot.define do
+  factory :escalated_webhook, class: "Escalated::Webhook" do
+    url { Faker::Internet.url(scheme: "https") }
+    secret { SecureRandom.hex(20) }
+    active { true }
+    events { %w[ticket.created ticket.updated ticket.resolved] }
+
+    trait :inactive do
+      active { false }
+    end
+
+    trait :all_events do
+      events do
+        %w[
+          ticket.created ticket.updated ticket.resolved ticket.closed
+          ticket.assigned reply.created note.created
+        ]
+      end
+    end
+
+    trait :with_deliveries do
+      after(:create) do |webhook|
+        create_list(:escalated_webhook_delivery, 3, webhook: webhook)
+      end
+    end
+  end
+
+  factory :escalated_webhook_delivery, class: "Escalated::WebhookDelivery" do
+    event { "ticket.created" }
+    response_code { 200 }
+    payload { { ticket_id: rand(1..100), event: "ticket.created" } }
+    response_body { '{"ok":true}' }
+    attempts { 1 }
+    association :webhook, factory: :escalated_webhook
+
+    trait :failed do
+      response_code { 500 }
+      response_body { '{"error":"Internal Server Error"}' }
+    end
+
+    trait :timeout do
+      response_code { nil }
+      response_body { nil }
+      attempts { 3 }
+    end
+  end
+end

--- a/spec/models/escalated/canned_response_spec.rb
+++ b/spec/models/escalated/canned_response_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Escalated::CannedResponse, type: :model do
 
     it "converts non-string values to strings" do
       response = build(:escalated_canned_response,
-                       body: "Ticket #{{ticket.id}}",
+                       body: 'Ticket #{{ticket.id}}',
                        creator: agent)
 
       result = response.render("ticket.id" => 42)

--- a/spec/models/escalated/platform_parity_spec.rb
+++ b/spec/models/escalated/platform_parity_spec.rb
@@ -1,0 +1,1395 @@
+require "rails_helper"
+
+# ====================================================================== #
+# Platform Parity Model Specs
+#
+# Covers all models added during the platform parity work:
+#   AuditLog, TicketStatus, BusinessSchedule, Holiday, Role, Permission,
+#   CustomField, CustomFieldValue, TicketLink, SideConversation,
+#   SideConversationReply, ArticleCategory, Article, AgentProfile,
+#   AgentSkill, Skill, AgentCapacity, Webhook, WebhookDelivery,
+#   Automation, TwoFactor, CustomObject, CustomObjectRecord
+# ====================================================================== #
+
+# ====================================================================== #
+# Escalated::AuditLog
+# ====================================================================== #
+RSpec.describe Escalated::AuditLog, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:user).optional }
+    it { is_expected.to belong_to(:auditable) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    let(:user) { create(:user) }
+
+    describe ".recent" do
+      it "returns audit logs ordered by created_at descending" do
+        old_log = create(:escalated_audit_log, created_at: 3.days.ago)
+        new_log = create(:escalated_audit_log, created_at: 1.day.ago)
+
+        result = described_class.recent
+        expect(result.first).to eq(new_log)
+        expect(result.last).to eq(old_log)
+      end
+    end
+
+    describe ".by_action" do
+      it "returns logs matching a specific action" do
+        login_log = create(:escalated_audit_log, action: "login")
+        _destroy_log = create(:escalated_audit_log, action: "destroy")
+
+        result = described_class.by_action("login")
+        expect(result).to include(login_log)
+        expect(result).not_to include(_destroy_log)
+      end
+    end
+
+    describe ".by_user" do
+      it "returns logs for a specific user" do
+        user_log = create(:escalated_audit_log, user: user)
+        _other_log = create(:escalated_audit_log)
+
+        result = described_class.by_user(user.id)
+        expect(result).to include(user_log)
+        expect(result).not_to include(_other_log)
+      end
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::TicketStatus
+# ====================================================================== #
+RSpec.describe Escalated::TicketStatus, type: :model do
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:label) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { create(:escalated_ticket_status) }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Callbacks
+  # ------------------------------------------------------------------ #
+  describe "callbacks" do
+    describe "#generate_slug" do
+      it "auto-generates slug from label when slug is blank" do
+        status = build(:escalated_ticket_status, label: "Waiting On Agent", slug: nil)
+        status.valid?
+        expect(status.slug).to eq("waiting_on_agent")
+      end
+
+      it "does not override an existing slug" do
+        status = build(:escalated_ticket_status, label: "Open", slug: "custom_slug")
+        status.valid?
+        expect(status.slug).to eq("custom_slug")
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".ordered" do
+      it "returns statuses ordered by category and position" do
+        later = create(:escalated_ticket_status, category: "pending", position: 2)
+        first = create(:escalated_ticket_status, category: "open", position: 1)
+
+        result = described_class.ordered
+        expect(result.first).to eq(first)
+        expect(result.last).to eq(later)
+      end
+    end
+
+    describe ".by_category" do
+      it "returns statuses in a specific category" do
+        open_status = create(:escalated_ticket_status, :open_category)
+        _pending_status = create(:escalated_ticket_status, :pending_category)
+
+        result = described_class.by_category("open")
+        expect(result).to include(open_status)
+        expect(result).not_to include(_pending_status)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Constants
+  # ------------------------------------------------------------------ #
+  describe "CATEGORIES" do
+    it "defines the expected categories" do
+      expect(described_class::CATEGORIES).to eq(%w[new open pending on_hold solved])
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the label" do
+      status = build(:escalated_ticket_status, label: "In Progress")
+      expect(status.to_s).to eq("In Progress")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::BusinessSchedule
+# ====================================================================== #
+RSpec.describe Escalated::BusinessSchedule, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_many(:holidays).dependent(:destroy) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      schedule = described_class.new(name: "US Business Hours")
+      expect(schedule.to_s).to eq("US Business Hours")
+    end
+  end
+
+  describe "holiday association" do
+    it "can have associated holidays" do
+      schedule = described_class.create!(name: "Test Schedule", timezone: "UTC")
+      Escalated::Holiday.create!(schedule: schedule, name: "New Year", date: Date.new(2026, 1, 1))
+      Escalated::Holiday.create!(schedule: schedule, name: "Christmas", date: Date.new(2026, 12, 25))
+
+      expect(schedule.holidays.count).to eq(2)
+    end
+
+    it "destroys holidays when schedule is destroyed" do
+      schedule = described_class.create!(name: "Destroy Test", timezone: "UTC")
+      Escalated::Holiday.create!(schedule: schedule, name: "Holiday 1", date: Date.new(2026, 6, 1))
+
+      expect { schedule.destroy }.to change(Escalated::Holiday, :count).by(-1)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Holiday
+# ====================================================================== #
+RSpec.describe Escalated::Holiday, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:schedule).class_name("Escalated::BusinessSchedule") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:date) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name and date" do
+      schedule = Escalated::BusinessSchedule.create!(name: "Test", timezone: "UTC")
+      holiday = described_class.new(
+        schedule: schedule,
+        name: "Christmas",
+        date: Date.new(2026, 12, 25)
+      )
+      expect(holiday.to_s).to eq("Christmas (2026-12-25)")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Role
+# ====================================================================== #
+RSpec.describe Escalated::Role, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_and_belong_to_many(:permissions).class_name("Escalated::Permission") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { create(:escalated_role) }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Callbacks
+  # ------------------------------------------------------------------ #
+  describe "callbacks" do
+    describe "#generate_slug" do
+      it "auto-generates slug from name when slug is blank" do
+        role = build(:escalated_role, name: "Support Agent", slug: nil)
+        role.valid?
+        expect(role.slug).to eq("support_agent")
+      end
+
+      it "does not override an existing slug" do
+        role = build(:escalated_role, name: "Admin", slug: "custom_admin")
+        role.valid?
+        expect(role.slug).to eq("custom_admin")
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#has_permission?" do
+    it "returns true when the role has the permission" do
+      role = create(:escalated_role)
+      permission = create(:escalated_permission, slug: "manage_tickets")
+      role.permissions << permission
+
+      expect(role.has_permission?("manage_tickets")).to be(true)
+    end
+
+    it "returns false when the role does not have the permission" do
+      role = create(:escalated_role)
+      _permission = create(:escalated_permission, slug: "manage_tickets")
+
+      expect(role.has_permission?("manage_tickets")).to be(false)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the name" do
+      role = build(:escalated_role, name: "Administrator")
+      expect(role.to_s).to eq("Administrator")
+    end
+  end
+
+  describe "permission management" do
+    it "can have permissions associated" do
+      role = create(:escalated_role)
+      perm1 = Escalated::Permission.create!(name: "View Tickets", slug: "view_tickets_#{SecureRandom.hex(4)}")
+      perm2 = Escalated::Permission.create!(name: "Edit Tickets", slug: "edit_tickets_#{SecureRandom.hex(4)}")
+      role.permissions << perm1
+      role.permissions << perm2
+
+      expect(role.permissions.count).to eq(2)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Permission
+# ====================================================================== #
+RSpec.describe Escalated::Permission, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_and_belong_to_many(:roles).class_name("Escalated::Role") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { create(:escalated_permission, slug: "test_perm_#{SecureRandom.hex(4)}") }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".ordered" do
+      it "returns permissions ordered by group and name" do
+        perm_b = create(:escalated_permission, group: "tickets", name: "Zeta", slug: "zeta_perm")
+        perm_a = create(:escalated_permission, group: "settings", name: "Alpha", slug: "alpha_perm")
+
+        result = described_class.ordered
+        expect(result.first).to eq(perm_a)
+        expect(result.last).to eq(perm_b)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      permission = build(:escalated_permission, name: "Manage Tickets")
+      expect(permission.to_s).to eq("Manage Tickets")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::CustomField
+# ====================================================================== #
+RSpec.describe Escalated::CustomField, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_many(:values).class_name("Escalated::CustomFieldValue").dependent(:destroy) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { described_class.create!(name: "Test Field", slug: "test_field_uniq", field_type: "text", context: "ticket") }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Callbacks
+  # ------------------------------------------------------------------ #
+  describe "callbacks" do
+    describe "#generate_slug" do
+      it "auto-generates slug from name when slug is blank" do
+        field = described_class.new(name: "Product Version", slug: nil, field_type: "text", context: "ticket")
+        field.valid?
+        expect(field.slug).to eq("product_version")
+      end
+
+      it "does not override an existing slug" do
+        field = described_class.new(name: "Priority Level", slug: "custom_priority", field_type: "text", context: "ticket")
+        field.valid?
+        expect(field.slug).to eq("custom_priority")
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Constants
+  # ------------------------------------------------------------------ #
+  describe "FIELD_TYPES" do
+    it "defines the expected field types" do
+      expect(described_class::FIELD_TYPES).to eq(%w[text textarea select multi_select checkbox date number])
+    end
+  end
+
+  describe "CONTEXTS" do
+    it "defines the expected contexts" do
+      expect(described_class::CONTEXTS).to eq(%w[ticket user organization])
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".ordered" do
+      it "returns fields ordered by position" do
+        second = described_class.create!(name: "Field B", slug: "field_b", field_type: "text", context: "ticket", position: 2)
+        first = described_class.create!(name: "Field A", slug: "field_a", field_type: "text", context: "ticket", position: 1)
+
+        result = described_class.ordered
+        expect(result.first).to eq(first)
+        expect(result.last).to eq(second)
+      end
+    end
+
+    describe ".active" do
+      it "returns only active fields" do
+        active = described_class.create!(name: "Active Field", slug: "active_field", field_type: "text", context: "ticket", active: true)
+        _inactive = described_class.create!(name: "Inactive Field", slug: "inactive_field", field_type: "text", context: "ticket", active: false)
+
+        result = described_class.active
+        expect(result).to include(active)
+        expect(result).not_to include(_inactive)
+      end
+    end
+
+    describe ".for_context" do
+      it "returns fields for a specific context" do
+        ticket_field = described_class.create!(name: "Ticket Field", slug: "ticket_field", field_type: "text", context: "ticket")
+        _user_field = described_class.create!(name: "User Field", slug: "user_field", field_type: "text", context: "user")
+
+        result = described_class.for_context("ticket")
+        expect(result).to include(ticket_field)
+        expect(result).not_to include(_user_field)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      field = described_class.new(name: "Product Version")
+      expect(field.to_s).to eq("Product Version")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::CustomFieldValue
+# ====================================================================== #
+RSpec.describe Escalated::CustomFieldValue, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:custom_field).class_name("Escalated::CustomField") }
+    it { is_expected.to belong_to(:entity) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the field name and value" do
+      field = Escalated::CustomField.create!(name: "Priority Level", slug: "priority_level", field_type: "text", context: "ticket")
+      ticket = create(:escalated_ticket)
+      value = described_class.new(
+        custom_field: field,
+        entity: ticket,
+        value: "High"
+      )
+
+      expect(value.to_s).to eq("Priority Level: High")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::TicketLink
+# ====================================================================== #
+RSpec.describe Escalated::TicketLink, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:parent_ticket).class_name("Escalated::Ticket") }
+    it { is_expected.to belong_to(:child_ticket).class_name("Escalated::Ticket") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:link_type) }
+
+    it "validates inclusion of link_type" do
+      ticket1 = create(:escalated_ticket)
+      ticket2 = create(:escalated_ticket)
+      link = described_class.new(
+        parent_ticket_id: ticket1.id,
+        child_ticket_id: ticket2.id,
+        link_type: "invalid_type"
+      )
+      expect(link).not_to be_valid
+      expect(link.errors[:link_type]).to be_present
+    end
+
+    it "accepts valid link types" do
+      ticket1 = create(:escalated_ticket)
+      ticket2 = create(:escalated_ticket)
+      %w[problem_incident parent_child related].each do |type|
+        link = described_class.new(
+          parent_ticket_id: ticket1.id,
+          child_ticket_id: ticket2.id,
+          link_type: type
+        )
+        link.valid?
+        expect(link.errors[:link_type]).to be_empty, "Expected #{type} to be valid"
+      end
+    end
+
+    context "uniqueness" do
+      it "prevents duplicate links between the same tickets with the same type" do
+        ticket1 = create(:escalated_ticket)
+        ticket2 = create(:escalated_ticket)
+        described_class.create!(
+          parent_ticket_id: ticket1.id,
+          child_ticket_id: ticket2.id,
+          link_type: "related"
+        )
+
+        duplicate = described_class.new(
+          parent_ticket_id: ticket1.id,
+          child_ticket_id: ticket2.id,
+          link_type: "related"
+        )
+        expect(duplicate).not_to be_valid
+      end
+
+      it "allows different link types between the same tickets" do
+        ticket1 = create(:escalated_ticket)
+        ticket2 = create(:escalated_ticket)
+        described_class.create!(
+          parent_ticket_id: ticket1.id,
+          child_ticket_id: ticket2.id,
+          link_type: "related"
+        )
+
+        different_type = described_class.new(
+          parent_ticket_id: ticket1.id,
+          child_ticket_id: ticket2.id,
+          link_type: "parent_child"
+        )
+        expect(different_type).to be_valid
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Constants
+  # ------------------------------------------------------------------ #
+  describe "LINK_TYPES" do
+    it "defines the expected link types" do
+      expect(described_class::LINK_TYPES).to eq(%w[problem_incident parent_child related])
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::SideConversation
+# ====================================================================== #
+RSpec.describe Escalated::SideConversation, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:ticket).class_name("Escalated::Ticket") }
+    it { is_expected.to belong_to(:created_by).optional }
+    it { is_expected.to have_many(:replies).class_name("Escalated::SideConversationReply").dependent(:destroy) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".open" do
+      it "returns only open side conversations" do
+        open_conv = create(:escalated_side_conversation, status: "open")
+        _closed_conv = create(:escalated_side_conversation, :closed)
+
+        result = described_class.open
+        expect(result).to include(open_conv)
+        expect(result).not_to include(_closed_conv)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the subject prefixed with 'Side conversation:'" do
+      conv = build(:escalated_side_conversation, subject: "Check with engineering")
+      expect(conv.to_s).to eq("Side conversation: Check with engineering")
+    end
+  end
+
+  describe "replies association" do
+    it "can have associated replies" do
+      conv = create(:escalated_side_conversation)
+      Escalated::SideConversationReply.create!(side_conversation: conv, body: "Reply 1")
+      Escalated::SideConversationReply.create!(side_conversation: conv, body: "Reply 2")
+
+      expect(conv.replies.count).to eq(2)
+    end
+
+    it "destroys replies when conversation is destroyed" do
+      conv = create(:escalated_side_conversation)
+      Escalated::SideConversationReply.create!(side_conversation: conv, body: "Reply 1")
+
+      expect { conv.destroy }.to change(Escalated::SideConversationReply, :count).by(-1)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::SideConversationReply
+# ====================================================================== #
+RSpec.describe Escalated::SideConversationReply, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:side_conversation).class_name("Escalated::SideConversation") }
+    it { is_expected.to belong_to(:author).optional }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:body) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns a description referencing the conversation subject" do
+      conv = create(:escalated_side_conversation, subject: "Engineering question")
+      reply = described_class.new(side_conversation: conv, body: "Test reply")
+      expect(reply.to_s).to eq("Reply on Engineering question")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::ArticleCategory
+# ====================================================================== #
+RSpec.describe Escalated::ArticleCategory, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:parent).class_name("Escalated::ArticleCategory").optional }
+    it { is_expected.to have_many(:children).class_name("Escalated::ArticleCategory").dependent(:nullify) }
+    it { is_expected.to have_many(:articles).class_name("Escalated::Article").dependent(:nullify) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".roots" do
+      it "returns categories with no parent" do
+        root = create(:escalated_article_category, parent: nil)
+        child = create(:escalated_article_category, parent: root)
+
+        result = described_class.roots
+        expect(result).to include(root)
+        expect(result).not_to include(child)
+      end
+    end
+
+    describe ".ordered" do
+      it "returns categories ordered by position and name" do
+        second = create(:escalated_article_category, position: 2, name: "Alpha")
+        first = create(:escalated_article_category, position: 1, name: "Zeta")
+
+        result = described_class.ordered
+        expect(result.first).to eq(first)
+        expect(result.last).to eq(second)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      category = build(:escalated_article_category, name: "Getting Started")
+      expect(category.to_s).to eq("Getting Started")
+    end
+  end
+
+  describe "parent-child relationships" do
+    it "supports nested categories" do
+      parent = create(:escalated_article_category, name: "Support")
+      child = create(:escalated_article_category, name: "FAQ", parent: parent)
+
+      expect(parent.children).to include(child)
+      expect(child.parent).to eq(parent)
+    end
+
+    it "nullifies children when parent is destroyed" do
+      parent = create(:escalated_article_category, name: "Support")
+      child = create(:escalated_article_category, name: "FAQ", parent: parent)
+
+      parent.destroy
+      child.reload
+      expect(child.parent_id).to be_nil
+    end
+  end
+
+  describe "with_articles trait" do
+    it "creates associated articles" do
+      category = create(:escalated_article_category, :with_articles)
+      expect(category.articles.count).to eq(3)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Article
+# ====================================================================== #
+RSpec.describe Escalated::Article, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:category).class_name("Escalated::ArticleCategory").optional }
+    it { is_expected.to belong_to(:author).optional }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { create(:escalated_article) }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".published" do
+      it "returns only published articles" do
+        published = create(:escalated_article, :published)
+        _draft = create(:escalated_article, status: "draft")
+
+        result = described_class.published
+        expect(result).to include(published)
+        expect(result).not_to include(_draft)
+      end
+    end
+
+    describe ".draft" do
+      it "returns only draft articles" do
+        _published = create(:escalated_article, :published)
+        draft = create(:escalated_article, status: "draft")
+
+        result = described_class.draft
+        expect(result).to include(draft)
+        expect(result).not_to include(_published)
+      end
+    end
+
+    describe ".search" do
+      it "searches by title" do
+        article = create(:escalated_article, title: "How to Reset Password")
+        _other = create(:escalated_article, title: "Billing FAQ")
+
+        result = described_class.search("Reset")
+        expect(result).to include(article)
+        expect(result).not_to include(_other)
+      end
+
+      it "searches by body" do
+        article = create(:escalated_article, body: "Navigate to the credentials page")
+        _other = create(:escalated_article, body: "Check your invoice details")
+
+        result = described_class.search("credentials")
+        expect(result).to include(article)
+        expect(result).not_to include(_other)
+      end
+    end
+
+    describe ".recent" do
+      it "returns articles ordered by created_at descending" do
+        old = create(:escalated_article, created_at: 3.days.ago)
+        newer = create(:escalated_article, created_at: 1.day.ago)
+
+        result = described_class.recent
+        expect(result.first).to eq(newer)
+        expect(result.last).to eq(old)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#increment_views!" do
+    it "increments the view count by 1" do
+      article = create(:escalated_article)
+      expect { article.increment_views! }.to change { article.reload.view_count }.by(1)
+    end
+  end
+
+  describe "#mark_helpful!" do
+    it "increments the helpful count by 1" do
+      article = create(:escalated_article)
+      expect { article.mark_helpful! }.to change { article.reload.helpful_count }.by(1)
+    end
+  end
+
+  describe "#mark_not_helpful!" do
+    it "increments the not helpful count by 1" do
+      article = create(:escalated_article)
+      expect { article.mark_not_helpful! }.to change { article.reload.not_helpful_count }.by(1)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the title" do
+      article = build(:escalated_article, title: "Getting Started Guide")
+      expect(article.to_s).to eq("Getting Started Guide")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::AgentProfile
+# ====================================================================== #
+RSpec.describe Escalated::AgentProfile, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    context "uniqueness" do
+      let(:user) { create(:user) }
+      subject { described_class.create!(user: user, agent_type: "full") }
+
+      it { is_expected.to validate_uniqueness_of(:user_id) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#light_agent?" do
+    it "returns true when agent_type is light" do
+      user = create(:user)
+      profile = described_class.new(user: user, agent_type: "light")
+      expect(profile.light_agent?).to be(true)
+    end
+
+    it "returns false when agent_type is full" do
+      user = create(:user)
+      profile = described_class.new(user: user, agent_type: "full")
+      expect(profile.light_agent?).to be(false)
+    end
+  end
+
+  describe "#full_agent?" do
+    it "returns true when agent_type is full" do
+      user = create(:user)
+      profile = described_class.new(user: user, agent_type: "full")
+      expect(profile.full_agent?).to be(true)
+    end
+
+    it "returns false when agent_type is light" do
+      user = create(:user)
+      profile = described_class.new(user: user, agent_type: "light")
+      expect(profile.full_agent?).to be(false)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Class methods
+  # ------------------------------------------------------------------ #
+  describe ".for_user" do
+    it "returns the profile for a given user_id" do
+      user = create(:user)
+      profile = described_class.create!(user: user, agent_type: "full")
+      expect(described_class.for_user(user.id)).to eq(profile)
+    end
+
+    it "returns nil when no profile exists" do
+      expect(described_class.for_user(999999)).to be_nil
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::AgentSkill
+# ====================================================================== #
+RSpec.describe Escalated::AgentSkill, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:skill).class_name("Escalated::Skill") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    context "uniqueness" do
+      let(:user) { create(:user) }
+      let(:skill) { create(:escalated_skill) }
+
+      it "prevents duplicate user-skill assignments" do
+        described_class.create!(user_id: user.id, skill_id: skill.id)
+        duplicate = described_class.new(user_id: user.id, skill_id: skill.id)
+        expect(duplicate).not_to be_valid
+      end
+
+      it "allows the same user with different skills" do
+        other_skill = create(:escalated_skill)
+        described_class.create!(user_id: user.id, skill_id: skill.id)
+        different = described_class.new(user_id: user.id, skill_id: other_skill.id)
+        expect(different).to be_valid
+      end
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Skill
+# ====================================================================== #
+RSpec.describe Escalated::Skill, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_many(:agent_skills).class_name("Escalated::AgentSkill").dependent(:destroy) }
+
+    it "has many agents through agent_skills" do
+      skill = described_class.create!(name: "Test Skill", slug: "test_skill_assoc")
+      user = create(:user)
+      Escalated::AgentSkill.create!(user: user, skill: skill)
+
+      expect(skill.agents).to include(user)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { create(:escalated_skill) }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Callbacks
+  # ------------------------------------------------------------------ #
+  describe "callbacks" do
+    describe "#generate_slug" do
+      it "auto-generates slug from name when slug is blank" do
+        skill = build(:escalated_skill, name: "Technical Support", slug: nil)
+        skill.valid?
+        expect(skill.slug).to eq("technical_support")
+      end
+
+      it "does not override an existing slug" do
+        skill = build(:escalated_skill, name: "Sales", slug: "custom_sales")
+        skill.valid?
+        expect(skill.slug).to eq("custom_sales")
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      skill = build(:escalated_skill, name: "Networking")
+      expect(skill.to_s).to eq("Networking")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::AgentCapacity
+# ====================================================================== #
+RSpec.describe Escalated::AgentCapacity, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    context "uniqueness" do
+      it "prevents duplicate user-channel combinations" do
+        user = create(:user)
+        described_class.create!(user_id: user.id, channel: "default", max_concurrent: 10, current_count: 0)
+        duplicate = described_class.new(user_id: user.id, channel: "default", max_concurrent: 5, current_count: 0)
+        expect(duplicate).not_to be_valid
+      end
+
+      it "allows the same user with different channels" do
+        user = create(:user)
+        described_class.create!(user_id: user.id, channel: "default", max_concurrent: 10, current_count: 0)
+        different = described_class.new(user_id: user.id, channel: "email", max_concurrent: 5, current_count: 0)
+        expect(different).to be_valid
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#load_percentage" do
+    let(:user) { create(:user) }
+
+    it "returns the load percentage" do
+      capacity = described_class.new(user: user, max_concurrent: 10, current_count: 5)
+      expect(capacity.load_percentage).to eq(50)
+    end
+
+    it "returns 0 when max_concurrent is zero" do
+      capacity = described_class.new(user: user, max_concurrent: 0, current_count: 0)
+      expect(capacity.load_percentage).to eq(0)
+    end
+
+    it "returns 0 when max_concurrent is nil" do
+      capacity = described_class.new(user: user, max_concurrent: nil, current_count: 0)
+      expect(capacity.load_percentage).to eq(0)
+    end
+
+    it "rounds to the nearest integer" do
+      capacity = described_class.new(user: user, max_concurrent: 3, current_count: 1)
+      expect(capacity.load_percentage).to eq(33)
+    end
+  end
+
+  describe "#has_capacity?" do
+    let(:user) { create(:user) }
+
+    it "returns true when current count is below max" do
+      capacity = described_class.new(user: user, max_concurrent: 5, current_count: 3)
+      expect(capacity.has_capacity?).to be(true)
+    end
+
+    it "returns false when at capacity" do
+      capacity = described_class.new(user: user, max_concurrent: 5, current_count: 5)
+      expect(capacity.has_capacity?).to be(false)
+    end
+
+    it "returns false when current count exceeds max" do
+      capacity = described_class.new(user: user, max_concurrent: 5, current_count: 6)
+      expect(capacity.has_capacity?).to be(false)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Webhook
+# ====================================================================== #
+RSpec.describe Escalated::Webhook, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_many(:deliveries).class_name("Escalated::WebhookDelivery").dependent(:destroy) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:url) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".active" do
+      it "returns only active webhooks" do
+        active = described_class.create!(url: "https://hooks.example.com/a", active: true)
+        _inactive = described_class.create!(url: "https://hooks.example.com/b", active: false)
+
+        result = described_class.active
+        expect(result).to include(active)
+        expect(result).not_to include(_inactive)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#subscribed_to?" do
+    let(:webhook) { described_class.new(url: "https://example.com", events: %w[ticket.created ticket.updated]) }
+
+    it "returns true when the event is in the events list" do
+      expect(webhook.subscribed_to?("ticket.created")).to be(true)
+    end
+
+    it "returns false when the event is not in the events list" do
+      expect(webhook.subscribed_to?("ticket.deleted")).to be(false)
+    end
+
+    it "accepts symbol event names" do
+      expect(webhook.subscribed_to?(:"ticket.created")).to be(true)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the url" do
+      webhook = described_class.new(url: "https://hooks.example.com/notify")
+      expect(webhook.to_s).to eq("https://hooks.example.com/notify")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::WebhookDelivery
+# ====================================================================== #
+RSpec.describe Escalated::WebhookDelivery, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:webhook).class_name("Escalated::Webhook") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#success?" do
+    let(:webhook) { Escalated::Webhook.create!(url: "https://test.example.com/hook", active: true) }
+
+    it "returns true for 200 response code" do
+      delivery = described_class.new(webhook: webhook, response_code: 200)
+      expect(delivery.success?).to be(true)
+    end
+
+    it "returns true for 201 response code" do
+      delivery = described_class.new(webhook: webhook, response_code: 201)
+      expect(delivery.success?).to be(true)
+    end
+
+    it "returns true for 299 response code" do
+      delivery = described_class.new(webhook: webhook, response_code: 299)
+      expect(delivery.success?).to be(true)
+    end
+
+    it "returns false for 500 response code" do
+      delivery = described_class.new(webhook: webhook, response_code: 500)
+      expect(delivery.success?).to be(false)
+    end
+
+    it "returns false for nil response code" do
+      delivery = described_class.new(webhook: webhook, response_code: nil)
+      expect(delivery.success?).to be(false)
+    end
+
+    it "returns false for 404 response code" do
+      delivery = described_class.new(webhook: webhook, response_code: 404)
+      expect(delivery.success?).to be(false)
+    end
+
+    it "returns false for 100 response code" do
+      delivery = described_class.new(webhook: webhook, response_code: 100)
+      expect(delivery.success?).to be(false)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::Automation
+# ====================================================================== #
+RSpec.describe Escalated::Automation, type: :model do
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Scopes
+  # ------------------------------------------------------------------ #
+  describe "scopes" do
+    describe ".active" do
+      it "returns only active automations ordered by position" do
+        active_second = described_class.create!(name: "Rule B", active: true, position: 2)
+        active_first = described_class.create!(name: "Rule A", active: true, position: 1)
+        _inactive = described_class.create!(name: "Rule C", active: false, position: 0)
+
+        result = described_class.active
+        expect(result).to include(active_first, active_second)
+        expect(result).not_to include(_inactive)
+        expect(result.first).to eq(active_first)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      automation = described_class.new(name: "Auto-assign urgent tickets")
+      expect(automation.to_s).to eq("Auto-assign urgent tickets")
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::TwoFactor
+# ====================================================================== #
+RSpec.describe Escalated::TwoFactor, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    context "uniqueness" do
+      let(:user) { create(:user) }
+      subject { described_class.create!(user: user, secret: "test_secret") }
+
+      it { is_expected.to validate_uniqueness_of(:user_id) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#confirmed?" do
+    it "returns true when confirmed_at is present" do
+      user = create(:user)
+      two_factor = described_class.new(user: user, confirmed_at: 1.hour.ago)
+      expect(two_factor.confirmed?).to be(true)
+    end
+
+    it "returns false when confirmed_at is nil" do
+      user = create(:user)
+      two_factor = described_class.new(user: user, confirmed_at: nil)
+      expect(two_factor.confirmed?).to be(false)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::CustomObject
+# ====================================================================== #
+RSpec.describe Escalated::CustomObject, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to have_many(:records).class_name("Escalated::CustomObjectRecord").dependent(:destroy) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Validations
+  # ------------------------------------------------------------------ #
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:slug) }
+
+    context "uniqueness" do
+      subject { described_class.create!(name: "Test Object", slug: "test_object_uniq") }
+
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Instance methods
+  # ------------------------------------------------------------------ #
+  describe "#to_s" do
+    it "returns the name" do
+      obj = described_class.new(name: "Asset Tracker")
+      expect(obj.to_s).to eq("Asset Tracker")
+    end
+  end
+
+  describe "dependent destroy" do
+    it "destroys associated records when custom object is destroyed" do
+      obj = described_class.create!(name: "Test", slug: "test_dep_destroy")
+      Escalated::CustomObjectRecord.create!(object: obj, data: { "name" => "Item" })
+      Escalated::CustomObjectRecord.create!(object: obj, data: { "name" => "Item 2" })
+
+      expect { obj.destroy }.to change(Escalated::CustomObjectRecord, :count).by(-2)
+    end
+  end
+end
+
+# ====================================================================== #
+# Escalated::CustomObjectRecord
+# ====================================================================== #
+RSpec.describe Escalated::CustomObjectRecord, type: :model do
+  # ------------------------------------------------------------------ #
+  # Associations
+  # ------------------------------------------------------------------ #
+  describe "associations" do
+    it { is_expected.to belong_to(:object).class_name("Escalated::CustomObject") }
+  end
+
+  # ------------------------------------------------------------------ #
+  # Record creation
+  # ------------------------------------------------------------------ #
+  describe "record creation" do
+    it "can be created with a custom object" do
+      custom_object = Escalated::CustomObject.create!(name: "Test Obj", slug: "test_obj_rec")
+      record = described_class.create!(object: custom_object, data: { "name" => "Test" })
+
+      expect(record).to be_persisted
+      expect(record.object).to eq(custom_object)
+    end
+  end
+
+  describe "dependent destroy" do
+    it "is destroyed when the parent custom object is destroyed" do
+      custom_object = Escalated::CustomObject.create!(name: "Destroyable", slug: "destroyable_obj")
+      described_class.create!(object: custom_object, data: { "name" => "Record 1" })
+      described_class.create!(object: custom_object, data: { "name" => "Record 2" })
+      described_class.create!(object: custom_object, data: { "name" => "Record 3" })
+
+      expect { custom_object.destroy }.to change(described_class, :count).by(-3)
+    end
+  end
+end

--- a/spec/models/escalated/reply_spec.rb
+++ b/spec/models/escalated/reply_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Escalated::Reply, type: :model do
   # ------------------------------------------------------------------ #
   describe "associations" do
     it { is_expected.to belong_to(:ticket).class_name("Escalated::Ticket") }
-    it { is_expected.to belong_to(:author) }
+    it { is_expected.to belong_to(:author).optional }
     it { is_expected.to have_many(:attachments) }
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,14 +12,18 @@ require "factory_bot_rails"
 require "shoulda-matchers"
 require "database_cleaner/active_record"
 
+# Load services from lib/ (not auto-loaded by Rails engine)
+Dir[File.join(File.dirname(__dir__), "lib", "escalated", "services", "*.rb")].sort.each { |f| require f }
+
 # Load support files
 Dir[File.join(__dir__, "support", "**", "*.rb")].sort.each { |f| require f }
 
-# Load factories
-Dir[File.join(__dir__, "factories", "**", "*.rb")].sort.each { |f| require f }
+# Tell FactoryBot where to find factories
+FactoryBot.definition_file_paths = [File.join(__dir__, "factories")]
+FactoryBot.find_definitions
 
 RSpec.configure do |config|
-  config.fixture_path = "#{__dir__}/fixtures"
+  config.fixture_paths = ["#{__dir__}/fixtures"]
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!

--- a/spec/services/escalated/platform_parity_services_spec.rb
+++ b/spec/services/escalated/platform_parity_services_spec.rb
@@ -1,0 +1,1648 @@
+require "rails_helper"
+
+# ============================================================================ #
+# Platform Parity Services — Comprehensive Specs
+#
+# Covers: BusinessHoursCalculator, TicketMergeService, SkillRoutingService,
+#         CapacityService, WebhookDispatcher, AutomationRunner,
+#         TwoFactorService, SsoService, ReportingService
+# ============================================================================ #
+
+# ---------------------------------------------------------------------------- #
+# 1. BusinessHoursCalculator
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::BusinessHoursCalculator do
+  subject(:calculator) { described_class.new }
+
+  # Disable notifications for service tests
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+  end
+
+  let(:schedule) do
+    create(:escalated_business_schedule, timezone: "UTC", schedule: {
+      "monday" => { "start" => "09:00", "end" => "17:00" },
+      "tuesday" => { "start" => "09:00", "end" => "17:00" },
+      "wednesday" => { "start" => "09:00", "end" => "17:00" },
+      "thursday" => { "start" => "09:00", "end" => "17:00" },
+      "friday" => { "start" => "09:00", "end" => "17:00" },
+      "saturday" => nil,
+      "sunday" => nil
+    })
+  end
+
+  # ------------------------------------------------------------------ #
+  # #within_business_hours?
+  # ------------------------------------------------------------------ #
+  describe "#within_business_hours?" do
+    it "returns true during business hours on a working day" do
+      # A Monday at 10:00 UTC
+      monday_10am = Time.zone.parse("2026-03-02 10:00:00 UTC") # Monday
+      expect(calculator.within_business_hours?(monday_10am, schedule)).to be(true)
+    end
+
+    it "returns false outside business hours on a working day" do
+      monday_7am = Time.zone.parse("2026-03-02 07:00:00 UTC") # Monday 7am
+      expect(calculator.within_business_hours?(monday_7am, schedule)).to be(false)
+    end
+
+    it "returns false at exactly the end time" do
+      monday_5pm = Time.zone.parse("2026-03-02 17:00:00 UTC") # Monday 5pm
+      expect(calculator.within_business_hours?(monday_5pm, schedule)).to be(false)
+    end
+
+    it "returns true at exactly the start time" do
+      monday_9am = Time.zone.parse("2026-03-02 09:00:00 UTC") # Monday 9am
+      expect(calculator.within_business_hours?(monday_9am, schedule)).to be(true)
+    end
+
+    it "returns false on a non-working day" do
+      saturday_noon = Time.zone.parse("2026-02-28 12:00:00 UTC") # Saturday
+      expect(calculator.within_business_hours?(saturday_noon, schedule)).to be(false)
+    end
+
+    context "with holidays" do
+      it "returns false on a non-recurring holiday" do
+        create(:escalated_holiday,
+               schedule: schedule,
+               name: "Company Day",
+               date: Date.parse("2026-03-02"),
+               recurring: false)
+
+        monday_10am = Time.zone.parse("2026-03-02 10:00:00 UTC")
+        expect(calculator.within_business_hours?(monday_10am, schedule.reload)).to be(false)
+      end
+
+      it "returns false on a recurring holiday matching month and day" do
+        create(:escalated_holiday,
+               schedule: schedule,
+               name: "New Year",
+               date: Date.parse("2025-01-01"),
+               recurring: true)
+
+        new_year_2026 = Time.zone.parse("2026-01-01 12:00:00 UTC") # Thursday
+        # Need to also have Thursday in the schedule for this to matter
+        schedule.update!(schedule: schedule.schedule.merge("thursday" => { "start" => "09:00", "end" => "17:00" }))
+        expect(calculator.within_business_hours?(new_year_2026, schedule.reload)).to be(false)
+      end
+    end
+
+    context "with different timezones" do
+      let(:eastern_schedule) do
+        create(:escalated_business_schedule, timezone: "America/New_York", schedule: {
+          "monday" => { "start" => "09:00", "end" => "17:00" },
+          "tuesday" => { "start" => "09:00", "end" => "17:00" },
+          "wednesday" => { "start" => "09:00", "end" => "17:00" },
+          "thursday" => { "start" => "09:00", "end" => "17:00" },
+          "friday" => { "start" => "09:00", "end" => "17:00" },
+          "saturday" => nil,
+          "sunday" => nil
+        })
+      end
+
+      it "converts the datetime to the schedule timezone" do
+        # 14:00 UTC = 09:00 EST (within business hours)
+        utc_2pm = Time.zone.parse("2026-03-02 14:00:00 UTC") # Monday
+        expect(calculator.within_business_hours?(utc_2pm, eastern_schedule)).to be(true)
+      end
+
+      it "returns false when UTC time is in hours but local time is not" do
+        # 12:00 UTC = 07:00 EST (before business hours)
+        utc_noon = Time.zone.parse("2026-03-02 12:00:00 UTC") # Monday
+        expect(calculator.within_business_hours?(utc_noon, eastern_schedule)).to be(false)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #add_business_hours
+  # ------------------------------------------------------------------ #
+  describe "#add_business_hours" do
+    it "adds hours within the same business day" do
+      monday_10am = Time.zone.parse("2026-03-02 10:00:00 UTC")
+      result = calculator.add_business_hours(monday_10am, 2, schedule)
+
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-02 12:00:00 UTC"))
+    end
+
+    it "rolls over to the next business day when hours exceed remaining time" do
+      monday_4pm = Time.zone.parse("2026-03-02 16:00:00 UTC")
+      result = calculator.add_business_hours(monday_4pm, 2, schedule)
+
+      # 1 hour left on Monday, 1 hour needed on Tuesday => Tuesday 10:00
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-03 10:00:00 UTC"))
+    end
+
+    it "skips non-working days" do
+      friday_4pm = Time.zone.parse("2026-02-27 16:00:00 UTC") # Friday
+      result = calculator.add_business_hours(friday_4pm, 2, schedule)
+
+      # 1 hour left on Friday, skip Saturday and Sunday, 1 hour on Monday => Monday 10:00
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-02 10:00:00 UTC"))
+    end
+
+    it "handles starting before business hours" do
+      monday_7am = Time.zone.parse("2026-03-02 07:00:00 UTC")
+      result = calculator.add_business_hours(monday_7am, 1, schedule)
+
+      # Should start at 09:00 and add 1 hour => 10:00
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-02 10:00:00 UTC"))
+    end
+
+    it "handles starting after business hours" do
+      monday_6pm = Time.zone.parse("2026-03-02 18:00:00 UTC")
+      result = calculator.add_business_hours(monday_6pm, 1, schedule)
+
+      # Should skip to Tuesday 09:00, add 1 hour => 10:00
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-03 10:00:00 UTC"))
+    end
+
+    it "handles multiple days worth of hours" do
+      monday_9am = Time.zone.parse("2026-03-02 09:00:00 UTC")
+      result = calculator.add_business_hours(monday_9am, 16, schedule)
+
+      # 8 hours Monday, 8 hours Tuesday => Tuesday 17:00
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-03 17:00:00 UTC"))
+    end
+
+    it "skips holidays" do
+      create(:escalated_holiday,
+             schedule: schedule,
+             name: "Holiday",
+             date: Date.parse("2026-03-03"),
+             recurring: false)
+
+      monday_4pm = Time.zone.parse("2026-03-02 16:00:00 UTC")
+      result = calculator.add_business_hours(monday_4pm, 2, schedule.reload)
+
+      # 1 hour Monday, skip Tuesday (holiday), 1 hour Wednesday => Wednesday 10:00
+      expect(result).to be_within(1.minute).of(Time.zone.parse("2026-03-04 10:00:00 UTC"))
+    end
+
+    it "returns UTC time" do
+      monday_10am = Time.zone.parse("2026-03-02 10:00:00 UTC")
+      result = calculator.add_business_hours(monday_10am, 1, schedule)
+
+      expect(result.utc?).to be(true)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 2. TicketMergeService
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::TicketMergeService do
+  subject(:service) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+  end
+
+  let(:agent) { create(:user, :agent) }
+  let(:source) { create(:escalated_ticket, status: :open) }
+  let(:target) { create(:escalated_ticket, status: :open) }
+
+  # ------------------------------------------------------------------ #
+  # #merge
+  # ------------------------------------------------------------------ #
+  describe "#merge" do
+    it "moves replies from source to target" do
+      reply1 = create(:escalated_reply, ticket: source)
+      reply2 = create(:escalated_reply, ticket: source)
+
+      service.merge(source, target, merged_by_user_id: agent.id)
+
+      expect(reply1.reload.ticket_id).to eq(target.id)
+      expect(reply2.reload.ticket_id).to eq(target.id)
+    end
+
+    it "creates a system note on the target ticket" do
+      service.merge(source, target, merged_by_user_id: agent.id)
+
+      note = target.replies.find_by("body LIKE ?", "%merged into this ticket%")
+      expect(note).to be_present
+      expect(note.is_internal).to be(true)
+      expect(note.is_system).to be(true)
+      expect(note.body).to include(source.reference)
+    end
+
+    it "creates a system note on the source ticket" do
+      service.merge(source, target, merged_by_user_id: agent.id)
+
+      note = source.replies.find_by("body LIKE ?", "%was merged into%")
+      expect(note).to be_present
+      expect(note.is_internal).to be(true)
+      expect(note.is_system).to be(true)
+      expect(note.body).to include(target.reference)
+    end
+
+    it "closes the source ticket" do
+      service.merge(source, target, merged_by_user_id: agent.id)
+      source.reload
+
+      expect(source.status).to eq("closed")
+    end
+
+    it "sets merged_into on the source ticket" do
+      service.merge(source, target, merged_by_user_id: agent.id)
+      source.reload
+
+      expect(source.merged_into_id).to eq(target.id)
+    end
+
+    it "wraps everything in a transaction" do
+      # If the source.update! fails, replies should not be moved
+      allow(source).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect {
+        service.merge(source, target, merged_by_user_id: agent.id) rescue nil
+      }.not_to change { Escalated::Reply.where(ticket: target).count }
+    end
+
+    context "without merged_by_user_id" do
+      it "still creates system notes" do
+        service.merge(source, target)
+
+        note = target.replies.find_by("body LIKE ?", "%merged into this ticket%")
+        expect(note).to be_present
+        expect(note.is_system).to be(true)
+      end
+    end
+
+    context "when source has no replies" do
+      it "still creates system notes and closes source" do
+        service.merge(source, target, merged_by_user_id: agent.id)
+
+        expect(source.reload.status).to eq("closed")
+        expect(target.replies.where("body LIKE ?", "%merged into this ticket%")).to exist
+        expect(source.replies.where("body LIKE ?", "%was merged into%")).to exist
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 3. SkillRoutingService
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::SkillRoutingService do
+  subject(:service) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+    allow(Escalated.configuration).to receive(:user_class).and_return("User")
+  end
+
+  # ------------------------------------------------------------------ #
+  # #find_matching_agents
+  # ------------------------------------------------------------------ #
+  describe "#find_matching_agents" do
+    context "when ticket has no tags" do
+      it "returns an empty relation" do
+        ticket = create(:escalated_ticket)
+
+        result = service.find_matching_agents(ticket)
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "when no skills match the ticket tags" do
+      it "returns an empty relation" do
+        tag = create(:escalated_tag, name: "billing")
+        ticket = create(:escalated_ticket)
+        ticket.tags << tag
+
+        # No skill named "billing" exists
+        result = service.find_matching_agents(ticket)
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "when skills exist but no agents have them" do
+      it "returns an empty relation" do
+        tag = create(:escalated_tag, name: "networking")
+        skill = create(:escalated_skill, name: "networking")
+        ticket = create(:escalated_ticket)
+        ticket.tags << tag
+
+        # Skill exists but no AgentSkill records
+        result = service.find_matching_agents(ticket)
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "when matching agents exist" do
+      it "returns agents with matching skills" do
+        agent = create(:user, :agent)
+        tag = create(:escalated_tag, name: "ruby")
+        skill = create(:escalated_skill, name: "ruby")
+        Escalated::AgentSkill.create!(user_id: agent.id, skill_id: skill.id)
+
+        ticket = create(:escalated_ticket)
+        ticket.tags << tag
+
+        result = service.find_matching_agents(ticket)
+
+        expect(result.map(&:id)).to include(agent.id)
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 4. CapacityService
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::CapacityService do
+  subject(:service) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+  end
+
+  let(:agent) { create(:user, :agent) }
+
+  # ------------------------------------------------------------------ #
+  # #can_accept_ticket?
+  # ------------------------------------------------------------------ #
+  describe "#can_accept_ticket?" do
+    it "returns true when agent has no existing capacity record" do
+      expect(service.can_accept_ticket?(agent.id)).to be(true)
+    end
+
+    it "creates a capacity record with defaults if none exists" do
+      expect {
+        service.can_accept_ticket?(agent.id)
+      }.to change(Escalated::AgentCapacity, :count).by(1)
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id)
+      expect(capacity.max_concurrent).to eq(10)
+      expect(capacity.current_count).to eq(0)
+    end
+
+    it "returns true when agent has capacity" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "default", max_concurrent: 5, current_count: 3)
+
+      expect(service.can_accept_ticket?(agent.id)).to be(true)
+    end
+
+    it "returns false when agent is at capacity" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "default", max_concurrent: 5, current_count: 5)
+
+      expect(service.can_accept_ticket?(agent.id)).to be(false)
+    end
+
+    it "respects channel parameter" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "email", max_concurrent: 2, current_count: 2)
+
+      expect(service.can_accept_ticket?(agent.id, channel: "email")).to be(false)
+      expect(service.can_accept_ticket?(agent.id, channel: "chat")).to be(true)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #increment_load
+  # ------------------------------------------------------------------ #
+  describe "#increment_load" do
+    it "increments the current_count" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "default", max_concurrent: 10, current_count: 3)
+
+      service.increment_load(agent.id)
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id, channel: "default")
+      expect(capacity.current_count).to eq(4)
+    end
+
+    it "creates a capacity record if none exists" do
+      expect {
+        service.increment_load(agent.id)
+      }.to change(Escalated::AgentCapacity, :count).by(1)
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id)
+      expect(capacity.current_count).to eq(1)
+    end
+
+    it "respects channel parameter" do
+      service.increment_load(agent.id, channel: "chat")
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id, channel: "chat")
+      expect(capacity).to be_present
+      expect(capacity.current_count).to eq(1)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #decrement_load
+  # ------------------------------------------------------------------ #
+  describe "#decrement_load" do
+    it "decrements the current_count" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "default", max_concurrent: 10, current_count: 3)
+
+      service.decrement_load(agent.id)
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id, channel: "default")
+      expect(capacity.current_count).to eq(2)
+    end
+
+    it "does not decrement below zero" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "default", max_concurrent: 10, current_count: 0)
+
+      service.decrement_load(agent.id)
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id, channel: "default")
+      expect(capacity.current_count).to eq(0)
+    end
+
+    it "creates a capacity record if none exists and does not decrement" do
+      expect {
+        service.decrement_load(agent.id)
+      }.to change(Escalated::AgentCapacity, :count).by(1)
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id)
+      expect(capacity.current_count).to eq(0)
+    end
+
+    it "respects channel parameter" do
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "chat", max_concurrent: 10, current_count: 5)
+
+      service.decrement_load(agent.id, channel: "chat")
+
+      capacity = Escalated::AgentCapacity.find_by(user_id: agent.id, channel: "chat")
+      expect(capacity.current_count).to eq(4)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #all_capacities
+  # ------------------------------------------------------------------ #
+  describe "#all_capacities" do
+    it "returns all capacity records" do
+      agent2 = create(:user, :agent)
+      Escalated::AgentCapacity.create!(user_id: agent.id, channel: "default", max_concurrent: 10, current_count: 0)
+      Escalated::AgentCapacity.create!(user_id: agent2.id, channel: "default", max_concurrent: 5, current_count: 3)
+
+      result = service.all_capacities
+
+      expect(result.count).to eq(2)
+    end
+
+    it "returns an empty relation when no capacity records exist" do
+      result = service.all_capacities
+
+      expect(result).to be_empty
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 5. WebhookDispatcher
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::WebhookDispatcher do
+  subject(:dispatcher) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+
+    # Stub HTTP requests by default
+    allow(Net::HTTP).to receive(:new).and_return(mock_http)
+  end
+
+  let(:mock_http) do
+    http = instance_double(Net::HTTP)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:open_timeout=)
+    allow(http).to receive(:read_timeout=)
+    allow(http).to receive(:request).and_return(mock_response)
+    http
+  end
+
+  let(:mock_response) do
+    response = instance_double(Net::HTTPResponse)
+    allow(response).to receive(:code).and_return("200")
+    allow(response).to receive(:body).and_return('{"ok":true}')
+    response
+  end
+
+  # ------------------------------------------------------------------ #
+  # #dispatch
+  # ------------------------------------------------------------------ #
+  describe "#dispatch" do
+    it "sends webhook to active webhooks subscribed to the event" do
+      webhook = Escalated::Webhook.create!(url: "https://example.com/hook", events: ["ticket.created"], active: true)
+
+      expect {
+        dispatcher.dispatch("ticket.created", { ticket_id: 1 })
+      }.to change(Escalated::WebhookDelivery, :count).by(1)
+    end
+
+    it "does not send webhook to inactive webhooks" do
+      Escalated::Webhook.create!(url: "https://example.com/hook", events: ["ticket.created"], active: false)
+
+      expect {
+        dispatcher.dispatch("ticket.created", { ticket_id: 1 })
+      }.not_to change(Escalated::WebhookDelivery, :count)
+    end
+
+    it "does not send webhook for unsubscribed events" do
+      Escalated::Webhook.create!(url: "https://example.com/hook", events: ["ticket.updated"], active: true)
+
+      expect {
+        dispatcher.dispatch("ticket.created", { ticket_id: 1 })
+      }.not_to change(Escalated::WebhookDelivery, :count)
+    end
+
+    it "sends to multiple subscribed webhooks" do
+      Escalated::Webhook.create!(url: "https://example.com/hook1", events: ["ticket.created"], active: true)
+      Escalated::Webhook.create!(url: "https://example.com/hook2", events: ["ticket.created"], active: true)
+
+      expect {
+        dispatcher.dispatch("ticket.created", { ticket_id: 1 })
+      }.to change(Escalated::WebhookDelivery, :count).by(2)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #send_webhook
+  # ------------------------------------------------------------------ #
+  describe "#send_webhook" do
+    let(:webhook) { Escalated::Webhook.create!(url: "https://example.com/hook", events: ["ticket.created"], active: true, secret: "test-secret") }
+
+    it "creates a WebhookDelivery record" do
+      expect {
+        dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+      }.to change(Escalated::WebhookDelivery, :count).by(1)
+    end
+
+    it "records the response code on success" do
+      dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+
+      delivery = Escalated::WebhookDelivery.last
+      expect(delivery.response_code).to eq(200)
+    end
+
+    it "records the delivered_at timestamp on success" do
+      dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+
+      delivery = Escalated::WebhookDelivery.last
+      expect(delivery.delivered_at).to be_present
+    end
+
+    it "records the response body" do
+      dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+
+      delivery = Escalated::WebhookDelivery.last
+      expect(delivery.response_body).to eq('{"ok":true}')
+    end
+
+    it "includes HMAC signature when secret is present" do
+      expect(mock_http).to receive(:request) do |request|
+        expect(request["X-Escalated-Signature"]).to be_present
+        mock_response
+      end
+
+      dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+    end
+
+    it "includes the event header" do
+      expect(mock_http).to receive(:request) do |request|
+        expect(request["X-Escalated-Event"]).to eq("ticket.created")
+        mock_response
+      end
+
+      dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+    end
+
+    context "without a secret" do
+      let(:webhook_no_secret) { Escalated::Webhook.create!(url: "https://example.com/hook", events: ["ticket.created"], active: true, secret: nil) }
+
+      it "does not include signature header" do
+        expect(mock_http).to receive(:request) do |request|
+          expect(request["X-Escalated-Signature"]).to be_nil
+          mock_response
+        end
+
+        dispatcher.send_webhook(webhook_no_secret, "ticket.created", { ticket_id: 1 })
+      end
+    end
+
+    context "when the request fails" do
+      before do
+        allow(mock_http).to receive(:request).and_raise(Errno::ECONNREFUSED, "Connection refused")
+      end
+
+      it "records the error in response_body" do
+        dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+
+        delivery = Escalated::WebhookDelivery.first
+        expect(delivery.response_code).to eq(0)
+        expect(delivery.response_body).to include("Connection refused")
+      end
+
+      it "retries up to MAX_ATTEMPTS times" do
+        expect {
+          dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+        }.to change(Escalated::WebhookDelivery, :count).by(3)
+      end
+    end
+
+    context "when response is non-2xx" do
+      let(:failed_response) do
+        response = instance_double(Net::HTTPResponse)
+        allow(response).to receive(:code).and_return("500")
+        allow(response).to receive(:body).and_return('{"error":"Internal Server Error"}')
+        response
+      end
+
+      before do
+        allow(mock_http).to receive(:request).and_return(failed_response)
+      end
+
+      it "retries on non-2xx responses" do
+        expect {
+          dispatcher.send_webhook(webhook, "ticket.created", { ticket_id: 1 })
+        }.to change(Escalated::WebhookDelivery, :count).by(3)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #retry_delivery
+  # ------------------------------------------------------------------ #
+  describe "#retry_delivery" do
+    it "re-dispatches the delivery's event and payload" do
+      webhook = Escalated::Webhook.create!(url: "https://example.com/hook", events: ["ticket.created"], active: true)
+      delivery = Escalated::WebhookDelivery.create!(
+        webhook: webhook,
+        event: "ticket.created",
+        payload: { ticket_id: 42 },
+        response_code: 500,
+        attempts: 1
+      )
+
+      expect {
+        dispatcher.retry_delivery(delivery)
+      }.to change(Escalated::WebhookDelivery, :count).by(1)
+    end
+
+    it "does nothing if the delivery has no webhook" do
+      delivery = instance_double(Escalated::WebhookDelivery, webhook: nil)
+
+      expect {
+        dispatcher.retry_delivery(delivery)
+      }.not_to change(Escalated::WebhookDelivery, :count)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 6. AutomationRunner
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::AutomationRunner do
+  subject(:runner) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+  end
+
+  # ------------------------------------------------------------------ #
+  # #run
+  # ------------------------------------------------------------------ #
+  describe "#run" do
+    it "returns 0 when no active automations exist" do
+      expect(runner.run).to eq(0)
+    end
+
+    it "skips inactive automations" do
+      Escalated::Automation.create!(
+        name: "Inactive",
+        conditions: [{ "field" => "status", "value" => "open" }],
+        actions: [{ "type" => "change_priority", "value" => "high" }],
+        active: false
+      )
+      create(:escalated_ticket, status: :open)
+
+      expect(runner.run).to eq(0)
+    end
+
+    context "with status condition" do
+      it "matches tickets with the specified status" do
+        Escalated::Automation.create!(
+          name: "Close stale",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "change_priority", "value" => "high" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("high")
+      end
+
+      it "does not match tickets with different status" do
+        Escalated::Automation.create!(
+          name: "Test",
+          conditions: [{ "field" => "status", "value" => "escalated" }],
+          actions: [{ "type" => "change_priority", "value" => "high" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("low")
+      end
+    end
+
+    context "with priority condition" do
+      it "matches tickets with the specified priority" do
+        Escalated::Automation.create!(
+          name: "Escalate urgent",
+          conditions: [{ "field" => "priority", "value" => "urgent" }],
+          actions: [{ "type" => "change_status", "value" => "escalated" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :urgent)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.status).to eq("escalated")
+      end
+    end
+
+    context "with hours_since_created condition" do
+      it "matches tickets created more than N hours ago" do
+        Escalated::Automation.create!(
+          name: "Stale tickets",
+          conditions: [{ "field" => "hours_since_created", "value" => "24" }],
+          actions: [{ "type" => "change_priority", "value" => "high" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low, created_at: 48.hours.ago)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("high")
+      end
+
+      it "does not match recent tickets" do
+        Escalated::Automation.create!(
+          name: "Stale tickets",
+          conditions: [{ "field" => "hours_since_created", "value" => "24" }],
+          actions: [{ "type" => "change_priority", "value" => "high" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low, created_at: 1.hour.ago)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("low")
+      end
+    end
+
+    context "with hours_since_updated condition" do
+      it "matches tickets not updated for N hours" do
+        Escalated::Automation.create!(
+          name: "Stale tickets",
+          conditions: [{ "field" => "hours_since_updated", "value" => "12" }],
+          actions: [{ "type" => "change_priority", "value" => "urgent" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low)
+        ticket.update_column(:updated_at, 24.hours.ago)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("urgent")
+      end
+    end
+
+    context "with assigned condition" do
+      it "matches unassigned tickets when value is 'unassigned'" do
+        Escalated::Automation.create!(
+          name: "Flag unassigned",
+          conditions: [{ "field" => "assigned", "value" => "unassigned" }],
+          actions: [{ "type" => "change_priority", "value" => "high" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low, assigned_to: nil)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("high")
+      end
+
+      it "matches assigned tickets when value is not 'unassigned'" do
+        agent = create(:user, :agent)
+        Escalated::Automation.create!(
+          name: "Flag assigned",
+          conditions: [{ "field" => "assigned", "value" => "assigned" }],
+          actions: [{ "type" => "change_priority", "value" => "high" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low, assigned_to: agent.id)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("high")
+      end
+    end
+
+    context "with change_status action" do
+      it "changes the ticket status" do
+        Escalated::Automation.create!(
+          name: "Auto escalate",
+          conditions: [{ "field" => "priority", "value" => "critical" }],
+          actions: [{ "type" => "change_status", "value" => "escalated" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :critical)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.status).to eq("escalated")
+      end
+    end
+
+    context "with assign action" do
+      it "assigns the ticket to the specified agent" do
+        agent = create(:user, :agent)
+        Escalated::Automation.create!(
+          name: "Auto assign",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "assign", "value" => agent.id.to_s }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, assigned_to: nil)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.assigned_to).to eq(agent.id)
+      end
+    end
+
+    context "with add_tag action" do
+      it "adds the specified tag to the ticket" do
+        tag = create(:escalated_tag, name: "auto-tagged")
+        Escalated::Automation.create!(
+          name: "Auto tag",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "add_tag", "value" => "auto-tagged" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open)
+
+        runner.run
+
+        expect(ticket.tags.reload).to include(tag)
+      end
+
+      it "does not duplicate existing tags" do
+        tag = create(:escalated_tag, name: "auto-tagged")
+        Escalated::Automation.create!(
+          name: "Auto tag",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "add_tag", "value" => "auto-tagged" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open)
+        ticket.tags << tag
+
+        runner.run
+
+        expect(ticket.tags.where(name: "auto-tagged").count).to eq(1)
+      end
+
+      it "does nothing when the tag does not exist" do
+        Escalated::Automation.create!(
+          name: "Auto tag",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "add_tag", "value" => "nonexistent-tag" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open)
+
+        expect {
+          runner.run
+        }.not_to change { ticket.tags.count }
+      end
+    end
+
+    context "with change_priority action" do
+      it "changes the ticket priority" do
+        Escalated::Automation.create!(
+          name: "Bump priority",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "change_priority", "value" => "urgent" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open, priority: :low)
+
+        runner.run
+        ticket.reload
+
+        expect(ticket.priority).to eq("urgent")
+      end
+    end
+
+    context "with add_note action" do
+      it "creates an internal note on the ticket" do
+        Escalated::Automation.create!(
+          name: "Add note",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "add_note", "value" => "Automated note added." }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open)
+
+        runner.run
+
+        note = ticket.replies.find_by(body: "Automated note added.")
+        expect(note).to be_present
+        expect(note.is_internal).to be(true)
+        expect(note.is_system).to be(true)
+      end
+    end
+
+    it "updates last_run_at on the automation" do
+      automation = Escalated::Automation.create!(
+        name: "Test",
+        conditions: [{ "field" => "status", "value" => "open" }],
+        actions: [{ "type" => "change_priority", "value" => "high" }],
+        active: true,
+        position: 0,
+        last_run_at: nil
+      )
+      create(:escalated_ticket, status: :open)
+
+      runner.run
+      automation.reload
+
+      expect(automation.last_run_at).to be_present
+    end
+
+    it "returns the total number of affected tickets" do
+      Escalated::Automation.create!(
+        name: "Test",
+        conditions: [{ "field" => "status", "value" => "open" }],
+        actions: [{ "type" => "change_priority", "value" => "high" }],
+        active: true,
+        position: 0
+      )
+      create(:escalated_ticket, status: :open, priority: :low)
+      create(:escalated_ticket, status: :open, priority: :medium)
+      create(:escalated_ticket, :closed) # Should not be matched
+
+      expect(runner.run).to eq(2)
+    end
+
+    it "excludes closed and resolved tickets from matching" do
+      Escalated::Automation.create!(
+        name: "Test",
+        conditions: [],
+        actions: [{ "type" => "change_priority", "value" => "high" }],
+        active: true,
+        position: 0
+      )
+      closed = create(:escalated_ticket, :closed)
+      resolved = create(:escalated_ticket, :resolved)
+
+      runner.run
+      closed.reload
+      resolved.reload
+
+      expect(closed.priority).not_to eq("high")
+      expect(resolved.priority).not_to eq("high")
+    end
+
+    context "when an action raises an error" do
+      it "logs the error and continues" do
+        Escalated::Automation.create!(
+          name: "Bad automation",
+          conditions: [{ "field" => "status", "value" => "open" }],
+          actions: [{ "type" => "change_status", "value" => "nonexistent_status" }],
+          active: true,
+          position: 0
+        )
+        ticket = create(:escalated_ticket, status: :open)
+
+        expect(Rails.logger).to receive(:warn).with(/Escalated automation action failed/)
+
+        runner.run
+      end
+    end
+
+    context "with multiple conditions" do
+      it "applies all conditions with AND logic" do
+        Escalated::Automation.create!(
+          name: "Multi-condition",
+          conditions: [
+            { "field" => "status", "value" => "open" },
+            { "field" => "priority", "value" => "urgent" }
+          ],
+          actions: [{ "type" => "change_status", "value" => "escalated" }],
+          active: true,
+          position: 0
+        )
+        matching = create(:escalated_ticket, status: :open, priority: :urgent)
+        non_matching = create(:escalated_ticket, status: :open, priority: :low)
+
+        runner.run
+        matching.reload
+        non_matching.reload
+
+        expect(matching.status).to eq("escalated")
+        expect(non_matching.status).to eq("open")
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 7. TwoFactorService
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::TwoFactorService do
+  subject(:service) { described_class.new }
+
+  # ------------------------------------------------------------------ #
+  # #generate_secret
+  # ------------------------------------------------------------------ #
+  describe "#generate_secret" do
+    it "returns a 16-character string" do
+      secret = service.generate_secret
+
+      expect(secret.length).to eq(16)
+    end
+
+    it "only contains valid Base32 characters" do
+      secret = service.generate_secret
+
+      expect(secret).to match(/\A[A-Z2-7]+\z/)
+    end
+
+    it "generates unique secrets" do
+      secrets = 10.times.map { service.generate_secret }
+
+      expect(secrets.uniq.length).to eq(10)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #generate_qr_uri
+  # ------------------------------------------------------------------ #
+  describe "#generate_qr_uri" do
+    it "returns an otpauth URI" do
+      uri = service.generate_qr_uri("JBSWY3DPEHPK3PXP", "user@example.com")
+
+      expect(uri).to start_with("otpauth://totp/")
+    end
+
+    it "includes the email in the URI" do
+      uri = service.generate_qr_uri("JBSWY3DPEHPK3PXP", "user@example.com")
+
+      expect(uri).to include("user@example.com")
+    end
+
+    it "includes the secret in the URI" do
+      uri = service.generate_qr_uri("JBSWY3DPEHPK3PXP", "user@example.com")
+
+      expect(uri).to include("secret=JBSWY3DPEHPK3PXP")
+    end
+
+    it "includes SHA1 algorithm" do
+      uri = service.generate_qr_uri("JBSWY3DPEHPK3PXP", "user@example.com")
+
+      expect(uri).to include("algorithm=SHA1")
+    end
+
+    it "includes 6 digits" do
+      uri = service.generate_qr_uri("JBSWY3DPEHPK3PXP", "user@example.com")
+
+      expect(uri).to include("digits=6")
+    end
+
+    it "includes 30-second period" do
+      uri = service.generate_qr_uri("JBSWY3DPEHPK3PXP", "user@example.com")
+
+      expect(uri).to include("period=30")
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #verify
+  # ------------------------------------------------------------------ #
+  describe "#verify" do
+    it "verifies a correct TOTP code for the current time step" do
+      secret = service.generate_secret
+      # Generate the correct code using the service's own logic
+      current_step = Time.now.to_i / 30
+      correct_code = service.send(:generate_totp, secret, current_step)
+
+      expect(service.verify(secret, correct_code)).to be(true)
+    end
+
+    it "accepts codes from the previous time step (drift tolerance)" do
+      secret = service.generate_secret
+      previous_step = (Time.now.to_i / 30) - 1
+      previous_code = service.send(:generate_totp, secret, previous_step)
+
+      expect(service.verify(secret, previous_code)).to be(true)
+    end
+
+    it "accepts codes from the next time step (drift tolerance)" do
+      secret = service.generate_secret
+      next_step = (Time.now.to_i / 30) + 1
+      next_code = service.send(:generate_totp, secret, next_step)
+
+      expect(service.verify(secret, next_code)).to be(true)
+    end
+
+    it "rejects an incorrect code" do
+      secret = service.generate_secret
+
+      expect(service.verify(secret, "000000")).to be(false)
+    end
+
+    it "rejects a code from a far-off time step" do
+      secret = service.generate_secret
+      far_step = (Time.now.to_i / 30) + 100
+      far_code = service.send(:generate_totp, secret, far_step)
+
+      expect(service.verify(secret, far_code)).to be(false)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #generate_recovery_codes
+  # ------------------------------------------------------------------ #
+  describe "#generate_recovery_codes" do
+    it "returns 8 recovery codes" do
+      codes = service.generate_recovery_codes
+
+      expect(codes.length).to eq(8)
+    end
+
+    it "returns codes in the format XXXX-XXXX (hex)" do
+      codes = service.generate_recovery_codes
+
+      codes.each do |code|
+        expect(code).to match(/\A[A-F0-9]{8}-[A-F0-9]{8}\z/)
+      end
+    end
+
+    it "generates unique codes" do
+      codes = service.generate_recovery_codes
+
+      expect(codes.uniq.length).to eq(8)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 8. SsoService
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::SsoService do
+  subject(:service) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+  end
+
+  # ------------------------------------------------------------------ #
+  # #get_config
+  # ------------------------------------------------------------------ #
+  describe "#get_config" do
+    it "returns all SSO configuration keys with defaults" do
+      config = service.get_config
+
+      expect(config).to include(
+        "sso_provider" => "none",
+        "sso_entity_id" => "",
+        "sso_url" => "",
+        "sso_certificate" => "",
+        "sso_attr_email" => "email",
+        "sso_attr_name" => "name",
+        "sso_attr_role" => "role",
+        "sso_jwt_secret" => "",
+        "sso_jwt_algorithm" => "HS256"
+      )
+    end
+
+    it "returns stored values when settings exist" do
+      Escalated::EscalatedSetting.create!(key: "sso_provider", value: "saml")
+      Escalated::EscalatedSetting.create!(key: "sso_url", value: "https://idp.example.com/sso")
+
+      config = service.get_config
+
+      expect(config["sso_provider"]).to eq("saml")
+      expect(config["sso_url"]).to eq("https://idp.example.com/sso")
+    end
+
+    it "mixes stored values with defaults for missing keys" do
+      Escalated::EscalatedSetting.create!(key: "sso_provider", value: "jwt")
+
+      config = service.get_config
+
+      expect(config["sso_provider"]).to eq("jwt")
+      expect(config["sso_attr_email"]).to eq("email") # default
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #save_config
+  # ------------------------------------------------------------------ #
+  describe "#save_config" do
+    it "creates settings for new keys" do
+      expect {
+        service.save_config("sso_provider" => "saml", "sso_url" => "https://idp.example.com")
+      }.to change(Escalated::EscalatedSetting, :count).by(2)
+    end
+
+    it "updates existing settings" do
+      Escalated::EscalatedSetting.create!(key: "sso_provider", value: "none")
+
+      service.save_config("sso_provider" => "saml")
+
+      expect(Escalated::EscalatedSetting.find_by(key: "sso_provider").value).to eq("saml")
+    end
+
+    it "ignores keys not in CONFIG_KEYS" do
+      expect {
+        service.save_config("unknown_key" => "value", "sso_provider" => "jwt")
+      }.to change(Escalated::EscalatedSetting, :count).by(1)
+    end
+
+    it "only saves provided keys" do
+      service.save_config("sso_provider" => "saml")
+
+      expect(Escalated::EscalatedSetting.find_by(key: "sso_url")).to be_nil
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #enabled?
+  # ------------------------------------------------------------------ #
+  describe "#enabled?" do
+    it "returns false when provider is 'none'" do
+      expect(service.enabled?).to be(false)
+    end
+
+    it "returns false when no provider setting exists" do
+      expect(service.enabled?).to be(false)
+    end
+
+    it "returns true when provider is set to something other than 'none'" do
+      Escalated::EscalatedSetting.create!(key: "sso_provider", value: "saml")
+
+      expect(service.enabled?).to be(true)
+    end
+
+    it "returns true when provider is 'jwt'" do
+      Escalated::EscalatedSetting.create!(key: "sso_provider", value: "jwt")
+
+      expect(service.enabled?).to be(true)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #provider
+  # ------------------------------------------------------------------ #
+  describe "#provider" do
+    it "returns 'none' by default" do
+      expect(service.provider).to eq("none")
+    end
+
+    it "returns the stored provider value" do
+      Escalated::EscalatedSetting.create!(key: "sso_provider", value: "saml")
+
+      expect(service.provider).to eq("saml")
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------- #
+# 9. ReportingService
+# ---------------------------------------------------------------------------- #
+RSpec.describe Escalated::Services::ReportingService do
+  subject(:service) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+    allow(Escalated.configuration).to receive(:webhook_url).and_return(nil)
+    allow(Escalated.configuration).to receive(:user_class).and_return("User")
+  end
+
+  let(:start_date) { 30.days.ago }
+  let(:end_date) { Time.current }
+
+  # ------------------------------------------------------------------ #
+  # #ticket_volume_by_date
+  # ------------------------------------------------------------------ #
+  describe "#ticket_volume_by_date" do
+    it "returns ticket counts grouped by date" do
+      create(:escalated_ticket, created_at: 5.days.ago)
+      create(:escalated_ticket, created_at: 5.days.ago)
+      create(:escalated_ticket, created_at: 3.days.ago)
+
+      result = service.ticket_volume_by_date(start_date, end_date)
+
+      expect(result).to be_an(Array)
+      expect(result.length).to eq(2) # 2 distinct dates
+    end
+
+    it "returns entries with date and count keys" do
+      create(:escalated_ticket, created_at: 2.days.ago)
+
+      result = service.ticket_volume_by_date(start_date, end_date)
+
+      expect(result.first).to have_key(:date)
+      expect(result.first).to have_key(:count)
+    end
+
+    it "returns empty array when no tickets in range" do
+      result = service.ticket_volume_by_date(start_date, end_date)
+
+      expect(result).to be_empty
+    end
+
+    it "excludes tickets outside the date range" do
+      create(:escalated_ticket, created_at: 60.days.ago)
+      create(:escalated_ticket, created_at: 5.days.ago)
+
+      result = service.ticket_volume_by_date(start_date, end_date)
+
+      total_count = result.sum { |r| r[:count] }
+      expect(total_count).to eq(1)
+    end
+
+    it "orders results by date" do
+      create(:escalated_ticket, created_at: 10.days.ago)
+      create(:escalated_ticket, created_at: 5.days.ago)
+      create(:escalated_ticket, created_at: 1.day.ago)
+
+      result = service.ticket_volume_by_date(start_date, end_date)
+      dates = result.map { |r| r[:date] }
+
+      expect(dates).to eq(dates.sort)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #tickets_by_status
+  # ------------------------------------------------------------------ #
+  describe "#tickets_by_status" do
+    it "returns ticket counts grouped by status" do
+      create(:escalated_ticket, :open)
+      create(:escalated_ticket, :open)
+      create(:escalated_ticket, :closed)
+
+      result = service.tickets_by_status
+
+      expect(result).to be_an(Array)
+      open_entry = result.find { |r| r[:status] == "open" }
+      closed_entry = result.find { |r| r[:status] == "closed" }
+      expect(open_entry[:count]).to eq(2)
+      expect(closed_entry[:count]).to eq(1)
+    end
+
+    it "returns empty array when no tickets exist" do
+      result = service.tickets_by_status
+
+      expect(result).to be_empty
+    end
+
+    it "includes all present statuses" do
+      create(:escalated_ticket, :open)
+      create(:escalated_ticket, :in_progress)
+      create(:escalated_ticket, :resolved)
+
+      result = service.tickets_by_status
+      statuses = result.map { |r| r[:status] }
+
+      expect(statuses).to include("open", "in_progress", "resolved")
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #tickets_by_priority
+  # ------------------------------------------------------------------ #
+  describe "#tickets_by_priority" do
+    it "returns ticket counts grouped by priority" do
+      create(:escalated_ticket, priority: :low)
+      create(:escalated_ticket, priority: :high)
+      create(:escalated_ticket, priority: :high)
+
+      result = service.tickets_by_priority
+
+      expect(result).to be_an(Array)
+      high_entry = result.find { |r| r[:priority] == "high" }
+      low_entry = result.find { |r| r[:priority] == "low" }
+      expect(high_entry[:count]).to eq(2)
+      expect(low_entry[:count]).to eq(1)
+    end
+
+    it "returns empty array when no tickets exist" do
+      result = service.tickets_by_priority
+
+      expect(result).to be_empty
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #average_response_time
+  # ------------------------------------------------------------------ #
+  describe "#average_response_time" do
+    it "returns the average first response time in hours" do
+      ticket1 = create(:escalated_ticket, created_at: 10.days.ago)
+      create(:escalated_reply, ticket: ticket1, is_internal: false, created_at: ticket1.created_at + 2.hours)
+
+      ticket2 = create(:escalated_ticket, created_at: 8.days.ago)
+      create(:escalated_reply, ticket: ticket2, is_internal: false, created_at: ticket2.created_at + 4.hours)
+
+      result = service.average_response_time(start_date, end_date)
+
+      # Average of 2 hours and 4 hours = 3 hours
+      expect(result).to be_within(0.1).of(3.0)
+    end
+
+    it "ignores internal replies for first response calculation" do
+      ticket = create(:escalated_ticket, created_at: 5.days.ago)
+      create(:escalated_reply, ticket: ticket, is_internal: true, created_at: ticket.created_at + 1.hour)
+      create(:escalated_reply, ticket: ticket, is_internal: false, created_at: ticket.created_at + 3.hours)
+
+      result = service.average_response_time(start_date, end_date)
+
+      expect(result).to be_within(0.1).of(3.0)
+    end
+
+    it "returns 0.0 when no tickets have replies" do
+      create(:escalated_ticket, created_at: 5.days.ago)
+
+      result = service.average_response_time(start_date, end_date)
+
+      expect(result).to eq(0.0)
+    end
+
+    it "returns 0.0 when no tickets exist in range" do
+      result = service.average_response_time(start_date, end_date)
+
+      expect(result).to eq(0.0)
+    end
+
+    it "only considers the first public reply per ticket" do
+      ticket = create(:escalated_ticket, created_at: 5.days.ago)
+      create(:escalated_reply, ticket: ticket, is_internal: false, created_at: ticket.created_at + 2.hours)
+      create(:escalated_reply, ticket: ticket, is_internal: false, created_at: ticket.created_at + 10.hours)
+
+      result = service.average_response_time(start_date, end_date)
+
+      expect(result).to be_within(0.1).of(2.0)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #average_resolution_time
+  # ------------------------------------------------------------------ #
+  describe "#average_resolution_time" do
+    it "returns the average resolution time in hours for resolved/closed tickets" do
+      ticket1 = create(:escalated_ticket, :resolved, created_at: 10.days.ago)
+      ticket1.update_column(:updated_at, ticket1.created_at + 12.hours)
+
+      ticket2 = create(:escalated_ticket, :closed, created_at: 8.days.ago)
+      ticket2.update_column(:updated_at, ticket2.created_at + 24.hours)
+
+      result = service.average_resolution_time(start_date, end_date)
+
+      # Average of 12 hours and 24 hours = 18 hours
+      expect(result).to be_within(0.5).of(18.0)
+    end
+
+    it "returns 0.0 when no resolved/closed tickets exist" do
+      create(:escalated_ticket, :open, created_at: 5.days.ago)
+
+      result = service.average_resolution_time(start_date, end_date)
+
+      expect(result).to eq(0.0)
+    end
+
+    it "returns 0.0 when no tickets exist in range" do
+      result = service.average_resolution_time(start_date, end_date)
+
+      expect(result).to eq(0.0)
+    end
+
+    it "excludes open tickets from the calculation" do
+      open_ticket = create(:escalated_ticket, :open, created_at: 5.days.ago)
+      resolved_ticket = create(:escalated_ticket, :resolved, created_at: 5.days.ago)
+      resolved_ticket.update_column(:updated_at, resolved_ticket.created_at + 6.hours)
+
+      result = service.average_resolution_time(start_date, end_date)
+
+      expect(result).to be_within(0.1).of(6.0)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #agent_performance
+  # ------------------------------------------------------------------ #
+  describe "#agent_performance" do
+    # The agent_performance method uses `joins(:escalated_assigned_tickets)`,
+    # which requires the User model to have this association defined.
+    # In the dummy test app, this association may not be set up, so we
+    # test the method's behavior when it can operate.
+
+    context "when no agents have assigned tickets" do
+      it "returns an empty array" do
+        # Add the association dynamically for testing
+        unless User.reflect_on_association(:escalated_assigned_tickets)
+          User.has_many :escalated_assigned_tickets,
+                        class_name: "Escalated::Ticket",
+                        foreign_key: :assigned_to,
+                        dependent: :nullify
+        end
+
+        result = service.agent_performance(start_date, end_date)
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "when agents have assigned tickets" do
+      before do
+        unless User.reflect_on_association(:escalated_assigned_tickets)
+          User.has_many :escalated_assigned_tickets,
+                        class_name: "Escalated::Ticket",
+                        foreign_key: :assigned_to,
+                        dependent: :nullify
+        end
+      end
+
+      it "returns performance data for each agent" do
+        agent = create(:user, :agent)
+        create(:escalated_ticket, :open, assigned_to: agent.id, created_at: 5.days.ago)
+        create(:escalated_ticket, :resolved, assigned_to: agent.id, created_at: 3.days.ago)
+
+        result = service.agent_performance(start_date, end_date)
+
+        expect(result.length).to eq(1)
+        expect(result.first[:agent_id]).to eq(agent.id)
+        expect(result.first[:total_tickets]).to eq(2)
+        expect(result.first[:resolved_tickets]).to eq(1)
+      end
+
+      it "includes the agent name" do
+        agent = create(:user, :agent, name: "Jane Smith")
+        create(:escalated_ticket, :open, assigned_to: agent.id, created_at: 5.days.ago)
+
+        result = service.agent_performance(start_date, end_date)
+
+        expect(result.first[:agent_name]).to eq("Jane Smith")
+      end
+
+      it "returns data for multiple agents" do
+        agent1 = create(:user, :agent)
+        agent2 = create(:user, :agent)
+        create(:escalated_ticket, :open, assigned_to: agent1.id, created_at: 5.days.ago)
+        create(:escalated_ticket, :open, assigned_to: agent2.id, created_at: 5.days.ago)
+
+        result = service.agent_performance(start_date, end_date)
+        agent_ids = result.map { |r| r[:agent_id] }
+
+        expect(agent_ids).to include(agent1.id, agent2.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Port all backend features from Laravel's feature/platform-parity branch:
- Phase 1: Audit logs, custom statuses, business hours, roles & permissions
- Phase 2: Custom fields, ticket linking, merging, side conversations, KB
- Phase 3: Agent profiles, skills, agent capacity
- Phase 4: Webhooks, automations, settings
- Phase 5: Two-factor auth, SSO, custom objects, reporting

Includes 23 models, 14 migrations, 9 services, 17 controllers, 16 factories, and 290 passing RSpec specs. Also fixes pre-existing test environment issues (tzinfo-data, factory loading, migration index names, dummy app root config).