### PR TITLE
feat: add embeddable widget API

### DIFF
--- a/app/controllers/escalated/widget_controller.rb
+++ b/app/controllers/escalated/widget_controller.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Escalated
+  class WidgetController < ActionController::Base
+    include Escalated::ApiRateLimiting
+
+    protect_from_forgery with: :null_session
+    before_action :enforce_rate_limit!
+    before_action :ensure_widget_enabled!
+
+    # GET /support/widget/config
+    def config
+      render json: {
+        enabled: widget_enabled?,
+        color: Escalated::EscalatedSetting.get('widget_color', '#4F46E5'),
+        position: Escalated::EscalatedSetting.get('widget_position', 'bottom-right'),
+        greeting: Escalated::EscalatedSetting.get('widget_greeting', 'How can we help you?'),
+        kb_enabled: Escalated::EscalatedSetting.get_bool('knowledge_base_enabled', default: true)
+      }
+    end
+
+    # GET /support/widget/articles?q=search_term
+    def articles
+      scope = Escalated::Article.published.recent
+
+      if params[:q].present?
+        scope = scope.search(params[:q])
+      end
+
+      articles = scope.limit(10)
+
+      render json: articles.map { |a|
+        {
+          id: a.id,
+          title: a.title,
+          slug: a.slug,
+          excerpt: a.body&.truncate(200)
+        }
+      }
+    end
+
+    # GET /support/widget/articles/:slug
+    def article
+      article = Escalated::Article.published.find_by!(slug: params[:slug])
+      article.increment_views!
+
+      render json: {
+        id: article.id,
+        title: article.title,
+        slug: article.slug,
+        body: article.body,
+        category: article.category ? { id: article.category.id, name: article.category.name } : nil
+      }
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: 'Article not found' }, status: :not_found
+    end
+
+    # POST /support/widget/tickets
+    def create_ticket
+      ticket = Escalated::Services::TicketService.create(
+        subject: params[:subject],
+        description: params[:description],
+        guest_name: params[:name],
+        guest_email: params[:email],
+        priority: Escalated.configuration.default_priority,
+        metadata: { 'source' => 'widget' }
+      )
+
+      render json: {
+        reference: ticket.reference,
+        guest_token: ticket.guest_token
+      }, status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { error: e.record.errors.full_messages.join(', ') }, status: :unprocessable_content
+    end
+
+    # GET /support/widget/tickets/:token
+    def lookup_ticket
+      ticket = Escalated::Ticket.find_by!(guest_token: params[:token])
+
+      render json: {
+        reference: ticket.reference,
+        subject: ticket.subject,
+        status: ticket.status,
+        created_at: ticket.created_at&.iso8601,
+        replies: ticket.replies.public_replies.chronological.map { |r|
+          {
+            body: r.body,
+            is_agent: r.author.respond_to?(:escalated_agent?) ? r.author.escalated_agent? : false,
+            created_at: r.created_at&.iso8601
+          }
+        }
+      }
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: 'Ticket not found' }, status: :not_found
+    end
+
+    private
+
+    def widget_enabled?
+      Escalated::EscalatedSetting.get_bool('widget_enabled', default: false)
+    end
+
+    def ensure_widget_enabled!
+      return if widget_enabled?
+
+      render json: { error: 'Widget is disabled' }, status: :forbidden
+    end
+
+    def rate_limit_key
+      "widget:ip:#{request.remote_ip}"
+    end
+  end
+end

--- a/app/controllers/escalated/widget_controller.rb
+++ b/app/controllers/escalated/widget_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Escalated
-  class WidgetController < ActionController::Base
+  class WidgetController < ApplicationController
     include Escalated::ApiRateLimiting
 
     protect_from_forgery with: :null_session
@@ -23,9 +23,7 @@ module Escalated
     def articles
       scope = Escalated::Article.published.recent
 
-      if params[:q].present?
-        scope = scope.search(params[:q])
-      end
+      scope = scope.search(params[:q]) if params[:q].present?
 
       articles = scope.limit(10)
 
@@ -83,13 +81,13 @@ module Escalated
         subject: ticket.subject,
         status: ticket.status,
         created_at: ticket.created_at&.iso8601,
-        replies: ticket.replies.public_replies.chronological.map { |r|
+        replies: ticket.replies.public_replies.chronological.map do |r|
           {
             body: r.body,
             is_agent: r.author.respond_to?(:escalated_agent?) ? r.author.escalated_agent? : false,
             created_at: r.created_at&.iso8601
           }
-        }
+        end
       }
     rescue ActiveRecord::RecordNotFound
       render json: { error: 'Ticket not found' }, status: :not_found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,15 @@ Escalated::Engine.routes.draw do
     end
   end
 
+  # Widget routes (public, no authentication required)
+  scope 'widget', controller: :widget do
+    get :config, as: :widget_config
+    get :articles, as: :widget_articles
+    get 'articles/:slug', action: :article, as: :widget_article
+    post :tickets, action: :create_ticket, as: :widget_create_ticket
+    get 'tickets/:token', action: :lookup_ticket, as: :widget_lookup_ticket
+  end
+
   # Guest routes (no authentication required)
   namespace :guest do
     get 'create', to: 'tickets#create'

