### PR TITLE
Add advanced reporting with percentiles, cohort analysis, and exports

### DIFF
--- a/app/controllers/escalated/admin/advanced_reports_controller.rb
+++ b/app/controllers/escalated/admin/advanced_reports_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Admin
+    class AdvancedReportsController < Escalated::ApplicationController
+      before_action :require_admin!
+      before_action :set_period
+
+      def sla_trends
+        data = reporting_service.sla_breach_trends
+        render_report('Escalated/Admin/Reports/SlaTrends', data)
+      end
+
+      def frt_distribution
+        data = reporting_service.frt_distribution
+        render_report('Escalated/Admin/Reports/FrtDistribution', data)
+      end
+
+      def frt_trends
+        data = reporting_service.frt_trends
+        render_report('Escalated/Admin/Reports/FrtTrends', data)
+      end
+
+      def frt_by_agent
+        data = reporting_service.frt_by_agent
+        render_report('Escalated/Admin/Reports/FrtByAgent', data)
+      end
+
+      def resolution_distribution
+        data = reporting_service.resolution_time_distribution
+        render_report('Escalated/Admin/Reports/ResolutionDistribution', data)
+      end
+
+      def resolution_trends
+        data = reporting_service.resolution_time_trends
+        render_report('Escalated/Admin/Reports/ResolutionTrends', data)
+      end
+
+      def agent_ranking
+        data = reporting_service.agent_performance_ranking
+        render_report('Escalated/Admin/Reports/AgentRanking', data)
+      end
+
+      def cohort
+        dimension = params[:dimension] || 'department'
+        data = reporting_service.cohort_analysis(dimension: dimension)
+        render_report('Escalated/Admin/Reports/Cohort', data, dimension: dimension)
+      end
+
+      def comparison
+        data = reporting_service.period_comparison
+        render_report('Escalated/Admin/Reports/Comparison', data)
+      end
+
+      def export
+        report_type = params[:report_type]
+        format = params[:export_format] || 'csv'
+        export_service = Escalated::ExportService.new(from: @period_start, to: @period_end)
+
+        content = if params[:dimension].present?
+                    format == 'json' ? export_service.export_cohort_json(params[:dimension]) : export_service.export_cohort_csv(params[:dimension])
+                  else
+                    format == 'json' ? export_service.export_json(report_type) : export_service.export_csv(report_type)
+                  end
+
+        content_type = format == 'json' ? 'application/json' : 'text/csv'
+        filename = "#{report_type || 'cohort'}_#{Time.current.strftime('%Y%m%d')}.#{format}"
+
+        send_data content, filename: filename, type: content_type, disposition: 'attachment'
+      end
+
+      private
+
+      def set_period
+        @period_start = parse_date(params[:from]) || 30.days.ago.beginning_of_day
+        @period_end = parse_date(params[:to]) || Time.current.end_of_day
+      end
+
+      def parse_date(value)
+        return nil if value.blank?
+
+        Time.zone.parse(value)
+      rescue ArgumentError
+        nil
+      end
+
+      def reporting_service
+        @reporting_service ||= Escalated::ReportingService.new(from: @period_start, to: @period_end)
+      end
+
+      def render_report(component, data, extra = {})
+        render_page component, {
+          data: data,
+          filters: { from: @period_start.iso8601, to: @period_end.iso8601 }
+        }.merge(extra)
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/advanced_reports_controller.rb
+++ b/app/controllers/escalated/admin/advanced_reports_controller.rb
@@ -58,7 +58,11 @@ module Escalated
         export_service = Escalated::ExportService.new(from: @period_start, to: @period_end)
 
         content = if params[:dimension].present?
-                    format == 'json' ? export_service.export_cohort_json(params[:dimension]) : export_service.export_cohort_csv(params[:dimension])
+                    if format == 'json'
+                      export_service.export_cohort_json(params[:dimension])
+                    else
+                      export_service.export_cohort_csv(params[:dimension])
+                    end
                   else
                     format == 'json' ? export_service.export_json(report_type) : export_service.export_csv(report_type)
                   end

