### PR TITLE
feat: add email threading and branded templates

### DIFF
--- a/app/mailers/escalated/ticket_mailer.rb
+++ b/app/mailers/escalated/ticket_mailer.rb
@@ -5,6 +5,9 @@ module Escalated
     def new_ticket(ticket)
       @ticket = ticket
       @requester = ticket.requester
+      load_branding
+
+      headers['Message-ID'] = message_id_for(ticket)
 
       mail(
         to: @requester.email,
@@ -15,6 +18,7 @@ module Escalated
     def reply_received(ticket, reply)
       @ticket = ticket
       @reply = reply
+      load_branding
 
       # Notify the requester if an agent replied, or notify the assignee if the customer replied
       recipient = if reply.author == ticket.requester
@@ -25,6 +29,8 @@ module Escalated
 
       return unless recipient
 
+      set_threading_headers(ticket)
+
       mail(
         to: recipient,
         subject: I18n.t('escalated.mailer.reply', reference: ticket.reference, subject: ticket.subject)
@@ -34,8 +40,11 @@ module Escalated
     def ticket_assigned(ticket)
       @ticket = ticket
       @assignee = ticket.assignee
+      load_branding
 
       return unless @assignee&.email
+
+      set_threading_headers(ticket)
 
       mail(
         to: @assignee.email,
@@ -45,6 +54,9 @@ module Escalated
 
     def status_changed(ticket)
       @ticket = ticket
+      load_branding
+
+      set_threading_headers(ticket)
 
       mail(
         to: ticket.requester.email,
@@ -54,12 +66,15 @@ module Escalated
 
     def sla_breach(ticket)
       @ticket = ticket
+      load_branding
 
       recipients = []
       recipients << ticket.assignee.email if ticket.assignee&.email
       recipients << ticket.department&.email if ticket.department&.email
 
       return if recipients.empty?
+
+      set_threading_headers(ticket)
 
       mail(
         to: recipients.compact.uniq,
@@ -70,12 +85,15 @@ module Escalated
     def ticket_escalated(ticket, rule)
       @ticket = ticket
       @rule = rule
+      load_branding
 
       recipients = Array(rule.actions['notification_recipients'])
       recipients << ticket.assignee&.email if ticket.assignee
       recipients << ticket.department&.email if ticket.department
 
       return if recipients.compact.empty?
+
+      set_threading_headers(ticket)
 
       mail(
         to: recipients.compact.uniq,
@@ -85,11 +103,42 @@ module Escalated
 
     def ticket_resolved(ticket)
       @ticket = ticket
+      load_branding
+
+      set_threading_headers(ticket)
 
       mail(
         to: ticket.requester.email,
         subject: I18n.t('escalated.mailer.resolved', reference: ticket.reference, subject: ticket.subject)
       )
+    end
+
+    private
+
+    def message_id_for(ticket)
+      domain = mail_domain
+      "<ticket-#{ticket.id}@#{domain}>"
+    end
+
+    def set_threading_headers(ticket)
+      original_message_id = message_id_for(ticket)
+      headers['In-Reply-To'] = original_message_id
+      headers['References'] = original_message_id
+    end
+
+    def mail_domain
+      from_address = Escalated.configuration.respond_to?(:mailer_from) ? Escalated.configuration.mailer_from : nil
+      if from_address.present? && from_address.include?('@')
+        from_address.split('@').last
+      else
+        'escalated.localhost'
+      end
+    end
+
+    def load_branding
+      @email_logo_url = Escalated::EscalatedSetting.get('email_logo_url')
+      @email_accent_color = Escalated::EscalatedSetting.get('email_accent_color', '#4F46E5')
+      @email_footer_text = Escalated::EscalatedSetting.get('email_footer_text')
     end
   end
 end

--- a/spec/mailers/escalated/ticket_mailer_spec.rb
+++ b/spec/mailers/escalated/ticket_mailer_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::TicketMailer do
+  let(:user) { create(:user) }
+  let(:agent) { create(:user, :agent) }
+  let(:ticket) { create(:escalated_ticket, requester: user, assigned_to: agent.id) }
+
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [:email], webhook_url: nil)
+  end
+
+  describe '#new_ticket' do
+    let(:mail) { described_class.new_ticket(ticket) }
+
+    it 'sets a Message-ID header' do
+      expect(mail['Message-ID'].to_s).to match(/ticket-#{ticket.id}@/)
+    end
+
+    it 'sends to the requester' do
+      expect(mail.to).to include(user.email)
+    end
+
+    it 'loads branding variables' do
+      Escalated::EscalatedSetting.set('email_logo_url', 'https://example.com/logo.png')
+      Escalated::EscalatedSetting.set('email_accent_color', '#FF0000')
+      Escalated::EscalatedSetting.set('email_footer_text', 'Powered by Escalated')
+
+      # Mail should build without error
+      expect(mail.subject).to be_present
+    end
+  end
+
+  describe '#reply_received' do
+    let(:reply) { create(:escalated_reply, ticket: ticket, author: agent) }
+    let(:mail) { described_class.reply_received(ticket, reply) }
+
+    it 'sets In-Reply-To header referencing the ticket' do
+      expect(mail['In-Reply-To'].to_s).to match(/ticket-#{ticket.id}@/)
+    end
+
+    it 'sets References header referencing the ticket' do
+      expect(mail['References'].to_s).to match(/ticket-#{ticket.id}@/)
+    end
+
+    it 'sends to the requester when agent replies' do
+      expect(mail.to).to include(user.email)
+    end
+  end
+
+  describe '#ticket_assigned' do
+    before { ticket.update!(assigned_to: agent.id) }
+
+    let(:mail) { described_class.ticket_assigned(ticket) }
+
+    it 'sets threading headers' do
+      expect(mail['In-Reply-To'].to_s).to match(/ticket-#{ticket.id}@/)
+      expect(mail['References'].to_s).to match(/ticket-#{ticket.id}@/)
+    end
+
+    it 'sends to the assignee' do
+      expect(mail.to).to include(agent.email)
+    end
+  end
+
+  describe '#status_changed' do
+    let(:mail) { described_class.status_changed(ticket) }
+
+    it 'sets threading headers' do
+      expect(mail['In-Reply-To'].to_s).to match(/ticket-#{ticket.id}@/)
+    end
+  end
+
+  describe '#ticket_resolved' do
+    let(:mail) { described_class.ticket_resolved(ticket) }
+
+    it 'sets threading headers' do
+      expect(mail['In-Reply-To'].to_s).to match(/ticket-#{ticket.id}@/)
+      expect(mail['References'].to_s).to match(/ticket-#{ticket.id}@/)
+    end
+  end
+
+  describe 'branding settings' do
+    it 'uses default accent color when not configured' do
+      mail = described_class.new_ticket(ticket)
+      # Should not raise error
+      expect(mail.subject).to be_present
+    end
+
+    it 'reads configured branding from settings' do
+      Escalated::EscalatedSetting.set('email_logo_url', 'https://example.com/logo.png')
+      Escalated::EscalatedSetting.set('email_accent_color', '#FF5733')
+      Escalated::EscalatedSetting.set('email_footer_text', 'Custom footer text')
+
+      mail = described_class.new_ticket(ticket)
+      expect(mail.subject).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add In-Reply-To/References headers to all outbound notification emails for proper threading
- Set Message-ID on new ticket emails as the thread root
- Add branding settings: `email_logo_url`, `email_accent_color`, `email_footer_text`
- All mailer methods load branding from `EscalatedSetting`

## Test plan
- [ ] Verify Message-ID is set on new_ticket emails
- [ ] Verify In-Reply-To and References headers on reply/status/assignment emails
- [ ] Verify branding settings are loaded and accessible in templates
- [ ] Verify default accent color when no branding configured