### PR TITLE
feat: add ticket splitting

### DIFF
--- a/app/controllers/escalated/admin/tickets_controller.rb
+++ b/app/controllers/escalated/admin/tickets_controller.rb
@@ -5,7 +5,8 @@ module Escalated
     class TicketsController < Escalated::ApplicationController
       before_action :require_admin!
       before_action :set_ticket,
-                    only: %i[show reply note assign status priority tags department apply_macro follow presence pin]
+                    only: %i[show reply note assign status priority tags department apply_macro follow presence pin
+                             split]
 
       def index
         scope = Escalated::Ticket.all.recent
@@ -196,6 +197,14 @@ module Escalated
         end
 
         render json: { viewers: viewers }
+      end
+
+      def split
+        reply = @ticket.replies.find(params[:reply_id])
+        new_ticket = Services::TicketService.split(@ticket, reply, actor: escalated_current_user)
+
+        redirect_to admin_ticket_path(new_ticket),
+                    notice: I18n.t('escalated.ticket.split_created', reference: new_ticket.reference)
       end
 
       def pin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Escalated::Engine.routes.draw do
         post :store_side_conversation, to: 'side_conversations#store'
         post 'side_conversations/:conversation_id/reply', to: 'side_conversations#reply', as: :side_conversation_reply
         post 'side_conversations/:conversation_id/close', to: 'side_conversations#close', as: :side_conversation_close
+        post 'replies/:reply_id/split', action: :split, as: :split_reply
       end
     end
     resources :articles, only: %i[index create update destroy]

--- a/lib/escalated/services/ticket_service.rb
+++ b/lib/escalated/services/ticket_service.rb
@@ -92,6 +92,51 @@ module Escalated
           result
         end
 
+        def split(ticket, reply, actor:)
+          new_ticket = nil
+
+          ActiveRecord::Base.transaction do
+            new_ticket = driver.create_ticket(
+              subject: "Split from #{ticket.reference}: #{reply.body.truncate(80)}",
+              description: reply.body,
+              requester: ticket.requester,
+              priority: ticket.priority,
+              department_id: ticket.department_id,
+              tag_ids: ticket.tag_ids,
+              metadata: (ticket.metadata || {}).merge('split_from' => ticket.reference)
+            )
+
+            # Link the new ticket to the original
+            Escalated::TicketLink.create!(
+              parent_ticket: ticket,
+              child_ticket: new_ticket,
+              link_type: 'parent_child'
+            )
+
+            # System note on original ticket
+            Escalated::Reply.create!(
+              ticket: ticket,
+              body: "Reply was split into new ticket #{new_ticket.reference}.",
+              is_internal: true,
+              is_system: true,
+              is_pinned: false
+            )
+
+            # System note on new ticket
+            Escalated::Reply.create!(
+              ticket: new_ticket,
+              body: "This ticket was split from #{ticket.reference}.",
+              is_internal: true,
+              is_system: true,
+              is_pinned: false
+            )
+          end
+
+          Services::NotificationService.dispatch(:ticket_created, ticket: new_ticket)
+
+          new_ticket
+        end
+
         def close(ticket, actor:)
           transition_status(ticket, :closed, actor: actor)
         end