--- a/app/services/escalated/export_service.rb
+++ b/app/services/escalated/export_service.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'json'
+
+module Escalated
+  class ExportService
+    EXPORTABLE_REPORTS = %w[
+      sla_breach_trends frt_distribution frt_trends frt_by_agent
+      resolution_time_distribution resolution_time_trends
+      agent_performance_ranking period_comparison
+    ].freeze
+
+    def initialize(from:, to:)
+      @reporting = ReportingService.new(from: from, to: to)
+    end
+
+    def export_csv(report_type)
+      validate_report_type!(report_type)
+      data = @reporting.public_send(report_type)
+      rows = flatten_for_csv(data, report_type)
+      generate_csv(rows)
+    end
+
+    def export_json(report_type)
+      validate_report_type!(report_type)
+      data = @reporting.public_send(report_type)
+      JSON.pretty_generate(data)
+    end
+
+    def export_cohort_csv(dimension)
+      data = @reporting.cohort_analysis(dimension: dimension)
+      rows = flatten_for_csv(data, 'cohort')
+      generate_csv(rows)
+    end
+
+    def export_cohort_json(dimension)
+      data = @reporting.cohort_analysis(dimension: dimension)
+      JSON.pretty_generate(data)
+    end
+
+    private
+
+    def validate_report_type!(report_type)
+      return if EXPORTABLE_REPORTS.include?(report_type.to_s)
+
+      raise ArgumentError, "Unknown report type: #{report_type}"
+    end
+
+    def flatten_for_csv(data, report_type)
+      case report_type.to_s
+      when 'sla_breach_trends', 'frt_trends', 'resolution_time_trends'
+        data.is_a?(Array) ? data.map { |row| flatten_hash(row) } : [flatten_hash(data)]
+      when 'frt_by_agent', 'agent_performance_ranking'
+        data.is_a?(Array) ? data.map { |row| flatten_hash(row) } : [flatten_hash(data)]
+      when 'frt_distribution', 'resolution_time_distribution'
+        return [flatten_hash(data[:stats]).merge(flatten_hash(data[:percentiles] || {}))] if data.is_a?(Hash)
+
+        [flatten_hash(data)]
+      when 'period_comparison'
+        if data.is_a?(Hash)
+          [
+            flatten_hash(data[:current] || {}).transform_keys { |k| "current_#{k}" }
+                                              .merge(flatten_hash(data[:previous] || {}).transform_keys do |k|
+                                                       "previous_#{k}"
+                                                     end)
+                                              .merge(flatten_hash(data[:changes] || {}).transform_keys do |k|
+                                                       "change_#{k}"
+                                                     end)
+          ]
+        else
+          [flatten_hash(data)]
+        end
+      when 'cohort'
+        data.is_a?(Array) ? data.map { |row| flatten_hash(row) } : [flatten_hash(data)]
+      else
+        data.is_a?(Array) ? data.map { |row| flatten_hash(row) } : [flatten_hash(data)]
+      end
+    end
+
+    def flatten_hash(hash, prefix = nil)
+      return {} unless hash.is_a?(Hash)
+
+      hash.each_with_object({}) do |(key, value), result|
+        full_key = prefix ? "#{prefix}_#{key}" : key.to_s
+        if value.is_a?(Hash)
+          result.merge!(flatten_hash(value, full_key))
+        else
+          result[full_key] = value
+        end
+      end
+    end
+
+    def generate_csv(rows)
+      return '' if rows.empty?
+
+      headers = rows.flat_map(&:keys).uniq
+      CSV.generate do |csv|
+        csv << headers
+        rows.each do |row|
+          csv << headers.map { |h| row[h] }
+        end
+      end
+    end
+  end
+end

