### PR TITLE
feat: add ticket snooze/schedule

### DIFF
--- a/app/controllers/escalated/admin/tickets_controller.rb
+++ b/app/controllers/escalated/admin/tickets_controller.rb
@@ -5,10 +5,18 @@ module Escalated
     class TicketsController < Escalated::ApplicationController
       before_action :require_admin!
       before_action :set_ticket,
-                    only: %i[show reply note assign status priority tags department apply_macro follow presence pin]
+                    only: %i[show reply note assign status priority tags department apply_macro follow presence pin
+                             snooze unsnooze]
 
       def index
         scope = Escalated::Ticket.all.recent
+
+        # Exclude snoozed tickets by default unless explicitly requested
+        scope = if params[:snoozed] == 'true'
+                  scope.snoozed
+                else
+                  scope.not_snoozed
+                end
 
         scope = scope.where(status: params[:status]) if params[:status].present?
         scope = scope.where(priority: params[:priority]) if params[:priority].present?
@@ -196,6 +204,17 @@ module Escalated
         end
 
         render json: { viewers: viewers }
+      end
+
+      def snooze
+        until_time = Time.zone.parse(params[:snoozed_until])
+        Services::TicketService.snooze_ticket(@ticket, until_time, actor: escalated_current_user)
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.snoozed')
+      end
+
+      def unsnooze
+        Services::TicketService.unsnooze_ticket(@ticket)
+        redirect_to admin_ticket_path(@ticket), notice: I18n.t('escalated.ticket.unsnoozed')
       end
 
       def pin

--- a/app/controllers/escalated/admin/tickets_controller.rb
+++ b/app/controllers/escalated/admin/tickets_controller.rb
@@ -27,18 +27,7 @@ module Escalated
         scope = scope.breached_sla if params[:sla_breached] == 'true'
         scope = scope.search(params[:search]) if params[:search].present?
 
-        # Following filter
-        if params[:following] == 'true'
-          followers_table = Escalated.table_name('ticket_followers')
-          tickets_table = Escalated.table_name('tickets')
-          join_sql = "INNER JOIN #{followers_table} " \
-                     "ON #{followers_table}.ticket_id = #{tickets_table}.id"
-          followed_ticket_ids = Escalated::Ticket
-                                .joins(join_sql)
-                                .where("#{followers_table}.user_id = ?", escalated_current_user.id)
-                                .pluck(:id)
-          scope = scope.where(id: followed_ticket_ids)
-        end
+        scope = filter_by_following(scope)
 
         result = paginate(scope)
 
@@ -236,6 +225,20 @@ module Escalated
       end
 
       private
+
+      def filter_by_following(scope)
+        return scope unless params[:following] == 'true'
+
+        followers_table = Escalated.table_name('ticket_followers')
+        tickets_table = Escalated.table_name('tickets')
+        join_sql = "INNER JOIN #{followers_table} " \
+                   "ON #{followers_table}.ticket_id = #{tickets_table}.id"
+        followed_ticket_ids = Escalated::Ticket
+                              .joins(join_sql)
+                              .where("#{followers_table}.user_id = ?", escalated_current_user.id)
+                              .pluck(:id)
+        scope.where(id: followed_ticket_ids)
+      end
 
       def set_ticket
         @ticket = Escalated::Ticket.find_by!(reference: params[:id])

--- a/app/models/escalated/ticket.rb
+++ b/app/models/escalated/ticket.rb
@@ -87,12 +87,19 @@ module Escalated
     scope :by_department, ->(department_id) { where(department_id: department_id) }
     scope :created_between, ->(from, to) { where(created_at: from..to) }
     scope :recent, -> { order(created_at: :desc) }
+    scope :snoozed, -> { where.not(snoozed_until: nil).where('snoozed_until > ?', Time.current) }
+    scope :not_snoozed, -> { where(snoozed_until: nil).or(where('snoozed_until <= ?', Time.current)) }
+    scope :snooze_expired, -> { where.not(snoozed_until: nil).where('snoozed_until <= ?', Time.current) }
 
     def self.generate_reference
       prefix = Escalated::EscalatedSetting.get('ticket_reference_prefix', 'ESC')
       timestamp = Time.current.strftime('%y%m')
       sequence = SecureRandom.alphanumeric(6).upcase
       "#{prefix}-#{timestamp}-#{sequence}"
+    end
+
+    def snoozed?
+      snoozed_until.present? && snoozed_until > Time.current
     end
 
     def open?

--- a/app/models/escalated/ticket.rb
+++ b/app/models/escalated/ticket.rb
@@ -88,8 +88,8 @@ module Escalated
     scope :created_between, ->(from, to) { where(created_at: from..to) }
     scope :recent, -> { order(created_at: :desc) }
     scope :snoozed, -> { where.not(snoozed_until: nil).where('snoozed_until > ?', Time.current) }
