### PR TITLE
feat: add knowledge base toggle settings

### DIFF
--- a/app/controllers/concerns/escalated/knowledge_base_guard.rb
+++ b/app/controllers/concerns/escalated/knowledge_base_guard.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Escalated
+  module KnowledgeBaseGuard
+    extend ActiveSupport::Concern
+
+    private
+
+    def require_knowledge_base_enabled!
+      return if Escalated::EscalatedSetting.knowledge_base_enabled?
+
+      render json: { error: 'Knowledge base is disabled' }, status: :forbidden
+    end
+
+    def require_knowledge_base_public!
+      return if Escalated::EscalatedSetting.knowledge_base_public?
+
+      render json: { error: 'Knowledge base is not publicly accessible' }, status: :forbidden
+    end
+
+    def require_knowledge_base_feedback_enabled!
+      return if Escalated::EscalatedSetting.knowledge_base_feedback_enabled?
+
+      render json: { error: 'Knowledge base feedback is disabled' }, status: :forbidden
+    end
+  end
+end

--- a/app/controllers/escalated/admin/articles_controller.rb
+++ b/app/controllers/escalated/admin/articles_controller.rb
@@ -3,7 +3,10 @@
 module Escalated
   module Admin
     class ArticlesController < Escalated::ApplicationController
+      include Escalated::KnowledgeBaseGuard
+
       before_action :require_admin!
+      before_action :require_knowledge_base_enabled!
       before_action :set_article, only: %i[update destroy]
 
       def index

--- a/app/controllers/escalated/admin/kb_categories_controller.rb
+++ b/app/controllers/escalated/admin/kb_categories_controller.rb
@@ -3,7 +3,10 @@
 module Escalated
   module Admin
     class KbCategoriesController < Escalated::ApplicationController
+      include Escalated::KnowledgeBaseGuard
+
       before_action :require_admin!
+      before_action :require_knowledge_base_enabled!
       before_action :set_category, only: %i[update destroy]
 
       def index

--- a/app/controllers/escalated/admin/settings_controller.rb
+++ b/app/controllers/escalated/admin/settings_controller.rb
@@ -104,7 +104,8 @@ module Escalated
 
       def update
         # Boolean settings
-        %w[guest_tickets_enabled allow_customer_close inbound_email_enabled show_powered_by].each do |key|
+        %w[guest_tickets_enabled allow_customer_close inbound_email_enabled show_powered_by
+           knowledge_base_enabled knowledge_base_public knowledge_base_feedback_enabled].each do |key|
           value = params[key].in?(%w[1 true on]) ? '1' : '0'
           Escalated::EscalatedSetting.set(key, value)
         end

--- a/app/controllers/escalated/application_controller.rb
+++ b/app/controllers/escalated/application_controller.rb
@@ -32,7 +32,10 @@ module Escalated
           max_attachment_size_kb: Escalated.configuration.max_attachment_size_kb,
           guest_tickets_enabled: Escalated::EscalatedSetting.guest_tickets_enabled?,
           show_powered_by: Escalated::EscalatedSetting.get_bool('show_powered_by', default: true),