--- a/app/services/escalated/reporting_service.rb
+++ b/app/services/escalated/reporting_service.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+module Escalated
+  class ReportingService
+    def initialize(from:, to:)
+      @from = from
+      @to = to
+      @tickets = Escalated::Ticket.where(created_at: @from..@to)
+    end
+
+    # SLA breach trends over time
+    def sla_breach_trends
+      date_series.map do |date|
+        day_range = date.all_day
+        day_tickets = Escalated::Ticket.where(created_at: ..date.end_of_day)
+        {
+          date: date.strftime('%Y-%m-%d'),
+          frt_breaches: day_tickets.where(sla_breached: true, first_response_at: nil)
+                        .where(sla_first_response_due_at: day_range).count,
+          resolution_breaches: day_tickets.where(sla_breached: true, resolved_at: nil)
+                               .where(sla_resolution_due_at: day_range).count,
+          total_breaches: day_tickets.where(sla_breached: true).where(updated_at: day_range).count
+        }
+      end
+    end
+
+    # First response time distribution with buckets and percentiles
+    def frt_distribution
+      values = frt_values
+      build_distribution(values, 'hours')
+    end
+
+    # Daily FRT trend averages
+    def frt_trends
+      date_series.map do |date|
+        day_range = date.all_day
+        frts = Escalated::Ticket.where(first_response_at: day_range)
+                                .where.not(first_response_at: nil)
+                                .pluck(:first_response_at, :created_at)
+                                .map { |fr, cr| (fr - cr) / 3600.0 }
+        {
+          date: date.strftime('%Y-%m-%d'),
+          avg_hours: safe_avg(frts),
+          count: frts.size,
+          percentiles: frts.any? ? percentiles(frts) : {}
+        }
+      end
+    end
+
+    # FRT broken down by agent
+    def frt_by_agent
+      tickets = @tickets.where.not(first_response_at: nil, assigned_to: nil)
+      grouped = tickets.pluck(:assigned_to, :first_response_at, :created_at).group_by(&:first)
+      grouped.filter_map do |agent_id, rows|
+        frts = rows.map { |_, fr, cr| (fr - cr) / 3600.0 }
+        agent = Escalated.configuration.user_model.find_by(id: agent_id)
+        next unless agent
+
+        {
+          agent_id: agent_id,
+          agent_name: agent.respond_to?(:name) ? agent.name : agent.email,
+          avg_hours: (frts.sum / frts.size).round(2),
+          count: frts.size,
+          percentiles: percentiles(frts)
+        }
+      end.sort_by { |a| a[:avg_hours] }
+    end
+
+    # Resolution time distribution
+    def resolution_time_distribution
+      tickets = @tickets.where.not(resolved_at: nil)
+      values = tickets.pluck(:resolved_at, :created_at).map { |r, c| ((r - c) / 3600.0).round(2) }
+      build_distribution(values, 'hours')
+    end
+
+    # Daily resolution time trends
+    def resolution_time_trends
+      date_series.map do |date|
+        day_range = date.all_day
+        times = Escalated::Ticket.where(resolved_at: day_range)
+                                 .where.not(resolved_at: nil)
+                                 .pluck(:resolved_at, :created_at)
+                                 .map { |r, c| (r - c) / 3600.0 }
+        {
+          date: date.strftime('%Y-%m-%d'),
+          avg_hours: safe_avg(times),
+          count: times.size,
+          percentiles: times.any? ? percentiles(times) : {}
+        }
+      end
+    end
+
+    # Agent performance ranking with composite score
+    def agent_performance_ranking
+      agent_ids = @tickets.where.not(assigned_to: nil).distinct.pluck(:assigned_to)
+      rankings = agent_ids.filter_map do |agent_id|
+        agent = Escalated.configuration.user_model.find_by(id: agent_id)
+        next unless agent
+
+        build_agent_ranking(agent_id, agent)
+      end
+      rankings.sort_by { |r| -(r[:composite_score] || 0) }
+    end
+
+    # Cohort analysis by tag, department, channel, or type
+    def cohort_analysis(dimension:)
+      case dimension.to_s
+      when 'tag' then cohort_by_tag
+      when 'department' then cohort_by_department
+      when 'channel' then cohort_by_channel
+      when 'type' then cohort_by_type
+      else { error: "Unknown dimension: #{dimension}" }
+      end
+    end
+
+    # Compare current period vs previous period of same length
+    def period_comparison
+      duration = @to - @from
+      prev_from = @from - duration
+      prev_to = @from
+      current = period_stats(@from, @to)
+      previous = period_stats(prev_from, prev_to)
+      { current: current, previous: previous, changes: calculate_changes(current, previous) }
+    end
+
+    private
+
+    def date_series
+      days = ((@to.to_date - @from.to_date).to_i + 1).clamp(1, 90)
+      (0...days).map { |i| @from.to_date + i.days }
+    end
+
+    def frt_values
+      @tickets.where.not(first_response_at: nil)
+              .pluck(:first_response_at, :created_at)
+              .map { |fr, cr| ((fr - cr) / 3600.0).round(2) }
+    end
+
+    def safe_avg(values)
+      return nil if values.empty?
+
+      (values.sum / values.size).round(2)
+    end
+
+    def percentiles(values)
+      sorted = values.sort
+      return {} if sorted.empty?
+
+      { p50: pct(sorted, 50), p75: pct(sorted, 75), p90: pct(sorted, 90),
+        p95: pct(sorted, 95), p99: pct(sorted, 99) }
+    end
+
+    def pct(sorted, p)
+      return sorted.first.round(2) if sorted.size == 1
+
+      k = (p / 100.0 * (sorted.size - 1))
+      f = k.floor
+      c = k.ceil
+      return sorted[f].round(2) if f == c
+
+      (sorted[f] + ((k - f) * (sorted[c] - sorted[f]))).round(2)
+    end
+
+    def build_distribution(values, unit)
+      return { buckets: [], stats: {} } if values.empty?
+
+      sorted = values.sort
+      {
+        buckets: distribution_buckets(sorted),
+        stats: { min: sorted.first, max: sorted.last, avg: safe_avg(sorted),
+                 median: pct(sorted, 50), count: sorted.size, unit: unit },
+        percentiles: percentiles(sorted)
+      }
+    end
+
+    def distribution_buckets(sorted)
+      return [] if sorted.empty?
+
+      max_val = sorted.last
+      bucket_size = [max_val / 10.0, 1].max.ceil
+      buckets = []
+      (0..max_val.ceil).step(bucket_size) do |start|
+        range_end = start + bucket_size
+        count = sorted.count { |v| v >= start && v < range_end }
+        buckets << { range: "#{start}-#{range_end}", count: count } if count.positive?
+      end
+      buckets
+    end
+
+    def calculate_composite_score(resolution_rate:, avg_frt:, avg_resolution:, avg_csat:)
+      score = 0.0
+      weights = 0.0
+      if resolution_rate
+        score += (resolution_rate / 100.0) * 30
+        weights += 30
+      end
+      if avg_frt&.positive?
+        score += [1.0 - (avg_frt / 24.0), 0].max * 25
+        weights += 25
+      end
+      if avg_resolution&.positive?
+        score += [1.0 - (avg_resolution / 72.0), 0].max * 25
+        weights += 25
+      end
+      if avg_csat
+        score += (avg_csat / 5.0) * 20
+        weights += 20
+      end
+      return 0 if weights.zero?
+
+      ((score / weights) * 100).round(1)
+    end
+
+    def build_agent_ranking(agent_id, agent)
+      agent_tickets = @tickets.where(assigned_to: agent_id)
+      resolved = agent_tickets.where.not(resolved_at: nil)
+      frts = agent_tickets.where.not(first_response_at: nil)
+                          .pluck(:first_response_at, :created_at).map { |fr, cr| (fr - cr) / 3600.0 }
+      res_times = resolved.pluck(:resolved_at, :created_at).map { |r, c| (r - c) / 3600.0 }
+      csat = Escalated::SatisfactionRating.joins(:ticket)
+                                          .where(Escalated.table_name('tickets') => { assigned_to: agent_id })
+                                          .where(created_at: @from..@to)
+      resolution_rate = agent_tickets.any? ? (resolved.count.to_f / agent_tickets.count * 100).round(1) : 0
+      avg_frt = safe_avg(frts)
+      avg_res = safe_avg(res_times)
+      avg_csat_val = csat.any? ? csat.average(:rating).to_f.round(2) : nil
+
+      {
+        agent_id: agent_id,
+        agent_name: agent.respond_to?(:name) ? agent.name : agent.email,
+        total_tickets: agent_tickets.count, resolved_count: resolved.count,
+        resolution_rate: resolution_rate, avg_frt_hours: avg_frt,
+        avg_resolution_hours: avg_res, avg_csat: avg_csat_val,
+        composite_score: calculate_composite_score(
+          resolution_rate: resolution_rate, avg_frt: avg_frt,
+          avg_resolution: avg_res, avg_csat: avg_csat_val
+        )
+      }
+    end
+
+    def cohort_by_tag
+      Escalated::Tag.all.map do |tag|
+        build_cohort_stats(tag.name, @tickets.joins(:tags).where(Escalated.table_name('tags') => { id: tag.id }))
+      end
+    end
+
+    def cohort_by_department
+      Escalated::Department.all.map { |dept| build_cohort_stats(dept.name, @tickets.where(department_id: dept.id)) }
+    end
+
+    def cohort_by_channel
+      @tickets.distinct.pluck(:channel).compact.map { |ch| build_cohort_stats(ch, @tickets.where(channel: ch)) }
+    end
+
+    def cohort_by_type
+      @tickets.distinct.pluck(:ticket_type).compact.map { |t| build_cohort_stats(t, @tickets.where(ticket_type: t)) }
+    end
+
+    def build_cohort_stats(name, scope)
+      resolved = scope.where.not(resolved_at: nil)
+      res_times = resolved.pluck(:resolved_at, :created_at).map { |r, c| (r - c) / 3600.0 }
+      frts = scope.where.not(first_response_at: nil)
+                  .pluck(:first_response_at, :created_at).map { |fr, cr| (fr - cr) / 3600.0 }
+      {
+        name: name, total: scope.count, resolved: resolved.count,
+        resolution_rate: scope.any? ? (resolved.count.to_f / scope.count * 100).round(1) : 0,
+        avg_resolution_hours: safe_avg(res_times), avg_frt_hours: safe_avg(frts),
+        percentiles: { resolution: res_times.any? ? percentiles(res_times) : {},
+                       frt: frts.any? ? percentiles(frts) : {} }
+      }
+    end
+
+    def period_stats(from, to)
+      tickets = Escalated::Ticket.where(created_at: from..to)
+      resolved = tickets.where.not(resolved_at: nil)
+      res_times = resolved.pluck(:resolved_at, :created_at).map { |r, c| (r - c) / 3600.0 }
+      frts = tickets.where.not(first_response_at: nil)
+                    .pluck(:first_response_at, :created_at).map { |fr, cr| (fr - cr) / 3600.0 }
+      {
+        total_created: tickets.count, total_resolved: resolved.count,
+        resolution_rate: tickets.any? ? (resolved.count.to_f / tickets.count * 100).round(1) : 0,
+        avg_frt_hours: safe_avg(frts), avg_resolution_hours: safe_avg(res_times),
+        sla_breaches: tickets.where(sla_breached: true).count,
+        percentiles: { resolution: res_times.any? ? percentiles(res_times) : {},
+                       frt: frts.any? ? percentiles(frts) : {} }
+      }
+    end
+
+    def calculate_changes(current, previous)
+      %i[total_created total_resolved resolution_rate avg_frt_hours avg_resolution_hours sla_breaches].to_h do |key|
+        cur = current[key].to_f
+        prev_val = previous[key].to_f
+        change = if prev_val.zero?
+                   cur.positive? ? 100.0 : 0.0
+                 else
+                   ((cur - prev_val) / prev_val * 100).round(1)
+                 end
+        [key, change]
+      end
+    end
+  end
+end

