### PR TITLE
feat: add real-time broadcasting support

### DIFF
--- a/app/channels/escalated/agent_channel.rb
+++ b/app/channels/escalated/agent_channel.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Escalated
+  class AgentChannel < ApplicationCable::Channel
+    def subscribed
+      if authorized_agent?
+        stream_from Escalated::Broadcasting.agent_channel
+        stream_from Escalated::Broadcasting.agent_channel(current_user.id)
+      else
+        reject
+      end
+    end
+
+    def unsubscribed
+      stop_all_streams
+    end
+
+    private
+
+    def authorized_agent?
+      return false unless current_user
+
+      (current_user.respond_to?(:escalated_agent?) && current_user.escalated_agent?) ||
+        (current_user.respond_to?(:escalated_admin?) && current_user.escalated_admin?)
+    end
+  end
+end

--- a/app/channels/escalated/ticket_channel.rb
+++ b/app/channels/escalated/ticket_channel.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Escalated
+  class TicketChannel < ApplicationCable::Channel
+    def subscribed
+      ticket = Escalated::Ticket.find(params[:ticket_id])
+
+      # Only agents/admins can subscribe to ticket channels
+      if authorized_for_ticket?(ticket)
+        stream_from Escalated::Broadcasting.ticket_channel(ticket)
+      else
+        reject
+      end
+    rescue ActiveRecord::RecordNotFound
+      reject
+    end
+
+    def unsubscribed
+      stop_all_streams
+    end
+
+    private
+
+    def authorized_for_ticket?(ticket)
+      return false unless current_user
+
+      # Agents and admins can subscribe
+      if current_user.respond_to?(:escalated_agent?)
+        return true if current_user.escalated_agent?
+      end
+
+      if current_user.respond_to?(:escalated_admin?)
+        return true if current_user.escalated_admin?
+      end
+
+      # Requesters can subscribe to their own tickets
+      ticket.requester == current_user
+    end
+  end
+end

--- a/app/channels/escalated/ticket_channel.rb
+++ b/app/channels/escalated/ticket_channel.rb
@@ -25,13 +25,9 @@ module Escalated
       return false unless current_user
 
       # Agents and admins can subscribe
-      if current_user.respond_to?(:escalated_agent?)
-        return true if current_user.escalated_agent?
-      end
+      return true if current_user.respond_to?(:escalated_agent?) && current_user.escalated_agent?
 
-      if current_user.respond_to?(:escalated_admin?)
-        return true if current_user.escalated_admin?
-      end
+      return true if current_user.respond_to?(:escalated_admin?) && current_user.escalated_admin?
 
       # Requesters can subscribe to their own tickets
       ticket.requester == current_user

--- a/lib/escalated.rb
+++ b/lib/escalated.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'escalated/broadcasting'
 require 'escalated/engine'
 require 'escalated/configuration'
 require 'escalated/manager'

--- a/lib/escalated/broadcasting.rb
+++ b/lib/escalated/broadcasting.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Broadcasting
+    class << self
+      def enabled?
+        Escalated::EscalatedSetting.get_bool('broadcasting_enabled', default: false)
+      end
+
+      def broadcast(channel, event, data)
+        return unless enabled?
+
+        payload = {
+          event: event.to_s,
+          data: data,
+          timestamp: Time.current.iso8601
+        }
+
+        ActionCable.server.broadcast(channel, payload)
+      rescue StandardError => e
+        Rails.logger.warn("[Escalated::Broadcasting] Failed to broadcast #{event} to #{channel}: #{e.message}")
+      end
+
+      def ticket_channel(ticket)
+        "escalated_ticket_#{ticket.respond_to?(:id) ? ticket.id : ticket}"
+      end
+
+      def agent_channel(agent_id = nil)
+        agent_id ? "escalated_agent_#{agent_id}" : 'escalated_agents'
+      end
+
+      # Broadcast events
+
+      def ticket_created(ticket)
+        broadcast(agent_channel, :ticket_created, ticket_payload(ticket))
+      end
+
+      def ticket_updated(ticket)
+        broadcast(ticket_channel(ticket), :ticket_updated, ticket_payload(ticket))
+        broadcast(agent_channel, :ticket_updated, ticket_payload(ticket))
+      end
+
+      def ticket_status_changed(ticket, old_status, new_status)
+        data = ticket_payload(ticket).merge(
+          old_status: old_status.to_s,
+          new_status: new_status.to_s
+        )
+        broadcast(ticket_channel(ticket), :ticket_status_changed, data)
+        broadcast(agent_channel, :ticket_status_changed, data)
+      end
+
+      def reply_created(ticket, reply)
+        data = {
+          ticket_id: ticket.id,
+          ticket_reference: ticket.reference,
+          reply_id: reply.id,
+          is_internal: reply.is_internal,
+          author: reply.author ? { id: reply.author.id, name: reply.author.respond_to?(:name) ? reply.author.name : reply.author.email } : nil
+        }
+        broadcast(ticket_channel(ticket), :reply_created, data)
+      end
+
+      def ticket_assigned(ticket, agent)
+        data = ticket_payload(ticket).merge(
+          assigned_to: agent ? { id: agent.id, name: agent.respond_to?(:name) ? agent.name : agent.email } : nil
+        )
+        broadcast(ticket_channel(ticket), :ticket_assigned, data)
+        broadcast(agent_channel(agent&.id), :ticket_assigned, data) if agent
+      end
+
+      def ticket_escalated(ticket)
+        broadcast(ticket_channel(ticket), :ticket_escalated, ticket_payload(ticket))
+        broadcast(agent_channel, :ticket_escalated, ticket_payload(ticket))
+      end
+
+      private
+
+      def ticket_payload(ticket)
+        {
+          id: ticket.id,
+          reference: ticket.reference,
+          subject: ticket.subject,
+          status: ticket.status,
+          priority: ticket.priority
+        }
+      end
+    end
+  end
+end

