### PR TITLE
feat: make Inertia UI optional with ui_enabled config

### DIFF
--- a/app/controllers/concerns/escalated/renderable.rb
+++ b/app/controllers/concerns/escalated/renderable.rb
@@ -1,0 +1,20 @@
+module Escalated
+  # Controller concern that delegates page rendering to the configured
+  # Escalated.ui_renderer.  Controllers call `render_page` instead of
+  # `render inertia:` directly, which allows the UI layer to be swapped
+  # or disabled entirely.
+  module Renderable
+    extend ActiveSupport::Concern
+
+    private
+
+    # Render a named UI page through the configured renderer.
+    #
+    # @param page   [String]  page/component identifier
+    # @param props  [Hash]    data passed to the page
+    # @param status [Symbol]  HTTP status (default :ok)
+    def render_page(page, props = {}, status: :ok)
+      Escalated.ui_renderer.render_page(self, page, props, status: status)
+    end
+  end
+end

--- a/app/controllers/escalated/admin/api_tokens_controller.rb
+++ b/app/controllers/escalated/admin/api_tokens_controller.rb
@@ -22,7 +22,7 @@ module Escalated
 
         users = agent_list
 
-        render inertia: "Escalated/Admin/ApiTokens/Index", props: {
+        render_page "Escalated/Admin/ApiTokens/Index", {
           tokens: tokens,
           users: users,
           api_enabled: Escalated.configuration.api_enabled

--- a/app/controllers/escalated/admin/articles_controller.rb
+++ b/app/controllers/escalated/admin/articles_controller.rb
@@ -13,7 +13,7 @@ module Escalated
 
         result = paginate(scope)
 
-        render inertia: "Escalated/Admin/Articles/Index", props: {
+        render_page "Escalated/Admin/Articles/Index", {
           articles: result[:data].map { |a| article_json(a) },
           meta: result[:meta],
           filters: {

--- a/app/controllers/escalated/admin/audit_logs_controller.rb
+++ b/app/controllers/escalated/admin/audit_logs_controller.rb
@@ -14,7 +14,7 @@ module Escalated
 
         result = paginate(scope)
 
-        render inertia: "Escalated/Admin/AuditLogs/Index", props: {
+        render_page "Escalated/Admin/AuditLogs/Index", {
           logs: result[:data].map { |l| log_json(l) },
           meta: result[:meta],
           filters: {

--- a/app/controllers/escalated/admin/automations_controller.rb
+++ b/app/controllers/escalated/admin/automations_controller.rb
@@ -7,13 +7,13 @@ module Escalated
       def index
         automations = Escalated::Automation.ordered
 
-        render inertia: "Escalated/Admin/Automations/Index", props: {
+        render_page "Escalated/Admin/Automations/Index", {
           automations: automations.map { |a| automation_json(a) }
         }
       end
 
       def new
-        render inertia: "Escalated/Admin/Automations/New", props: {
+        render_page "Escalated/Admin/Automations/New", {
           condition_fields: condition_fields,
           action_types: action_types
         }
@@ -31,7 +31,7 @@ module Escalated
       end
 
       def edit
-        render inertia: "Escalated/Admin/Automations/Edit", props: {
+        render_page "Escalated/Admin/Automations/Edit", {
           automation: automation_json(@automation),
           condition_fields: condition_fields,
           action_types: action_types

--- a/app/controllers/escalated/admin/business_hours_controller.rb
+++ b/app/controllers/escalated/admin/business_hours_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         schedules = Escalated::BusinessSchedule.includes(:holidays).ordered
 
-        render inertia: "Escalated/Admin/BusinessHours/Index", props: {
+        render_page "Escalated/Admin/BusinessHours/Index", {
           schedules: schedules.map { |s| schedule_json(s) }
         }
       end

--- a/app/controllers/escalated/admin/canned_responses_controller.rb
+++ b/app/controllers/escalated/admin/canned_responses_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         responses = Escalated::CannedResponse.ordered
 
-        render inertia: "Escalated/Admin/CannedResponses/Index", props: {
+        render_page "Escalated/Admin/CannedResponses/Index", {
           canned_responses: responses.map { |r| canned_response_json(r) }
         }
       end

--- a/app/controllers/escalated/admin/capacity_controller.rb
+++ b/app/controllers/escalated/admin/capacity_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         capacities = Escalated::AgentCapacity.includes(:agent).ordered
 
-        render inertia: "Escalated/Admin/Capacity/Index", props: {
+        render_page "Escalated/Admin/Capacity/Index", {
           capacities: capacities.map { |c| capacity_json(c) }
         }
       end

--- a/app/controllers/escalated/admin/custom_fields_controller.rb
+++ b/app/controllers/escalated/admin/custom_fields_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         fields = Escalated::CustomField.ordered
 
-        render inertia: "Escalated/Admin/CustomFields/Index", props: {
+        render_page "Escalated/Admin/CustomFields/Index", {
           fields: fields.map { |f| field_json(f) }
         }
       end

--- a/app/controllers/escalated/admin/custom_objects_controller.rb
+++ b/app/controllers/escalated/admin/custom_objects_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         definitions = Escalated::CustomObject.ordered
 
-        render inertia: "Escalated/Admin/CustomObjects/Index", props: {
+        render_page "Escalated/Admin/CustomObjects/Index", {
           objects: definitions.map { |o| object_json(o) }
         }
       end

--- a/app/controllers/escalated/admin/departments_controller.rb
+++ b/app/controllers/escalated/admin/departments_controller.rb
@@ -7,13 +7,13 @@ module Escalated
       def index
         departments = Escalated::Department.ordered
 
-        render inertia: "Escalated/Admin/Departments/Index", props: {
+        render_page "Escalated/Admin/Departments/Index", {
           departments: departments.map { |d| department_json(d) }
         }
       end
 
       def new
-        render inertia: "Escalated/Admin/Departments/Form", props: {
+        render_page "Escalated/Admin/Departments/Form", {
           department: nil,
           sla_policies: Escalated::SlaPolicy.active.ordered.map { |p| { id: p.id, name: p.name } },
           agents: agent_list
@@ -33,7 +33,7 @@ module Escalated
       end
 
       def show
-        render inertia: "Escalated/Admin/Departments/Show", props: {
+        render_page "Escalated/Admin/Departments/Show", {
           department: department_json(@department),
           agents: @department.agents.map { |a|
             { id: a.id, name: a.respond_to?(:name) ? a.name : a.email, email: a.email }
@@ -47,7 +47,7 @@ module Escalated
       end
 
       def edit
-        render inertia: "Escalated/Admin/Departments/Form", props: {
+        render_page "Escalated/Admin/Departments/Form", {
           department: department_json(@department),
           sla_policies: Escalated::SlaPolicy.active.ordered.map { |p| { id: p.id, name: p.name } },
           agents: agent_list,

--- a/app/controllers/escalated/admin/escalation_rules_controller.rb
+++ b/app/controllers/escalated/admin/escalation_rules_controller.rb
@@ -7,13 +7,13 @@ module Escalated
       def index
         rules = Escalated::EscalationRule.ordered
 
-        render inertia: "Escalated/Admin/EscalationRules/Index", props: {
+        render_page "Escalated/Admin/EscalationRules/Index", {
           escalation_rules: rules.map { |r| rule_json(r) }
         }
       end
 
       def new
-        render inertia: "Escalated/Admin/EscalationRules/Form", props: {
+        render_page "Escalated/Admin/EscalationRules/Form", {
           escalation_rule: nil,
           departments: Escalated::Department.active.ordered.map { |d| { id: d.id, name: d.name } },
           agents: agent_list,
@@ -34,13 +34,13 @@ module Escalated
       end
 
       def show
-        render inertia: "Escalated/Admin/EscalationRules/Show", props: {
+        render_page "Escalated/Admin/EscalationRules/Show", {
           escalation_rule: rule_json(@rule)
         }
       end
 
       def edit
-        render inertia: "Escalated/Admin/EscalationRules/Form", props: {
+        render_page "Escalated/Admin/EscalationRules/Form", {
           escalation_rule: rule_json(@rule),
           departments: Escalated::Department.active.ordered.map { |d| { id: d.id, name: d.name } },
           agents: agent_list,

--- a/app/controllers/escalated/admin/imports_controller.rb
+++ b/app/controllers/escalated/admin/imports_controller.rb
@@ -10,7 +10,7 @@ module Escalated
           .order(created_at: :desc)
           .limit(100)
 
-        render inertia: "Escalated/Admin/Imports/Index", props: {
+        render_page "Escalated/Admin/Imports/Index", {
           jobs:     jobs.map { |j| job_json(j) },
           adapters: import_service.available_adapters.map { |a| adapter_json(a) },
         }
@@ -18,7 +18,7 @@ module Escalated
 
       # GET /admin/imports/:id
       def show
-        render inertia: "Escalated/Admin/Imports/Show", props: {
+        render_page "Escalated/Admin/Imports/Show", {
           job:      job_json(@job),
           adapters: import_service.available_adapters.map { |a| adapter_json(a) },
         }

--- a/app/controllers/escalated/admin/kb_categories_controller.rb
+++ b/app/controllers/escalated/admin/kb_categories_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         categories = Escalated::ArticleCategory.ordered
 
-        render inertia: "Escalated/Admin/KbCategories/Index", props: {
+        render_page "Escalated/Admin/KbCategories/Index", {
           categories: categories.map { |c| category_json(c) }
         }
       end

--- a/app/controllers/escalated/admin/macros_controller.rb
+++ b/app/controllers/escalated/admin/macros_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         macros = Escalated::Macro.ordered
 
-        render inertia: "Escalated/Admin/Macros/Index", props: {
+        render_page "Escalated/Admin/Macros/Index", {
           macros: macros.map { |m| macro_json(m) }
         }
       end

--- a/app/controllers/escalated/admin/plugins_controller.rb
+++ b/app/controllers/escalated/admin/plugins_controller.rb
@@ -6,7 +6,7 @@ module Escalated
       def index
         plugins = Escalated::Services::PluginService.all_plugins
 
-        render inertia: "Escalated/Admin/Plugins/Index", props: {
+        render_page "Escalated/Admin/Plugins/Index", {
           plugins: plugins.map { |p| plugin_json(p) }
         }
       end

--- a/app/controllers/escalated/admin/reports_controller.rb
+++ b/app/controllers/escalated/admin/reports_controller.rb
@@ -42,7 +42,7 @@ module Escalated
           csat: calculate_csat_stats(period_start, period_end)
         }
 
-        render inertia: "Escalated/Admin/Reports/Index", props: {
+        render_page "Escalated/Admin/Reports/Index", {
           stats: stats,
           filters: {
             from: period_start.iso8601,
@@ -55,7 +55,7 @@ module Escalated
         today = Time.current.beginning_of_day..Time.current.end_of_day
         this_week = 1.week.ago.beginning_of_day..Time.current.end_of_day
 
-        render inertia: "Escalated/Admin/Reports/Dashboard", props: {
+        render_page "Escalated/Admin/Reports/Dashboard", {
           today: {
             created: Escalated::Ticket.where(created_at: today).count,
             resolved: Escalated::Ticket.where(resolved_at: today).count,

--- a/app/controllers/escalated/admin/roles_controller.rb
+++ b/app/controllers/escalated/admin/roles_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         roles = Escalated::Role.includes(:permissions).ordered
 
-        render inertia: "Escalated/Admin/Roles/Index", props: {
+        render_page "Escalated/Admin/Roles/Index", {
           roles: roles.map { |r| role_json(r) },
           permissions: Escalated::Permission.ordered.map { |p| permission_json(p) }
         }

--- a/app/controllers/escalated/admin/settings_controller.rb
+++ b/app/controllers/escalated/admin/settings_controller.rb
@@ -11,20 +11,20 @@ module Escalated
           settings[key] = mask_secret(settings[key]) if settings.key?(key)
         end
 
-        render inertia: "Escalated/Admin/Settings", props: {
+        render_page "Escalated/Admin/Settings", {
           settings: settings
         }
       end
 
       def two_factor
-        render inertia: "Escalated/Admin/Settings/TwoFactor", props: {
+        render_page "Escalated/Admin/Settings/TwoFactor", {
           two_factor_required: Escalated::EscalatedSetting.get("two_factor_required") == "1",
           two_factor_grace_period_hours: Escalated::EscalatedSetting.get("two_factor_grace_period_hours").to_i
         }
       end
 
       def two_factor_setup
-        render inertia: "Escalated/Admin/Settings/TwoFactorSetup", props: {
+        render_page "Escalated/Admin/Settings/TwoFactorSetup", {
           otp_secret: ROTP::Base32.random,
           user_email: escalated_current_user.email
         }
@@ -54,7 +54,7 @@ module Escalated
       end
 
       def sso
-        render inertia: "Escalated/Admin/Settings/Sso", props: {
+        render_page "Escalated/Admin/Settings/Sso", {
           sso_enabled: Escalated::EscalatedSetting.get("sso_enabled") == "1",
           sso_provider: Escalated::EscalatedSetting.get("sso_provider"),
           sso_metadata_url: Escalated::EscalatedSetting.get("sso_metadata_url"),
@@ -77,7 +77,7 @@ module Escalated
       end
 
       def csat
-        render inertia: "Escalated/Admin/Settings/Csat", props: {
+        render_page "Escalated/Admin/Settings/Csat", {
           csat_enabled: Escalated::EscalatedSetting.get("csat_enabled") == "1",
           csat_send_after_hours: Escalated::EscalatedSetting.get("csat_send_after_hours").to_i,
           csat_message: Escalated::EscalatedSetting.get("csat_message")

--- a/app/controllers/escalated/admin/skills_controller.rb
+++ b/app/controllers/escalated/admin/skills_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         skills = Escalated::Skill.ordered
 
-        render inertia: "Escalated/Admin/Skills/Index", props: {
+        render_page "Escalated/Admin/Skills/Index", {
           skills: skills.map { |s| skill_json(s) }
         }
       end

--- a/app/controllers/escalated/admin/sla_policies_controller.rb
+++ b/app/controllers/escalated/admin/sla_policies_controller.rb
@@ -7,13 +7,13 @@ module Escalated
       def index
         policies = Escalated::SlaPolicy.ordered
 
-        render inertia: "Escalated/Admin/SlaPolicies/Index", props: {
+        render_page "Escalated/Admin/SlaPolicies/Index", {
           sla_policies: policies.map { |p| sla_policy_json(p) }
         }
       end
 
       def new
-        render inertia: "Escalated/Admin/SlaPolicies/Form", props: {
+        render_page "Escalated/Admin/SlaPolicies/Form", {
           sla_policy: nil,
           priorities: Escalated::Ticket.priorities.keys
         }
@@ -31,7 +31,7 @@ module Escalated
       end
 
       def show
-        render inertia: "Escalated/Admin/SlaPolicies/Show", props: {
+        render_page "Escalated/Admin/SlaPolicies/Show", {
           sla_policy: sla_policy_json(@sla_policy),
           targets: @sla_policy.priority_targets,
           department_count: @sla_policy.departments.count,
@@ -40,7 +40,7 @@ module Escalated
       end
 
       def edit
-        render inertia: "Escalated/Admin/SlaPolicies/Form", props: {
+        render_page "Escalated/Admin/SlaPolicies/Form", {
           sla_policy: sla_policy_json(@sla_policy),
           priorities: Escalated::Ticket.priorities.keys
         }

--- a/app/controllers/escalated/admin/statuses_controller.rb
+++ b/app/controllers/escalated/admin/statuses_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         statuses = Escalated::TicketStatus.ordered
 
-        render inertia: "Escalated/Admin/Statuses/Index", props: {
+        render_page "Escalated/Admin/Statuses/Index", {
           statuses: statuses.map { |s| status_json(s) },
           categories: Escalated::TicketStatus.categories.keys
         }

--- a/app/controllers/escalated/admin/tags_controller.rb
+++ b/app/controllers/escalated/admin/tags_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         tags = Escalated::Tag.ordered
 
-        render inertia: "Escalated/Admin/Tags/Index", props: {
+        render_page "Escalated/Admin/Tags/Index", {
           tags: tags.map { |t| tag_json(t) }
         }
       end

--- a/app/controllers/escalated/admin/tickets_controller.rb
+++ b/app/controllers/escalated/admin/tickets_controller.rb
@@ -27,7 +27,7 @@ module Escalated
 
         result = paginate(scope)
 
-        render inertia: "Escalated/Admin/Tickets/Index", props: {
+        render_page "Escalated/Admin/Tickets/Index", {
           tickets: result[:data].includes(:requester, :department, :assignee, :tags).map { |t| ticket_list_json(t) },
           meta: result[:meta],
           filters: {
@@ -54,7 +54,7 @@ module Escalated
         replies = @ticket.replies.chronological.includes(:author, :attachments)
         activities = @ticket.activities.reverse_chronological.limit(50)
 
-        render inertia: "Escalated/Admin/Tickets/Show", props: {
+        render_page "Escalated/Admin/Tickets/Show", {
           ticket: ticket_detail_json(@ticket),
           replies: replies.map { |r| reply_json(r) },
           activities: activities.map { |a| activity_json(a) },

--- a/app/controllers/escalated/admin/webhooks_controller.rb
+++ b/app/controllers/escalated/admin/webhooks_controller.rb
@@ -7,7 +7,7 @@ module Escalated
       def index
         webhooks = Escalated::Webhook.ordered
 
-        render inertia: "Escalated/Admin/Webhooks/Index", props: {
+        render_page "Escalated/Admin/Webhooks/Index", {
           webhooks: webhooks.map { |w| webhook_json(w) }
         }
       end
@@ -40,7 +40,7 @@ module Escalated
       def deliveries
         result = paginate(@webhook.deliveries.recent)
 
-        render inertia: "Escalated/Admin/Webhooks/Deliveries", props: {
+        render_page "Escalated/Admin/Webhooks/Deliveries", {
           webhook: webhook_json(@webhook),
           deliveries: result[:data].map { |d| delivery_json(d) },
           meta: result[:meta]

--- a/app/controllers/escalated/agent/dashboard_controller.rb
+++ b/app/controllers/escalated/agent/dashboard_controller.rb
@@ -31,7 +31,7 @@ module Escalated
         unassigned_tickets = all_open.unassigned.recent.limit(10)
         breached_tickets = all_open.breached_sla.recent.limit(10)
 
-        render inertia: "Escalated/Agent/Dashboard", props: {
+        render_page "Escalated/Agent/Dashboard", {
           stats: stats,
           recent_tickets: recent_tickets.map { |t| ticket_summary_json(t) },
           unassigned_tickets: unassigned_tickets.map { |t| ticket_summary_json(t) },

--- a/app/controllers/escalated/agent/tickets_controller.rb
+++ b/app/controllers/escalated/agent/tickets_controller.rb
@@ -27,7 +27,7 @@ module Escalated
 
         result = paginate(scope)
 
-        render inertia: "Escalated/Agent/TicketIndex", props: {
+        render_page "Escalated/Agent/TicketIndex", {
           tickets: result[:data].includes(:requester, :department, :assignee, :tags).map { |t| ticket_list_json(t) },
           meta: result[:meta],
           filters: {
@@ -56,7 +56,7 @@ module Escalated
         replies = @ticket.replies.chronological.includes(:author, :attachments)
         activities = @ticket.activities.reverse_chronological.limit(50)
 
-        render inertia: "Escalated/Agent/TicketShow", props: {
+        render_page "Escalated/Agent/TicketShow", {
           ticket: ticket_detail_json(@ticket),
           replies: replies.map { |r| reply_json(r) },
           activities: activities.map { |a| activity_json(a) },

--- a/app/controllers/escalated/application_controller.rb
+++ b/app/controllers/escalated/application_controller.rb
@@ -1,11 +1,12 @@
 module Escalated
   class ApplicationController < ActionController::Base
     include Pundit::Authorization
+    include Escalated::Renderable
 
     protect_from_forgery with: :exception
 
     before_action :apply_middleware
-    before_action :set_inertia_shared_data
+    before_action :set_inertia_shared_data, if: -> { Escalated.configuration.ui_enabled? }
 
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
@@ -78,14 +79,14 @@ module Escalated
     end
 
     def user_not_authorized
-      render inertia: "Escalated/Error", props: {
+      render_page "Escalated/Error", {
         status: 403,
         message: I18n.t('escalated.middleware.not_authorized')
       }, status: :forbidden
     end
 
     def not_found
-      render inertia: "Escalated/Error", props: {
+      render_page "Escalated/Error", {
         status: 404,
         message: I18n.t('escalated.middleware.not_found')
       }, status: :not_found

--- a/app/controllers/escalated/customer/tickets_controller.rb
+++ b/app/controllers/escalated/customer/tickets_controller.rb
@@ -13,7 +13,7 @@ module Escalated
 
         result = paginate(scope)
 
-        render inertia: "Escalated/Customer/Index", props: {
+        render_page "Escalated/Customer/Index", {
           tickets: result[:data].map { |t| ticket_json(t) },
           meta: result[:meta],
           filters: {
@@ -24,7 +24,7 @@ module Escalated
       end
 
       def create
-        render inertia: "Escalated/Customer/Create", props: {
+        render_page "Escalated/Customer/Create", {
           departments: Escalated::Department.active.ordered.map { |d|
             { id: d.id, name: d.name }
           },
@@ -62,7 +62,7 @@ module Escalated
           .chronological
           .includes(:author, :attachments)
 
-        render inertia: "Escalated/Customer/Show", props: {
+        render_page "Escalated/Customer/Show", {
           ticket: ticket_json(@ticket),
           replies: replies.map { |r| reply_json(r) },
           can_close: Escalated.configuration.allow_customer_close && @ticket.open?,

--- a/app/controllers/escalated/guest/tickets_controller.rb
+++ b/app/controllers/escalated/guest/tickets_controller.rb
@@ -1,14 +1,16 @@
 module Escalated
   module Guest
     class TicketsController < ActionController::Base
+      include Escalated::Renderable
+
       protect_from_forgery with: :exception
 
       before_action :ensure_guest_tickets_enabled
       before_action :set_ticket_by_token, only: [:show, :reply, :rate]
-      before_action :set_inertia_shared_data
+      before_action :set_inertia_shared_data, if: -> { Escalated.configuration.ui_enabled? }
 
       def create
-        render inertia: "Escalated/Guest/Create", props: {
+        render_page "Escalated/Guest/Create", {
           departments: Escalated::Department.active.ordered.map { |d|
             { id: d.id, name: d.name }
           },
@@ -20,7 +22,7 @@ module Escalated
       def store
         errors = validate_guest_params
         if errors.any?
-          render inertia: "Escalated/Guest/Create", props: {
+          render_page "Escalated/Guest/Create", {
             errors: errors,
             old: guest_ticket_params.to_h,
             departments: Escalated::Department.active.ordered.map { |d|
@@ -62,7 +64,7 @@ module Escalated
           .order(created_at: :asc)
           .includes(:author, :attachments)
 
-        render inertia: "Escalated/Guest/Show", props: {
+        render_page "Escalated/Guest/Show", {
           ticket: guest_ticket_json(@ticket),
           replies: replies.map { |r| guest_reply_json(r) },
           token: params[:token],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,25 @@
 Escalated::Engine.routes.draw do
+  # ── Core routes (always registered) ──────────────────────────────────
+  # These work without the Inertia UI: inbound email webhooks and
+  # SDK plugin endpoints/webhooks (registered dynamically at boot by
+  # Escalated::Bridge::RouteRegistrar).
+
+  # Inbound email webhook (no authentication -- verified by adapter)
+  post "inbound/:adapter", to: "inbound#webhook", as: :inbound_webhook
+
+  # SDK plugin routes are registered dynamically at boot time by
+  # Escalated::Bridge::RouteRegistrar based on each plugin's manifest.
+  # They appear as:
+  #   GET/POST /support/plugins/:plugin/api/:path   → plugins/endpoints#handle
+  #   POST     /support/plugins/:plugin/webhooks/:path → plugins/webhooks#handle
+
+  # ── UI routes (only when ui_enabled is true) ─────────────────────────
+  # Agent, admin, customer, and guest routes depend on Inertia and the
+  # configured UI renderer.  Skipped when the host app sets
+  # Escalated.configuration.ui_enabled = false.
+
+  return unless Escalated.configuration.ui_enabled?
+
   # Customer-facing routes
   namespace :customer do
     resources :tickets, only: [:index, :create, :show] do
@@ -155,15 +176,6 @@ Escalated::Engine.routes.draw do
     post ":token/rate", to: "tickets#rate", as: :ticket_rate
   end
 
-  # Inbound email webhook (no authentication -- verified by adapter)
-  post "inbound/:adapter", to: "inbound#webhook", as: :inbound_webhook
-
   # Root redirect to customer tickets
   root to: "customer/tickets#index"
-
-  # SDK plugin routes are registered dynamically at boot time by
-  # Escalated::Bridge::RouteRegistrar based on each plugin's manifest.
-  # They appear as:
-  #   GET/POST /support/plugins/:plugin/api/:path   → plugins/endpoints#handle
-  #   POST     /support/plugins/:plugin/webhooks/:path → plugins/webhooks#handle
 end

--- a/lib/escalated.rb
+++ b/lib/escalated.rb
@@ -8,6 +8,7 @@ require "escalated/services/hook_registry"
 require "escalated/services/plugin_service"
 require "escalated/services/plugin_ui_service"
 require "escalated/services/import_service"
+require "escalated/ui_renderer"
 require "escalated/bridge/json_rpc_client"
 require "escalated/bridge/context_handler"
 require "escalated/bridge/route_registrar"
@@ -28,6 +29,22 @@ module Escalated
     def driver
       Manager.driver
     end
+
+    # Global UI renderer instance.
+    #
+    # Defaults to InertiaRenderer when ui_enabled is true.
+    # Raises RuntimeError when UI is disabled and no custom renderer is set.
+    #
+    # @return [Escalated::UiRenderer::Base]
+    def ui_renderer
+      @ui_renderer ||= if configuration.ui_enabled?
+                          UiRenderer::InertiaRenderer.new
+                        else
+                          raise "Escalated UI is disabled. Set ui_enabled=true or assign a custom Escalated.ui_renderer."
+                        end
+    end
+
+    attr_writer :ui_renderer
 
     def table_name(name)
       "#{configuration.table_prefix}#{name}"
@@ -76,6 +93,7 @@ module Escalated
       @hooks         = Support::HookManager.new
       @plugin_ui     = Services::PluginUIService.new
       @plugin_bridge = Bridge::PluginBridge.new
+      @ui_renderer   = nil
     end
   end
 end

--- a/lib/escalated/configuration.rb
+++ b/lib/escalated/configuration.rb
@@ -42,6 +42,8 @@ module Escalated
                   :imap_username,
                   :imap_password,
                   :imap_mailbox,
+                  # UI settings
+                  :ui_enabled,
                   # REST API settings
                   :api_enabled,
                   :api_rate_limit,
@@ -100,6 +102,9 @@ module Escalated
       @imap_password = nil
       @imap_mailbox = "INBOX"
 
+      # UI defaults
+      @ui_enabled = true
+
       # REST API defaults
       @api_enabled = false
       @api_rate_limit = 60
@@ -129,6 +134,10 @@ module Escalated
 
     def business_hours
       sla[:business_hours] || {}
+    end
+
+    def ui_enabled?
+      ui_enabled == true
     end
 
     def plugins_enabled?

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -11,6 +11,8 @@ module Escalated
     end
 
     initializer "escalated.assets" do |app|
+      next unless Escalated.configuration.ui_enabled?
+
       # Make engine assets available to host app
       app.config.assets.precompile += %w[escalated_manifest.js] if app.config.respond_to?(:assets)
     end
@@ -69,6 +71,8 @@ module Escalated
     end
 
     initializer "escalated.inertia" do
+      next unless Escalated.configuration.ui_enabled?
+
       ActiveSupport.on_load(:action_controller) do
         # Configure Inertia shared data at engine level
       end

--- a/lib/escalated/ui_renderer.rb
+++ b/lib/escalated/ui_renderer.rb
@@ -1,0 +1,30 @@
+module Escalated
+  # Abstract base for rendering UI pages.
+  #
+  # The default implementation delegates to Inertia (via InertiaRenderer).
+  # Host apps that disable the built-in Inertia UI can provide their own
+  # renderer by assigning a custom object to Escalated.ui_renderer.
+  #
+  # Any renderer must respond to #render_page(controller, page, props, status:).
+  module UiRenderer
+    class Base
+      # Render a named page with the given props.
+      #
+      # @param controller [ActionController::Base] the current controller instance
+      # @param page       [String]  page/component identifier (e.g. "Escalated/Agent/Dashboard")
+      # @param props      [Hash]    data to pass to the page
+      # @param status     [Symbol]  HTTP status (default :ok)
+      # @return [void]
+      def render_page(controller, page, props = {}, status: :ok)
+        raise NotImplementedError, "#{self.class}#render_page must be implemented"
+      end
+    end
+
+    # Default renderer that delegates to the inertia-rails gem.
+    class InertiaRenderer < Base
+      def render_page(controller, page, props = {}, status: :ok)
+        controller.render inertia: page, props: props, status: status
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Add \`ui_enabled\` config option** in \`Escalated::Configuration\` (defaults to \`true\`), matching the \`ui.enabled\` option in the Laravel package
- **Split route registration** in \`config/routes.rb\`: core routes (inbound email webhooks, SDK plugin endpoints) always register; UI routes (agent, admin, customer, guest) are guarded behind \`ui_enabled?\`
- **Create \`Escalated::UiRenderer\` abstraction** with a \`Base\` class and \`InertiaRenderer\` implementation, equivalent to Laravel's \`EscalatedUiRenderer\` contract and \`InertiaUiRenderer\`
- **Add \`Escalated::Renderable\` concern** that provides \`render_page\` to controllers, replacing direct \`render inertia:\` calls across all 29 controllers
- **Guard Inertia middleware** — the \`set_inertia_shared_data\` before_action in \`ApplicationController\` and \`Guest::TicketsController\` is skipped when UI is disabled; the Inertia and assets engine initializers are also guarded

This enables API-only / headless deployments by setting \`config.ui_enabled = false\` in the initializer.

## Test plan

- [ ] Verify default behavior unchanged: \`ui_enabled\` defaults to \`true\`, all routes register, Inertia renders as before
- [ ] Set \`config.ui_enabled = false\` and confirm only inbound webhook and plugin routes are registered
- [ ] Confirm \`Escalated.ui_renderer\` raises when UI is disabled and no custom renderer is assigned
- [ ] Verify a custom renderer can be injected via \`Escalated.ui_renderer = MyRenderer.new\`
- [ ] Confirm shared Inertia data callback is skipped when UI is disabled