--- a/app/services/escalated/reporting_service.rb
+++ b/app/services/escalated/reporting_service.rb
@@ -51,7 +51,7 @@ module Escalated
     def frt_by_agent
       tickets = @tickets.where.not(first_response_at: nil, assigned_to: nil)
       grouped = tickets.pluck(:assigned_to, :first_response_at, :created_at).group_by(&:first)
-      grouped.filter_map do |agent_id, rows|
+      results = grouped.filter_map do |agent_id, rows|
         frts = rows.map { |_, fr, cr| (fr - cr) / 3600.0 }
         agent = Escalated.configuration.user_model.find_by(id: agent_id)
         next unless agent
@@ -63,7 +63,8 @@ module Escalated
           count: frts.size,
           percentiles: percentiles(frts)
         }
-      end.sort_by { |a| a[:avg_hours] }
+      end
+      results.sort_by { |a| a[:avg_hours] }
     end
 
     # Resolution time distribution

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,21 @@ Escalated::Engine.routes.draw do
     end
     get :reports, to: 'reports#index'
     get 'reports/dashboard', to: 'reports#dashboard', as: :reports_dashboard
+
+    # Advanced reporting endpoints
+    scope 'reports/advanced', controller: :advanced_reports do
+      get :sla_trends, as: :reports_sla_trends
+      get :frt_distribution, as: :reports_frt_distribution
+      get :frt_trends, as: :reports_frt_trends
+      get :frt_by_agent, as: :reports_frt_by_agent
+      get :resolution_distribution, as: :reports_resolution_distribution
+      get :resolution_trends, as: :reports_resolution_trends
+      get :agent_ranking, as: :reports_agent_ranking
+      get :cohort, as: :reports_cohort
+      get :comparison, as: :reports_comparison
+      get :export, as: :reports_export
+    end
+
     get :settings, to: 'settings#index'
     post :settings, to: 'settings#update'
 