-    scope :not_snoozed, -> { where(snoozed_until: nil).or(where('snoozed_until <= ?', Time.current)) }
-    scope :snooze_expired, -> { where.not(snoozed_until: nil).where('snoozed_until <= ?', Time.current) }
+    scope :not_snoozed, -> { where(snoozed_until: nil).or(where(snoozed_until: ..Time.current)) }
+    scope :snooze_expired, -> { where.not(snoozed_until: nil).where(snoozed_until: ..Time.current) }
 
     def self.generate_reference
       prefix = Escalated::EscalatedSetting.get('ticket_reference_prefix', 'ESC')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Escalated::Engine.routes.draw do
         post :department
         post :macro, action: :apply_macro
         post :follow
+        post :snooze
+        post :unsnooze
         post :presence
         post 'replies/:reply_id/pin', action: :pin, as: :reply_pin
       end

--- a/db/migrate/035_add_snooze_fields_to_escalated_tickets.rb
+++ b/db/migrate/035_add_snooze_fields_to_escalated_tickets.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddSnoozeFieldsToEscalatedTickets < ActiveRecord::Migration[7.1]
+  def change
+    add_column Escalated.table_name('tickets'), :snoozed_until, :datetime, null: true
+    add_column Escalated.table_name('tickets'), :snoozed_by, :bigint, null: true
+    add_column Escalated.table_name('tickets'), :status_before_snooze, :integer, null: true
+
+    add_index Escalated.table_name('tickets'), :snoozed_until
+  end
+end

--- a/lib/escalated/services/ticket_service.rb
+++ b/lib/escalated/services/ticket_service.rb
@@ -92,6 +92,36 @@ module Escalated
           result
         end
 
+        def snooze_ticket(ticket, until_time, actor:)
+          ticket.update!(
+            status_before_snooze: Escalated::Ticket.statuses[ticket.status],
+            snoozed_until: until_time,
+            snoozed_by: actor.id
+          )
+
+          Services::NotificationService.dispatch(:ticket_snoozed, ticket: ticket)
+
+          ticket
+        end
+
+        def unsnooze_ticket(ticket)
+          previous_status = ticket.status_before_snooze
+          ticket.update!(
+            snoozed_until: nil,
+            snoozed_by: nil,
+            status_before_snooze: nil
+          )
+
+          if previous_status.present?
+            status_key = Escalated::Ticket.statuses.key(previous_status)
+            ticket.update!(status: status_key) if status_key
+          end
+
+          Services::NotificationService.dispatch(:ticket_unsnoozed, ticket: ticket)
+
+          ticket
+        end
+
         def close(ticket, actor:)
           transition_status(ticket, :closed, actor: actor)
         end

--- a/lib/tasks/escalated_snooze.rake
+++ b/lib/tasks/escalated_snooze.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :escalated do
+  desc 'Wake snoozed tickets whose snooze time has expired'
+  task wake_snoozed_tickets: :environment do
+    tickets = Escalated::Ticket.snooze_expired
+    count = 0
+
+    tickets.find_each do |ticket|
+      Escalated::Services::TicketService.unsnooze_ticket(ticket)
+      count += 1
+    end
+
+    puts "Woke #{count} snoozed ticket(s)"
+  end
+end

--- a/spec/services/escalated/ticket_snooze_spec.rb
+++ b/spec/services/escalated/ticket_snooze_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Escalated::Services::TicketService do
   end
 end
 
-RSpec.describe Escalated::Ticket, 'snooze scopes' do
+RSpec.describe Escalated::Ticket do # snooze scopes
   before do
     allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
   end
@@ -90,7 +90,7 @@ RSpec.describe Escalated::Ticket, 'snooze scopes' do
 
   describe '.snoozed' do
     it 'returns only actively snoozed tickets' do
-      result = Escalated::Ticket.snoozed
+      result = described_class.snoozed
       expect(result).to include(snoozed_ticket)
       expect(result).not_to include(expired_snooze_ticket, normal_ticket)
     end
@@ -98,7 +98,7 @@ RSpec.describe Escalated::Ticket, 'snooze scopes' do
 
   describe '.not_snoozed' do
     it 'returns tickets that are not snoozed' do
-      result = Escalated::Ticket.not_snoozed
+      result = described_class.not_snoozed
       expect(result).to include(expired_snooze_ticket, normal_ticket)
       expect(result).not_to include(snoozed_ticket)
     end
@@ -106,7 +106,7 @@ RSpec.describe Escalated::Ticket, 'snooze scopes' do
 
   describe '.snooze_expired' do
     it 'returns tickets whose snooze has expired' do
-      result = Escalated::Ticket.snooze_expired
+      result = described_class.snooze_expired
       expect(result).to include(expired_snooze_ticket)
       expect(result).not_to include(snoozed_ticket, normal_ticket)
     end