--- a/spec/services/escalated/ticket_split_service_spec.rb
+++ b/spec/services/escalated/ticket_split_service_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Services::TicketService, '.split' do
+  let(:user) { create(:user) }
+  let(:agent) { create(:user, :agent) }
+  let(:department) { create(:escalated_department) }
+  let(:tag1) { create(:escalated_tag) }
+  let(:tag2) { create(:escalated_tag) }
+
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+  end
+
+  let(:ticket) do
+    t = create(:escalated_ticket, :with_department, priority: :high, requester: user, department: department)
+    t.tags << tag1
+    t.tags << tag2
+    t
+  end
+
+  let(:reply) do
+    create(:escalated_reply, ticket: ticket, author: user, body: 'I have a separate issue with billing.')
+  end
+
+  describe '.split' do
+    it 'creates a new ticket from the reply' do
+      expect { described_class.split(ticket, reply, actor: agent) }
+        .to change(Escalated::Ticket, :count).by(1)
+    end
+
+    it 'returns the new ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket).to be_a(Escalated::Ticket)
+      expect(new_ticket).to be_persisted
+    end
+
+    it 'sets the description from the reply body' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.description).to eq(reply.body)
+    end
+
+    it 'copies the requester from the original ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.requester).to eq(user)
+    end
+
+    it 'copies the priority from the original ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.priority).to eq('high')
+    end
+
+    it 'copies the department from the original ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.department_id).to eq(department.id)
+    end
+
+    it 'copies tags from the original ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.tags).to include(tag1, tag2)
+    end
+
+    it 'creates a parent_child link between the tickets' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      link = Escalated::TicketLink.find_by(parent_ticket: ticket, child_ticket: new_ticket)
+      expect(link).to be_present
+      expect(link.link_type).to eq('parent_child')
+    end
+
+    it 'adds a system note to the original ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      system_note = ticket.replies.where(is_system: true).last
+      expect(system_note.body).to include(new_ticket.reference)
+      expect(system_note.body).to include('split into')
+    end
+
+    it 'adds a system note to the new ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      system_note = new_ticket.replies.where(is_system: true).last
+      expect(system_note.body).to include(ticket.reference)
+      expect(system_note.body).to include('split from')
+    end
+
+    it 'stores split_from in metadata' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.metadata['split_from']).to eq(ticket.reference)
+    end
+
+    it 'generates a unique reference for the new ticket' do
+      new_ticket = described_class.split(ticket, reply, actor: agent)
+      expect(new_ticket.reference).to be_present
+      expect(new_ticket.reference).not_to eq(ticket.reference)
+    end
+  end
+end

--- a/spec/services/escalated/ticket_split_service_spec.rb
+++ b/spec/services/escalated/ticket_split_service_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 
 RSpec.describe Escalated::Services::TicketService, '.split' do
   let(:user) { create(:user) }
+  let(:ticket) do
+    t = create(:escalated_ticket, :with_department, priority: :high, requester: user, department: department)
+    t.tags << tag1
+    t.tags << tag2
+    t
+  end
+  let(:reply) do
+    create(:escalated_reply, ticket: ticket, author: user, body: 'I have a separate issue with billing.')
+  end
   let(:agent) { create(:user, :agent) }
   let(:department) { create(:escalated_department) }
   let(:tag1) { create(:escalated_tag) }
@@ -13,16 +22,7 @@ RSpec.describe Escalated::Services::TicketService, '.split' do
     allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
   end
 
-  let(:ticket) do
-    t = create(:escalated_ticket, :with_department, priority: :high, requester: user, department: department)
-    t.tags << tag1
-    t.tags << tag2
-    t
-  end
 
-  let(:reply) do
-    create(:escalated_reply, ticket: ticket, author: user, body: 'I have a separate issue with billing.')
-  end
 
   describe '.split' do
     it 'creates a new ticket from the reply' do

--- a/spec/services/escalated/ticket_split_service_spec.rb
+++ b/spec/services/escalated/ticket_split_service_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe Escalated::Services::TicketService, '.split' do
     allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
   end
 
-
-
   describe '.split' do
     it 'creates a new ticket from the reply' do
       expect { described_class.split(ticket, reply, actor: agent) }


### PR DESCRIPTION
## Summary
- Add `split` method to `TicketService` that creates a new ticket from a reply
- Copies metadata (requester, department, tags, priority) and stores `split_from` in metadata
- Links tickets via `TicketLink` with `parent_child` relationship
- Adds system notes to both original and new ticket
- Controller action: `POST /tickets/:id/replies/:reply_id/split`
- RSpec tests covering all split behavior

## Test plan
- [ ] Verify splitting a reply creates a new ticket with correct metadata
- [ ] Verify parent_child link is created between tickets
- [ ] Verify system notes are added to both tickets
- [ ] Verify tags and department are copied