--- a/spec/services/escalated/export_service_spec.rb
+++ b/spec/services/escalated/export_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Escalated::ExportService do
+  let(:from) { 30.days.ago.beginning_of_day }
+  let(:to) { Time.current.end_of_day }
+  let(:service) { described_class.new(from: from, to: to) }
+
+  before do
+    @agent = create(:user)
+    create(:escalated_ticket,
+           assigned_to: @agent.id,
+           first_response_at: 2.hours.ago,
+           resolved_at: 1.hour.ago,
+           created_at: 5.days.ago)
+  end
+
+  describe "#export_csv" do
+    Escalated::ExportService::EXPORTABLE_REPORTS.each do |report_type|
+      it "exports #{report_type} as CSV" do
+        result = service.export_csv(report_type)
+        expect(result).to be_a(String)
+      end
+    end
+
+    it "raises for unknown report type" do
+      expect { service.export_csv("nonexistent") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#export_json" do
+    Escalated::ExportService::EXPORTABLE_REPORTS.each do |report_type|
+      it "exports #{report_type} as JSON" do
+        result = service.export_json(report_type)
+        expect { JSON.parse(result) }.not_to raise_error
+      end
+    end
+
+    it "raises for unknown report type" do
+      expect { service.export_json("nonexistent") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#export_cohort_csv" do
+    %w[department channel type].each do |dimension|
+      it "exports #{dimension} cohort as CSV" do
+        result = service.export_cohort_csv(dimension)
+        expect(result).to be_a(String)
+      end
+    end
+  end
+
+  describe "#export_cohort_json" do
+    %w[department channel type].each do |dimension|
+      it "exports #{dimension} cohort as JSON" do
+        result = service.export_cohort_json(dimension)
+        expect { JSON.parse(result) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/escalated/export_service_spec.rb
+++ b/spec/services/escalated/export_service_spec.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Escalated::ExportService do
   let(:from) { 30.days.ago.beginning_of_day }
   let(:to) { Time.current.end_of_day }
   let(:service) { described_class.new(from: from, to: to) }
 
+  let(:agent) { create(:user) }
+
   before do
-    @agent = create(:user)
     create(:escalated_ticket,
-           assigned_to: @agent.id,
+           assigned_to: agent.id,
            first_response_at: 2.hours.ago,
            resolved_at: 1.hour.ago,
            created_at: 5.days.ago)
   end
 
-  describe "#export_csv" do
+  describe '#export_csv' do
     Escalated::ExportService::EXPORTABLE_REPORTS.each do |report_type|
       it "exports #{report_type} as CSV" do
         result = service.export_csv(report_type)
@@ -24,12 +25,12 @@ RSpec.describe Escalated::ExportService do
       end
     end
 
-    it "raises for unknown report type" do
-      expect { service.export_csv("nonexistent") }.to raise_error(ArgumentError)
+    it 'raises for unknown report type' do
+      expect { service.export_csv('nonexistent') }.to raise_error(ArgumentError)
     end
   end
 
-  describe "#export_json" do
+  describe '#export_json' do
     Escalated::ExportService::EXPORTABLE_REPORTS.each do |report_type|
       it "exports #{report_type} as JSON" do
         result = service.export_json(report_type)
@@ -37,12 +38,12 @@ RSpec.describe Escalated::ExportService do
       end
     end
 
-    it "raises for unknown report type" do
-      expect { service.export_json("nonexistent") }.to raise_error(ArgumentError)
+    it 'raises for unknown report type' do
+      expect { service.export_json('nonexistent') }.to raise_error(ArgumentError)
     end
   end
 
-  describe "#export_cohort_csv" do
+  describe '#export_cohort_csv' do
     %w[department channel type].each do |dimension|
       it "exports #{dimension} cohort as CSV" do
         result = service.export_cohort_csv(dimension)
@@ -51,7 +52,7 @@ RSpec.describe Escalated::ExportService do
     end
   end
 
-  describe "#export_cohort_json" do
+  describe '#export_cohort_json' do
     %w[department channel type].each do |dimension|
       it "exports #{dimension} cohort as JSON" do
         result = service.export_cohort_json(dimension)

--- a/spec/services/escalated/reporting_service_spec.rb
+++ b/spec/services/escalated/reporting_service_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Escalated::ReportingService do
+  let(:from) { 30.days.ago.beginning_of_day }
+  let(:to) { Time.current.end_of_day }
+  let(:service) { described_class.new(from: from, to: to) }
+
+  before do
+    # Create test tickets with various attributes
+    @agent = create(:user)
+    @department = create(:escalated_department)
+    @tag = create(:escalated_tag, name: "billing")
+
+    @ticket1 = create(:escalated_ticket,
+                       assigned_to: @agent.id,
+                       department: @department,
+                       first_response_at: 2.hours.ago,
+                       resolved_at: 1.hour.ago,
+                       channel: "email",
+                       ticket_type: "question",
+                       created_at: 5.days.ago)
+    @ticket1.tags << @tag
+
+    @ticket2 = create(:escalated_ticket,
+                       assigned_to: @agent.id,
+                       department: @department,
+                       first_response_at: 4.hours.ago,
+                       resolved_at: nil,
+                       sla_breached: true,
+                       channel: "chat",
+                       ticket_type: "incident",
+                       created_at: 3.days.ago)
+
+    @ticket3 = create(:escalated_ticket,
+                       assigned_to: nil,
+                       first_response_at: nil,
+                       resolved_at: nil,
+                       created_at: 1.day.ago)
+  end
+
+  describe "#sla_breach_trends" do
+    it "returns daily breach data" do
+      result = service.sla_breach_trends
+      expect(result).to be_an(Array)
+      expect(result.first).to have_key(:date)
+      expect(result.first).to have_key(:total_breaches)
+    end
+  end
+
+  describe "#frt_distribution" do
+    it "returns distribution with buckets and percentiles" do
+      result = service.frt_distribution
+      expect(result).to have_key(:buckets)
+      expect(result).to have_key(:stats)
+      expect(result).to have_key(:percentiles)
+    end
+
+    it "includes p50 through p99 percentiles" do
+      result = service.frt_distribution
+      if result[:percentiles].any?
+        expect(result[:percentiles]).to have_key(:p50)
+        expect(result[:percentiles]).to have_key(:p75)
+        expect(result[:percentiles]).to have_key(:p90)
+        expect(result[:percentiles]).to have_key(:p95)
+        expect(result[:percentiles]).to have_key(:p99)
+      end
+    end
+  end
+
+  describe "#frt_trends" do
+    it "returns daily FRT averages" do
+      result = service.frt_trends
+      expect(result).to be_an(Array)
+      expect(result.first).to have_key(:date)
+      expect(result.first).to have_key(:avg_hours)
+    end
+  end
+
+  describe "#frt_by_agent" do
+    it "returns FRT grouped by agent" do
+      result = service.frt_by_agent
+      expect(result).to be_an(Array)
+      agent_data = result.find { |r| r[:agent_id] == @agent.id }
+      expect(agent_data).not_to be_nil
+      expect(agent_data).to have_key(:avg_hours)
+      expect(agent_data).to have_key(:percentiles)
+    end
+  end
+
+  describe "#resolution_time_distribution" do
+    it "returns resolution time distribution" do
+      result = service.resolution_time_distribution
+      expect(result).to have_key(:stats)
+      expect(result[:stats][:count]).to be >= 1
+    end
+  end
+
+  describe "#resolution_time_trends" do
+    it "returns daily resolution time averages" do
+      result = service.resolution_time_trends
+      expect(result).to be_an(Array)
+    end
+  end
+
+  describe "#agent_performance_ranking" do
+    it "ranks agents by composite score" do
+      result = service.agent_performance_ranking
+      expect(result).to be_an(Array)
+      agent_data = result.find { |r| r[:agent_id] == @agent.id }
+      expect(agent_data).not_to be_nil
+      expect(agent_data).to have_key(:composite_score)
+      expect(agent_data).to have_key(:resolution_rate)
+      expect(agent_data[:composite_score]).to be_a(Numeric)
+    end
+  end
+
+  describe "#cohort_analysis" do
+    it "analyzes by department" do
+      result = service.cohort_analysis(dimension: "department")
+      expect(result).to be_an(Array)
+      dept_data = result.find { |r| r[:name] == @department.name }
+      expect(dept_data).not_to be_nil
+      expect(dept_data[:total]).to be >= 1
+    end
+
+    it "analyzes by tag" do
+      result = service.cohort_analysis(dimension: "tag")
+      expect(result).to be_an(Array)
+    end
+
+    it "analyzes by channel" do
+      result = service.cohort_analysis(dimension: "channel")
+      expect(result).to be_an(Array)
+    end
+
+    it "analyzes by type" do
+      result = service.cohort_analysis(dimension: "type")
+      expect(result).to be_an(Array)
+    end
+
+    it "returns error for unknown dimension" do
+      result = service.cohort_analysis(dimension: "unknown")
+      expect(result).to have_key(:error)
+    end
+  end
+
+  describe "#period_comparison" do
+    it "compares current vs previous period" do
+      result = service.period_comparison
+      expect(result).to have_key(:current)
+      expect(result).to have_key(:previous)
+      expect(result).to have_key(:changes)
+      expect(result[:current]).to have_key(:total_created)
+      expect(result[:changes]).to have_key(:total_created)
+    end
+  end
+end

--- a/spec/services/escalated/reporting_service_spec.rb
+++ b/spec/services/escalated/reporting_service_spec.rb
@@ -1,47 +1,55 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Escalated::ReportingService do
   let(:from) { 30.days.ago.beginning_of_day }
   let(:to) { Time.current.end_of_day }
   let(:service) { described_class.new(from: from, to: to) }
 
-  before do
-    # Create test tickets with various attributes
-    @agent = create(:user)
-    @department = create(:escalated_department)
-    @tag = create(:escalated_tag, name: "billing")
+  let(:agent) { create(:user) }
+  let(:department) { create(:escalated_department) }
+  let(:tag) { create(:escalated_tag, name: 'billing') }
 
-    @ticket1 = create(:escalated_ticket,
-                       assigned_to: @agent.id,
-                       department: @department,
-                       first_response_at: 2.hours.ago,
-                       resolved_at: 1.hour.ago,
-                       channel: "email",
-                       ticket_type: "question",
-                       created_at: 5.days.ago)
-    @ticket1.tags << @tag
-
-    @ticket2 = create(:escalated_ticket,
-                       assigned_to: @agent.id,
-                       department: @department,
-                       first_response_at: 4.hours.ago,
-                       resolved_at: nil,
-                       sla_breached: true,
-                       channel: "chat",
-                       ticket_type: "incident",
-                       created_at: 3.days.ago)
-
-    @ticket3 = create(:escalated_ticket,
-                       assigned_to: nil,
-                       first_response_at: nil,
-                       resolved_at: nil,
-                       created_at: 1.day.ago)
+  let(:ticket1) do
+    create(:escalated_ticket,
+           assigned_to: agent.id,
+           department: department,
+           first_response_at: 2.hours.ago,
+           resolved_at: 1.hour.ago,
+           channel: 'email',
+           ticket_type: 'question',
+           created_at: 5.days.ago)
   end
 
-  describe "#sla_breach_trends" do
-    it "returns daily breach data" do
+  let(:ticket2) do
+    create(:escalated_ticket,
+           assigned_to: agent.id,
+           department: department,
+           first_response_at: 4.hours.ago,
+           resolved_at: nil,
+           sla_breached: true,
+           channel: 'chat',
+           ticket_type: 'incident',
+           created_at: 3.days.ago)
+  end
+
+  let(:ticket3) do
+    create(:escalated_ticket,
+           assigned_to: nil,
+           first_response_at: nil,
+           resolved_at: nil,
+           created_at: 1.day.ago)
+  end
+
+  before do
+    ticket1.tags << tag
+    ticket2
+    ticket3
+  end
+
+  describe '#sla_breach_trends' do
+    it 'returns daily breach data' do
       result = service.sla_breach_trends
       expect(result).to be_an(Array)
       expect(result.first).to have_key(:date)
@@ -49,15 +57,15 @@ RSpec.describe Escalated::ReportingService do
     end
   end
 
-  describe "#frt_distribution" do
-    it "returns distribution with buckets and percentiles" do
+  describe '#frt_distribution' do
+    it 'returns distribution with buckets and percentiles' do
       result = service.frt_distribution
       expect(result).to have_key(:buckets)
       expect(result).to have_key(:stats)
       expect(result).to have_key(:percentiles)
     end
 
-    it "includes p50 through p99 percentiles" do
+    it 'includes p50 through p99 percentiles' do
       result = service.frt_distribution
       if result[:percentiles].any?
         expect(result[:percentiles]).to have_key(:p50)
@@ -69,8 +77,8 @@ RSpec.describe Escalated::ReportingService do
     end
   end
 
-  describe "#frt_trends" do
-    it "returns daily FRT averages" do
+  describe '#frt_trends' do
+    it 'returns daily FRT averages' do
       result = service.frt_trends
       expect(result).to be_an(Array)
       expect(result.first).to have_key(:date)
@@ -78,37 +86,37 @@ RSpec.describe Escalated::ReportingService do
     end
   end
 
-  describe "#frt_by_agent" do
-    it "returns FRT grouped by agent" do
+  describe '#frt_by_agent' do
+    it 'returns FRT grouped by agent' do
       result = service.frt_by_agent
       expect(result).to be_an(Array)
-      agent_data = result.find { |r| r[:agent_id] == @agent.id }
+      agent_data = result.find { |r| r[:agent_id] == agent.id }
       expect(agent_data).not_to be_nil
       expect(agent_data).to have_key(:avg_hours)
       expect(agent_data).to have_key(:percentiles)
     end
   end
 
-  describe "#resolution_time_distribution" do
-    it "returns resolution time distribution" do
+  describe '#resolution_time_distribution' do
+    it 'returns resolution time distribution' do
       result = service.resolution_time_distribution
       expect(result).to have_key(:stats)
       expect(result[:stats][:count]).to be >= 1
     end
   end
 
-  describe "#resolution_time_trends" do
-    it "returns daily resolution time averages" do
+  describe '#resolution_time_trends' do
+    it 'returns daily resolution time averages' do
       result = service.resolution_time_trends
       expect(result).to be_an(Array)
     end
   end
 
-  describe "#agent_performance_ranking" do
-    it "ranks agents by composite score" do
+  describe '#agent_performance_ranking' do
+    it 'ranks agents by composite score' do
       result = service.agent_performance_ranking
       expect(result).to be_an(Array)
-      agent_data = result.find { |r| r[:agent_id] == @agent.id }
+      agent_data = result.find { |r| r[:agent_id] == agent.id }
       expect(agent_data).not_to be_nil
       expect(agent_data).to have_key(:composite_score)
       expect(agent_data).to have_key(:resolution_rate)
@@ -116,38 +124,38 @@ RSpec.describe Escalated::ReportingService do
     end
   end
 
-  describe "#cohort_analysis" do
-    it "analyzes by department" do
-      result = service.cohort_analysis(dimension: "department")
+  describe '#cohort_analysis' do
+    it 'analyzes by department' do
+      result = service.cohort_analysis(dimension: 'department')
       expect(result).to be_an(Array)
-      dept_data = result.find { |r| r[:name] == @department.name }
+      dept_data = result.find { |r| r[:name] == department.name }
       expect(dept_data).not_to be_nil
       expect(dept_data[:total]).to be >= 1
     end
 
-    it "analyzes by tag" do
-      result = service.cohort_analysis(dimension: "tag")
+    it 'analyzes by tag' do
+      result = service.cohort_analysis(dimension: 'tag')
       expect(result).to be_an(Array)
     end
 
-    it "analyzes by channel" do
-      result = service.cohort_analysis(dimension: "channel")
+    it 'analyzes by channel' do
+      result = service.cohort_analysis(dimension: 'channel')
       expect(result).to be_an(Array)
     end
 
-    it "analyzes by type" do
-      result = service.cohort_analysis(dimension: "type")
+    it 'analyzes by type' do
+      result = service.cohort_analysis(dimension: 'type')
       expect(result).to be_an(Array)
     end
 
-    it "returns error for unknown dimension" do
-      result = service.cohort_analysis(dimension: "unknown")
+    it 'returns error for unknown dimension' do
+      result = service.cohort_analysis(dimension: 'unknown')
       expect(result).to have_key(:error)
     end
   end
 
-  describe "#period_comparison" do
-    it "compares current vs previous period" do
+  describe '#period_comparison' do
+    it 'compares current vs previous period' do
       result = service.period_comparison
       expect(result).to have_key(:current)
       expect(result).to have_key(:previous)


### PR DESCRIPTION
## Summary
- Adds `ReportingService` with SLA breach trends, FRT distribution/trends/by-agent, resolution time distribution/trends, agent performance ranking with composite score, cohort analysis (by tag/dept/channel/type), period comparison, and percentile calculations (p50/p75/p90/p95/p99)
- Adds `ExportService` for CSV and JSON export of all report types
- Adds `AdvancedReportsController` with endpoints for each report view plus export

## Test plan
- [ ] Verify ReportingService specs pass with representative ticket data
- [ ] Verify ExportService specs produce valid CSV and JSON
- [ ] Test each advanced report endpoint returns expected data structure
- [ ] Confirm period comparison correctly calculates changes between periods