--- a/spec/services/escalated/ticket_snooze_spec.rb
+++ b/spec/services/escalated/ticket_snooze_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Services::TicketService do
+  let(:agent) { create(:user, :agent) }
+
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+  end
+
+  describe '.snooze_ticket' do
+    let(:ticket) { create(:escalated_ticket, status: :in_progress) }
+    let(:snooze_until) { 2.hours.from_now }
+
+    it 'sets snoozed_until on the ticket' do
+      described_class.snooze_ticket(ticket, snooze_until, actor: agent)
+      ticket.reload
+      expect(ticket.snoozed_until).to be_within(1.second).of(snooze_until)
+    end
+
+    it 'records the snoozed_by user' do
+      described_class.snooze_ticket(ticket, snooze_until, actor: agent)
+      ticket.reload
+      expect(ticket.snoozed_by).to eq(agent.id)
+    end
+
+    it 'saves the status before snooze' do
+      described_class.snooze_ticket(ticket, snooze_until, actor: agent)
+      ticket.reload
+      expect(ticket.status_before_snooze).to eq(Escalated::Ticket.statuses['in_progress'])
+    end
+
+    it 'marks the ticket as snoozed' do
+      described_class.snooze_ticket(ticket, snooze_until, actor: agent)
+      ticket.reload
+      expect(ticket.snoozed?).to be true
+    end
+  end
+
+  describe '.unsnooze_ticket' do
+    let(:ticket) do
+      create(:escalated_ticket,
+             status: :in_progress,
+             snoozed_until: 1.hour.from_now,
+             snoozed_by: agent.id,
+             status_before_snooze: Escalated::Ticket.statuses['waiting_on_customer'])
+    end
+
+    it 'clears the snoozed_until field' do
+      described_class.unsnooze_ticket(ticket)
+      ticket.reload
+      expect(ticket.snoozed_until).to be_nil
+    end
+
+    it 'clears the snoozed_by field' do
+      described_class.unsnooze_ticket(ticket)
+      ticket.reload
+      expect(ticket.snoozed_by).to be_nil
+    end
+
+    it 'restores the previous status' do
+      described_class.unsnooze_ticket(ticket)
+      ticket.reload
+      expect(ticket.status).to eq('waiting_on_customer')
+    end
+
+    it 'clears status_before_snooze' do
+      described_class.unsnooze_ticket(ticket)
+      ticket.reload
+      expect(ticket.status_before_snooze).to be_nil
+    end
+
+    it 'marks the ticket as not snoozed' do
+      described_class.unsnooze_ticket(ticket)
+      ticket.reload
+      expect(ticket.snoozed?).to be false
+    end
+  end
+end
+
+RSpec.describe Escalated::Ticket, 'snooze scopes' do
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+  end
+
+  let!(:snoozed_ticket) { create(:escalated_ticket, snoozed_until: 2.hours.from_now) }
+  let!(:expired_snooze_ticket) { create(:escalated_ticket, snoozed_until: 1.hour.ago) }
+  let!(:normal_ticket) { create(:escalated_ticket, snoozed_until: nil) }
+
+  describe '.snoozed' do
+    it 'returns only actively snoozed tickets' do
+      result = Escalated::Ticket.snoozed
+      expect(result).to include(snoozed_ticket)
+      expect(result).not_to include(expired_snooze_ticket, normal_ticket)
+    end
+  end
+
+  describe '.not_snoozed' do
+    it 'returns tickets that are not snoozed' do
+      result = Escalated::Ticket.not_snoozed
+      expect(result).to include(expired_snooze_ticket, normal_ticket)
+      expect(result).not_to include(snoozed_ticket)
+    end
+  end
+
+  describe '.snooze_expired' do
+    it 'returns tickets whose snooze has expired' do
+      result = Escalated::Ticket.snooze_expired
+      expect(result).to include(expired_snooze_ticket)
+      expect(result).not_to include(snoozed_ticket, normal_ticket)
+    end
+  end
+
+  describe '#snoozed?' do
+    it 'returns true for snoozed ticket' do
+      expect(snoozed_ticket.snoozed?).to be true
+    end
+
+    it 'returns false for expired snooze ticket' do
+      expect(expired_snooze_ticket.snoozed?).to be false
+    end
+
+    it 'returns false for normal ticket' do
+      expect(normal_ticket.snoozed?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Migration: adds `snoozed_until`, `snoozed_by`, `status_before_snooze` columns to tickets
- Model: `snoozed`, `not_snoozed`, `snooze_expired` scopes and `snoozed?` method
- Service: `snooze_ticket` and `unsnooze_ticket` methods with status restoration
- Rake task: `escalated:wake_snoozed_tickets` for cron-based unsnoozing
- Controller: snooze/unsnooze actions with routes
- Default ticket index excludes snoozed tickets

## Test plan
- [ ] Verify snoozing a ticket stores until_time and original status
- [ ] Verify unsnoozing restores the previous status
- [ ] Verify scopes correctly filter snoozed/not_snoozed/expired tickets
- [ ] Verify rake task wakes expired snoozed tickets