--- a/lib/escalated/broadcasting.rb
+++ b/lib/escalated/broadcasting.rb
@@ -55,14 +55,19 @@ module Escalated
           ticket_reference: ticket.reference,
           reply_id: reply.id,
           is_internal: reply.is_internal,
-          author: reply.author ? { id: reply.author.id, name: reply.author.respond_to?(:name) ? reply.author.name : reply.author.email } : nil
+          author: if reply.author
+                    { id: reply.author.id,
+                      name: reply.author.respond_to?(:name) ? reply.author.name : reply.author.email }
+                  end
         }
         broadcast(ticket_channel(ticket), :reply_created, data)
       end
 
       def ticket_assigned(ticket, agent)
         data = ticket_payload(ticket).merge(
-          assigned_to: agent ? { id: agent.id, name: agent.respond_to?(:name) ? agent.name : agent.email } : nil
+          assigned_to: if agent
+                         { id: agent.id, name: agent.respond_to?(:name) ? agent.name : agent.email }
+                       end
         )
         broadcast(ticket_channel(ticket), :ticket_assigned, data)
         broadcast(agent_channel(agent&.id), :ticket_assigned, data) if agent

--- a/lib/escalated/services/ticket_service.rb
+++ b/lib/escalated/services/ticket_service.rb
@@ -12,12 +12,15 @@ module Escalated
           end
 
           Services::NotificationService.dispatch(:ticket_created, ticket: ticket)
+          Escalated::Broadcasting.ticket_created(ticket)
 
           ticket
         end
 
         def update(ticket, params, actor:)
-          driver.update_ticket(ticket, params, actor: actor)
+          result = driver.update_ticket(ticket, params, actor: actor)
+          Escalated::Broadcasting.ticket_updated(result)
+          result
         end
 
         def transition_status(ticket, new_status, actor:, note: nil)
@@ -32,6 +35,7 @@ module Escalated
           end
 
           Services::NotificationService.dispatch(:status_changed, ticket: result, status: new_status)
+          Escalated::Broadcasting.ticket_status_changed(result, ticket.status_was || ticket.status, new_status)
 
           result
         end
@@ -44,6 +48,7 @@ module Escalated
           end
 
           Services::NotificationService.dispatch(:ticket_assigned, ticket: result, agent: agent)
+          Escalated::Broadcasting.ticket_assigned(result, agent)
 
           result
         end
@@ -60,6 +65,7 @@ module Escalated
           end
 
           Services::NotificationService.dispatch(:reply_added, ticket: ticket, reply: reply)
+          Escalated::Broadcasting.reply_created(ticket, reply)
 
           reply
         end