--- a/spec/controllers/escalated/widget_controller_spec.rb
+++ b/spec/controllers/escalated/widget_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Escalated::WidgetController do
 
   describe 'ticket creation from widget' do
     it 'creates a ticket via TicketService' do
-      expect {
+      expect do
         Escalated::Services::TicketService.create(
           subject: 'Widget ticket',
           description: 'Created from widget',
@@ -74,7 +74,7 @@ RSpec.describe Escalated::WidgetController do
           priority: :medium,
           metadata: { 'source' => 'widget' }
         )
-      }.to change(Escalated::Ticket, :count).by(1)
+      end.to change(Escalated::Ticket, :count).by(1)
     end
 
     it 'stores widget source in metadata' do
@@ -99,9 +99,9 @@ RSpec.describe Escalated::WidgetController do
     end
 
     it 'raises RecordNotFound for invalid token' do
-      expect {
+      expect do
         Escalated::Ticket.find_by!(guest_token: 'invalid_token')
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/controllers/escalated/widget_controller_spec.rb
+++ b/spec/controllers/escalated/widget_controller_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::WidgetController do
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+    Escalated::EscalatedSetting.set('widget_enabled', '1')
+  end
+
+  describe 'widget settings' do
+    it 'recognizes widget_enabled setting' do
+      expect(Escalated::EscalatedSetting.get_bool('widget_enabled')).to be true
+    end
+
+    it 'recognizes widget_color setting' do
+      Escalated::EscalatedSetting.set('widget_color', '#FF0000')
+      expect(Escalated::EscalatedSetting.get('widget_color')).to eq('#FF0000')
+    end
+
+    it 'recognizes widget_position setting' do
+      Escalated::EscalatedSetting.set('widget_position', 'bottom-left')
+      expect(Escalated::EscalatedSetting.get('widget_position')).to eq('bottom-left')
+    end
+
+    it 'recognizes widget_greeting setting' do
+      Escalated::EscalatedSetting.set('widget_greeting', 'Hello!')
+      expect(Escalated::EscalatedSetting.get('widget_greeting')).to eq('Hello!')
+    end
+  end
+
+  describe 'widget disabled behavior' do
+    it 'returns false when widget is not enabled' do
+      Escalated::EscalatedSetting.set('widget_enabled', '0')
+      expect(Escalated::EscalatedSetting.get_bool('widget_enabled')).to be false
+    end
+
+    it 'defaults to disabled when setting is not present' do
+      # Clear any existing setting
+      Escalated::EscalatedSetting.where(key: 'widget_enabled').destroy_all
+      expect(Escalated::EscalatedSetting.get_bool('widget_enabled', default: false)).to be false
+    end
+  end
+
+  describe 'article search for widget' do
+    let!(:published_article) { create(:escalated_article, :published, title: 'Getting Started Guide') }
+    let!(:draft_article) { create(:escalated_article, title: 'Draft Article') }
+
+    it 'returns only published articles' do
+      results = Escalated::Article.published
+      expect(results).to include(published_article)
+      expect(results).not_to include(draft_article)
+    end
+
+    it 'searches articles by title' do
+      results = Escalated::Article.published.search('Getting Started')
+      expect(results).to include(published_article)
+    end
+
+    it 'does not return draft articles in search' do
+      results = Escalated::Article.published.search('Draft')
+      expect(results).not_to include(draft_article)
+    end
+  end
+
+  describe 'ticket creation from widget' do
+    it 'creates a ticket via TicketService' do
+      expect {
+        Escalated::Services::TicketService.create(
+          subject: 'Widget ticket',
+          description: 'Created from widget',
+          guest_name: 'John',
+          guest_email: 'john@example.com',
+          priority: :medium,
+          metadata: { 'source' => 'widget' }
+        )
+      }.to change(Escalated::Ticket, :count).by(1)
+    end
+
+    it 'stores widget source in metadata' do
+      ticket = Escalated::Services::TicketService.create(
+        subject: 'Widget ticket',
+        description: 'Created from widget',
+        guest_name: 'John',
+        guest_email: 'john@example.com',
+        priority: :medium,
+        metadata: { 'source' => 'widget' }
+      )
+      expect(ticket.metadata['source']).to eq('widget')
+    end
+  end
+
+  describe 'ticket lookup by guest token' do
+    let(:ticket) { create(:escalated_ticket, guest_token: SecureRandom.hex(16)) }
+
+    it 'finds ticket by guest_token' do
+      found = Escalated::Ticket.find_by!(guest_token: ticket.guest_token)
+      expect(found).to eq(ticket)
+    end
+
+    it 'raises RecordNotFound for invalid token' do
+      expect {
+        Escalated::Ticket.find_by!(guest_token: 'invalid_token')
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- WidgetController with public endpoints: config, article search, article detail, create ticket, lookup ticket
- Routes under `/support/widget/` with rate limiting, no authentication required
- Widget settings: `widget_enabled`, `widget_color`, `widget_position`, `widget_greeting`
- Widget is disabled by default; must be enabled via settings

## Test plan
- [ ] Verify widget config endpoint returns settings
- [ ] Verify article search returns only published articles
- [ ] Verify ticket creation stores widget source in metadata
- [ ] Verify ticket lookup by guest token
- [ ] Verify widget returns 403 when disabled