### PR TITLE
ci: add linting to CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    name: RuboCop
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run RuboCop
+        run: bundle exec rubocop --format github

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,25 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - "vendor/**/*"
+    - "spec/dummy/**/*"
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+    - "*.gemspec"
+
+Layout/LineLength:
+  Max: 120


### PR DESCRIPTION
## Summary
- Create `.rubocop.yml` with relaxed defaults (disabled docs, frozen string literal, 120 char lines)
- Create `lint.yml` workflow that runs RuboCop with `--format github` on PRs to main
- RuboCop + rubocop-rails + rubocop-rspec were already in the Gemfile

## Test plan
- [ ] Verify the lint workflow runs on PRs to main
- [ ] Verify RuboCop catches violations and fails the build
- [ ] Verify existing test workflow is unaffected