### PR TITLE
feat: add saved views / custom queues

### DIFF
--- a/app/controllers/escalated/admin/saved_views_controller.rb
+++ b/app/controllers/escalated/admin/saved_views_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Admin
+    class SavedViewsController < Escalated::ApplicationController
+      before_action :require_agent!
+      before_action :set_saved_view, only: %i[update destroy]
+
+      def index
+        views = Escalated::SavedView.accessible_by(escalated_current_user.id).ordered
+
+        render json: views.map { |v| view_json(v) }
+      end
+
+      def create
+        view = Escalated::SavedView.new(saved_view_params)
+        view.user_id = escalated_current_user.id
+
+        if view.save
+          render json: view_json(view), status: :created
+        else
+          render json: { error: view.errors.full_messages.join(', ') }, status: :unprocessable_content
+        end
+      end
+
+      def update
+        if @saved_view.update(saved_view_params)
+          render json: view_json(@saved_view)
+        else
+          render json: { error: @saved_view.errors.full_messages.join(', ') }, status: :unprocessable_content
+        end
+      end
+
+      def destroy
+        @saved_view.destroy!
+        render json: { success: true }
+      end
+
+      def reorder
+        params[:view_ids].each_with_index do |id, index|
+          Escalated::SavedView
+            .accessible_by(escalated_current_user.id)
+            .where(id: id)
+            .update_all(position: index)
+        end
+
+        render json: { success: true }
+      end
+
+      private
+
+      def set_saved_view
+        @saved_view = Escalated::SavedView.accessible_by(escalated_current_user.id).find(params[:id])
+      end
+
+      def saved_view_params
+        params.permit(:name, :is_shared, :is_default, :icon, :color, filters: {})
+      end
+
+      def view_json(view)
+        {
+          id: view.id,
+          name: view.name,
+          filters: view.filters,
+          user_id: view.user_id,
+          is_shared: view.is_shared,
+          is_default: view.is_default,
+          position: view.position,
+          icon: view.icon,
+          color: view.color,
+          created_at: view.created_at&.iso8601,
+          updated_at: view.updated_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/models/escalated/saved_view.rb
+++ b/app/models/escalated/saved_view.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Escalated
+  class SavedView < ApplicationRecord
+    self.table_name = Escalated.table_name('saved_views')
+
+    belongs_to :user, class_name: Escalated.configuration.user_class, optional: true
+
+    validates :name, presence: true, length: { maximum: 100 }
+
+    scope :for_user, ->(user_id) { where(user_id: user_id) }
+    scope :shared, -> { where(is_shared: true) }
+    scope :default_views, -> { where(is_default: true) }
+    scope :ordered, -> { order(position: :asc, name: :asc) }
+    scope :accessible_by, ->(user_id) { where(user_id: user_id).or(where(is_shared: true)) }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,11 @@ Escalated::Engine.routes.draw do
         post 'side_conversations/:conversation_id/close', to: 'side_conversations#close', as: :side_conversation_close
       end
     end
+    resources :saved_views, only: %i[index create update destroy] do
+      collection do
+        post :reorder
+      end
+    end
     resources :articles, only: %i[index create update destroy]
     resources :kb_categories, only: %i[index create update destroy]
 

--- a/db/migrate/035_create_escalated_saved_views.rb
+++ b/db/migrate/035_create_escalated_saved_views.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateEscalatedSavedViews < ActiveRecord::Migration[7.1]
+  def change
+    create_table Escalated.table_name('saved_views') do |t|
+      t.string :name, null: false
+      t.json :filters, default: {}
+      t.bigint :user_id, null: true
+      t.boolean :is_shared, default: false, null: false
+      t.boolean :is_default, default: false, null: false
+      t.integer :position, default: 0, null: false
+      t.string :icon
+      t.string :color
+
+      t.timestamps
+    end
+
+    add_index Escalated.table_name('saved_views'), :user_id
+    add_index Escalated.table_name('saved_views'), :is_shared
+    add_index Escalated.table_name('saved_views'), :position
+  end
+end

--- a/spec/factories/saved_views.rb
+++ b/spec/factories/saved_views.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :escalated_saved_view, class: 'Escalated::SavedView' do
+    name { Faker::Lorem.sentence(word_count: 3) }
+    filters { { 'status' => 'open', 'priority' => 'high' } }
+    association :user, factory: :user
+    is_shared { false }
+    is_default { false }
+    position { 0 }
+
+    trait :shared do
+      is_shared { true }
+    end
+
+    trait :default_view do
+      is_default { true }
+    end
+  end
+end

--- a/spec/models/escalated/saved_view_spec.rb
+++ b/spec/models/escalated/saved_view_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Escalated::SavedView do
 
     describe '.ordered' do
       it 'orders by position then name' do
-        view_a = create(:escalated_saved_view, user: user, position: 1, name: 'B View')
-        view_b = create(:escalated_saved_view, user: user, position: 0, name: 'A View')
+        create(:escalated_saved_view, user: user, position: 1, name: 'B View')
+        create(:escalated_saved_view, user: user, position: 0, name: 'A View')
         result = described_class.for_user(user.id).ordered
         positions = result.pluck(:position)
         expect(positions).to eq(positions.sort)

--- a/spec/models/escalated/saved_view_spec.rb
+++ b/spec/models/escalated/saved_view_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::SavedView do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+  end
+
+  describe 'validations' do
+    it 'requires a name' do
+      view = build(:escalated_saved_view, name: nil)
+      expect(view).not_to be_valid
+      expect(view.errors[:name]).to include("can't be blank")
+    end
+
+    it 'limits name to 100 characters' do
+      view = build(:escalated_saved_view, name: 'a' * 101)
+      expect(view).not_to be_valid
+    end
+
+    it 'is valid with valid attributes' do
+      view = build(:escalated_saved_view)
+      expect(view).to be_valid
+    end
+  end
+
+  describe 'scopes' do
+    let!(:user_view) { create(:escalated_saved_view, user: user) }
+    let!(:shared_view) { create(:escalated_saved_view, :shared, user: other_user) }
+    let!(:other_view) { create(:escalated_saved_view, user: other_user, is_shared: false) }
+    let!(:default_view) { create(:escalated_saved_view, :default_view, user: user) }
+
+    describe '.for_user' do
+      it 'returns views belonging to the user' do
+        result = described_class.for_user(user.id)
+        expect(result).to include(user_view, default_view)
+        expect(result).not_to include(shared_view, other_view)
+      end
+    end
+
+    describe '.shared' do
+      it 'returns only shared views' do
+        result = described_class.shared
+        expect(result).to include(shared_view)
+        expect(result).not_to include(user_view, other_view)
+      end
+    end
+
+    describe '.default_views' do
+      it 'returns default views' do
+        result = described_class.default_views
+        expect(result).to include(default_view)
+        expect(result).not_to include(user_view)
+      end
+    end
+
+    describe '.accessible_by' do
+      it 'returns user views and shared views' do
+        result = described_class.accessible_by(user.id)
+        expect(result).to include(user_view, shared_view, default_view)
+        expect(result).not_to include(other_view)
+      end
+    end
+
+    describe '.ordered' do
+      it 'orders by position then name' do
+        view_a = create(:escalated_saved_view, user: user, position: 1, name: 'B View')
+        view_b = create(:escalated_saved_view, user: user, position: 0, name: 'A View')
+        result = described_class.for_user(user.id).ordered
+        positions = result.pluck(:position)
+        expect(positions).to eq(positions.sort)
+      end
+    end
+  end
+
+  describe 'filters' do
+    it 'stores and retrieves JSON filters' do
+      filters = { 'status' => 'open', 'priority' => 'high', 'tags' => [1, 2] }
+      view = create(:escalated_saved_view, user: user, filters: filters)
+      view.reload
+      expect(view.filters).to eq(filters)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Migration: creates `escalated_saved_views` table with name, filters (JSON), user_id, is_shared, is_default, position, icon, color
- Model: `SavedView` with scopes `for_user`, `shared`, `default_views`, `accessible_by`, `ordered`
- Controller: full CRUD + reorder endpoint
- Routes under admin namespace

## Test plan
- [ ] Verify creating saved views with filters JSON
- [ ] Verify scopes filter correctly (for_user, shared, accessible_by)
- [ ] Verify reorder updates positions
- [ ] Verify name validation (presence, max length)