--- a/spec/lib/escalated/broadcasting_spec.rb
+++ b/spec/lib/escalated/broadcasting_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Broadcasting do
+  let(:user) { create(:user) }
+  let(:agent) { create(:user, :agent) }
+  let(:ticket) { create(:escalated_ticket, requester: user) }
+
+  before do
+    allow(Escalated.configuration).to receive_messages(notification_channels: [], webhook_url: nil)
+  end
+
+  describe '.enabled?' do
+    it 'defaults to false' do
+      expect(described_class.enabled?).to be false
+    end
+
+    it 'returns true when broadcasting_enabled setting is set' do
+      Escalated::EscalatedSetting.set('broadcasting_enabled', '1')
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'returns false when broadcasting_enabled is 0' do
+      Escalated::EscalatedSetting.set('broadcasting_enabled', '0')
+      expect(described_class.enabled?).to be false
+    end
+  end
+
+  describe '.ticket_channel' do
+    it 'returns channel name for ticket' do
+      expect(described_class.ticket_channel(ticket)).to eq("escalated_ticket_#{ticket.id}")
+    end
+
+    it 'accepts a plain ID' do
+      expect(described_class.ticket_channel(42)).to eq('escalated_ticket_42')
+    end
+  end
+
+  describe '.agent_channel' do
+    it 'returns global agent channel when no ID given' do
+      expect(described_class.agent_channel).to eq('escalated_agents')
+    end
+
+    it 'returns agent-specific channel when ID given' do
+      expect(described_class.agent_channel(5)).to eq('escalated_agent_5')
+    end
+  end
+
+  context 'when broadcasting is disabled' do
+    before do
+      Escalated::EscalatedSetting.set('broadcasting_enabled', '0')
+    end
+
+    it 'does not call ActionCable.server.broadcast for ticket_created' do
+      expect(ActionCable.server).not_to receive(:broadcast)
+      described_class.ticket_created(ticket)
+    end
+
+    it 'does not call ActionCable.server.broadcast for ticket_updated' do
+      expect(ActionCable.server).not_to receive(:broadcast)
+      described_class.ticket_updated(ticket)
+    end
+
+    it 'does not call ActionCable.server.broadcast for reply_created' do
+      reply = create(:escalated_reply, ticket: ticket, author: agent)
+      expect(ActionCable.server).not_to receive(:broadcast)
+      described_class.reply_created(ticket, reply)
+    end
+  end
+
+  context 'when broadcasting is enabled' do
+    before do
+      Escalated::EscalatedSetting.set('broadcasting_enabled', '1')
+    end
+
+    describe '.ticket_created' do
+      it 'broadcasts to agent channel' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          'escalated_agents',
+          hash_including(event: 'ticket_created')
+        )
+        described_class.ticket_created(ticket)
+      end
+    end
+
+    describe '.ticket_updated' do
+      it 'broadcasts to ticket channel and agent channel' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "escalated_ticket_#{ticket.id}",
+          hash_including(event: 'ticket_updated')
+        )
+        expect(ActionCable.server).to receive(:broadcast).with(
+          'escalated_agents',
+          hash_including(event: 'ticket_updated')
+        )
+        described_class.ticket_updated(ticket)
+      end
+    end
+
+    describe '.ticket_status_changed' do
+      it 'broadcasts with old and new status' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "escalated_ticket_#{ticket.id}",
+          hash_including(event: 'ticket_status_changed', data: hash_including(old_status: 'open', new_status: 'closed'))
+        )
+        expect(ActionCable.server).to receive(:broadcast).with(
+          'escalated_agents',
+          hash_including(event: 'ticket_status_changed')
+        )
+        described_class.ticket_status_changed(ticket, :open, :closed)
+      end
+    end
+
+    describe '.reply_created' do
+      let(:reply) { create(:escalated_reply, ticket: ticket, author: agent) }
+
+      it 'broadcasts to ticket channel' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "escalated_ticket_#{ticket.id}",
+          hash_including(event: 'reply_created')
+        )
+        described_class.reply_created(ticket, reply)
+      end
+    end
+
+    describe '.ticket_assigned' do
+      it 'broadcasts to ticket channel and agent-specific channel' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "escalated_ticket_#{ticket.id}",
+          hash_including(event: 'ticket_assigned')
+        )
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "escalated_agent_#{agent.id}",
+          hash_including(event: 'ticket_assigned')
+        )
+        described_class.ticket_assigned(ticket, agent)
+      end
+    end
+
+    describe '.ticket_escalated' do
+      it 'broadcasts to ticket channel and agent channel' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "escalated_ticket_#{ticket.id}",
+          hash_including(event: 'ticket_escalated')
+        )
+        expect(ActionCable.server).to receive(:broadcast).with(
+          'escalated_agents',
+          hash_including(event: 'ticket_escalated')
+        )
+        described_class.ticket_escalated(ticket)
+      end
+    end
+  end
+
+  describe 'error handling' do
+    before do
+      Escalated::EscalatedSetting.set('broadcasting_enabled', '1')
+    end
+
+    it 'catches and logs errors without raising' do
+      allow(ActionCable.server).to receive(:broadcast).and_raise(StandardError, 'Connection refused')
+      expect(Rails.logger).to receive(:warn).with(/Failed to broadcast/)
+      expect { described_class.ticket_created(ticket) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Escalated::Broadcasting` module for ActionCable real-time events
- Opt-in config via `broadcasting_enabled` setting (disabled by default)
- Channel authorization: `TicketChannel` (agents/admins/requesters), `AgentChannel` (agents/admins only)
- Broadcasts on: ticket created/updated/status changed, reply created, ticket assigned, ticket escalated
- Integrated into `TicketService` for automatic broadcasting on all core events
- Error handling prevents broadcast failures from disrupting normal operations

## Test plan
- [ ] Verify broadcasting is disabled by default
- [ ] Verify no broadcasts when disabled
- [ ] Verify correct channels receive correct events when enabled
- [ ] Verify ticket_status_changed includes old/new status
- [ ] Verify error handling logs warnings without raising