-          plugins_enabled: Escalated.configuration.plugins_enabled?
+          plugins_enabled: Escalated.configuration.plugins_enabled?,
+          knowledge_base_enabled: Escalated::EscalatedSetting.knowledge_base_enabled?,
+          knowledge_base_public: Escalated::EscalatedSetting.knowledge_base_public?,
+          knowledge_base_feedback_enabled: Escalated::EscalatedSetting.knowledge_base_feedback_enabled?
         },
         flash: {
           success: flash[:success],

--- a/app/models/escalated/escalated_setting.rb
+++ b/app/models/escalated/escalated_setting.rb
@@ -38,6 +38,18 @@ module Escalated
       get_bool('guest_tickets_enabled', default: true)
     end
 
+    def self.knowledge_base_enabled?
+      get_bool('knowledge_base_enabled', default: true)
+    end
+
+    def self.knowledge_base_public?
+      get_bool('knowledge_base_public', default: true)
+    end
+
+    def self.knowledge_base_feedback_enabled?
+      get_bool('knowledge_base_feedback_enabled', default: true)
+    end
+
     def self.all_as_hash
       all.to_h { |s| [s.key, s.value] }
     end

--- a/spec/models/escalated/knowledge_base_settings_spec.rb
+++ b/spec/models/escalated/knowledge_base_settings_spec.rb
@@ -2,55 +2,53 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Knowledge Base Settings' do
+RSpec.describe Escalated::EscalatedSetting do # Knowledge Base Settings
   before do
     allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
   end
 
-  describe Escalated::EscalatedSetting do
-    describe '.knowledge_base_enabled?' do
-      it 'defaults to true' do
-        expect(described_class.knowledge_base_enabled?).to be true
-      end
-
-      it 'returns false when set to 0' do
-        described_class.set('knowledge_base_enabled', '0')
-        expect(described_class.knowledge_base_enabled?).to be false
-      end
-
-      it 'returns true when set to 1' do
-        described_class.set('knowledge_base_enabled', '1')
-        expect(described_class.knowledge_base_enabled?).to be true
-      end
+  describe '.knowledge_base_enabled?' do
+    it 'defaults to true' do
+      expect(described_class.knowledge_base_enabled?).to be true
     end
 
-    describe '.knowledge_base_public?' do
-      it 'defaults to true' do
-        expect(described_class.knowledge_base_public?).to be true
-      end
-
-      it 'returns false when set to 0' do
-        described_class.set('knowledge_base_public', '0')
-        expect(described_class.knowledge_base_public?).to be false
-      end
+    it 'returns false when set to 0' do
+      described_class.set('knowledge_base_enabled', '0')
+      expect(described_class.knowledge_base_enabled?).to be false
     end
 
-    describe '.knowledge_base_feedback_enabled?' do
-      it 'defaults to true' do
-        expect(described_class.knowledge_base_feedback_enabled?).to be true
-      end
+    it 'returns true when set to 1' do
+      described_class.set('knowledge_base_enabled', '1')
+      expect(described_class.knowledge_base_enabled?).to be true
+    end
+  end
 
-      it 'returns false when set to 0' do
-        described_class.set('knowledge_base_feedback_enabled', '0')
-        expect(described_class.knowledge_base_feedback_enabled?).to be false
-      end
+  describe '.knowledge_base_public?' do
+    it 'defaults to true' do
+      expect(described_class.knowledge_base_public?).to be true
+    end
+
+    it 'returns false when set to 0' do
+      described_class.set('knowledge_base_public', '0')
+      expect(described_class.knowledge_base_public?).to be false
+    end
+  end
+
+  describe '.knowledge_base_feedback_enabled?' do
+    it 'defaults to true' do
+      expect(described_class.knowledge_base_feedback_enabled?).to be true
+    end
+
+    it 'returns false when set to 0' do
+      described_class.set('knowledge_base_feedback_enabled', '0')
+      expect(described_class.knowledge_base_feedback_enabled?).to be false
     end
   end
 
   describe Escalated::KnowledgeBaseGuard do
     # Create a test controller to include the concern
     let(:controller_class) do
-      Class.new(ActionController::Base) do
+      Class.new(ApplicationController) do
         include Escalated::KnowledgeBaseGuard
 
         def test_enabled

--- a/spec/models/escalated/knowledge_base_settings_spec.rb
+++ b/spec/models/escalated/knowledge_base_settings_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Knowledge Base Settings' do
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+  end
+
+  describe Escalated::EscalatedSetting do
+    describe '.knowledge_base_enabled?' do
+      it 'defaults to true' do
+        expect(described_class.knowledge_base_enabled?).to be true
+      end
+
+      it 'returns false when set to 0' do
+        described_class.set('knowledge_base_enabled', '0')
+        expect(described_class.knowledge_base_enabled?).to be false
+      end
+
+      it 'returns true when set to 1' do
+        described_class.set('knowledge_base_enabled', '1')
+        expect(described_class.knowledge_base_enabled?).to be true
+      end
+    end
+
+    describe '.knowledge_base_public?' do
+      it 'defaults to true' do
+        expect(described_class.knowledge_base_public?).to be true
+      end
+
+      it 'returns false when set to 0' do
+        described_class.set('knowledge_base_public', '0')
+        expect(described_class.knowledge_base_public?).to be false
+      end
+    end
+
+    describe '.knowledge_base_feedback_enabled?' do
+      it 'defaults to true' do
+        expect(described_class.knowledge_base_feedback_enabled?).to be true
+      end
+
+      it 'returns false when set to 0' do
+        described_class.set('knowledge_base_feedback_enabled', '0')
+        expect(described_class.knowledge_base_feedback_enabled?).to be false
+      end
+    end
+  end
+
+  describe Escalated::KnowledgeBaseGuard do
+    # Create a test controller to include the concern
+    let(:controller_class) do
+      Class.new(ActionController::Base) do
+        include Escalated::KnowledgeBaseGuard
+
+        def test_enabled
+          require_knowledge_base_enabled!
+        end
+
+        def test_public
+          require_knowledge_base_public!
+        end
+
+        def test_feedback
+          require_knowledge_base_feedback_enabled!
+        end
+      end
+    end
+
+    describe 'guard checks' do
+      it 'knowledge_base_enabled guard passes when enabled' do
+        Escalated::EscalatedSetting.set('knowledge_base_enabled', '1')
+        expect(Escalated::EscalatedSetting.knowledge_base_enabled?).to be true
+      end
+
+      it 'knowledge_base_enabled guard blocks when disabled' do
+        Escalated::EscalatedSetting.set('knowledge_base_enabled', '0')
+        expect(Escalated::EscalatedSetting.knowledge_base_enabled?).to be false
+      end
+
+      it 'knowledge_base_public guard passes when public' do
+        Escalated::EscalatedSetting.set('knowledge_base_public', '1')
+        expect(Escalated::EscalatedSetting.knowledge_base_public?).to be true
+      end
+
+      it 'knowledge_base_public guard blocks when not public' do
+        Escalated::EscalatedSetting.set('knowledge_base_public', '0')
+        expect(Escalated::EscalatedSetting.knowledge_base_public?).to be false
+      end
+
+      it 'feedback guard passes when enabled' do
+        Escalated::EscalatedSetting.set('knowledge_base_feedback_enabled', '1')
+        expect(Escalated::EscalatedSetting.knowledge_base_feedback_enabled?).to be true
+      end
+
+      it 'feedback guard blocks when disabled' do
+        Escalated::EscalatedSetting.set('knowledge_base_feedback_enabled', '0')
+        expect(Escalated::EscalatedSetting.knowledge_base_feedback_enabled?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add settings: `knowledge_base_enabled`, `knowledge_base_public`, `knowledge_base_feedback_enabled` (all default true)
- Add `KnowledgeBaseGuard` concern to gate KB controller actions
- Apply guard to Articles and KbCategories controllers
- Pass KB settings to frontend via Inertia shared data
- Add KB settings to admin settings update whitelist

## Test plan
- [ ] Verify KB settings default to true
- [ ] Verify settings can be toggled via admin
- [ ] Verify KB controllers are gated when disabled
- [ ] Verify frontend receives KB settings in shared data