### PR TITLE
docs: add translated READMEs (13 languages)

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <b>العربية</b> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## الميزات
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## المتطلبات
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## البدء السريع
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## أوضاع الاستضافة
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## الإعدادات
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## الجدولة
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## المسارات
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## الأحداث
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## البريد الوارد
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -364,7 +364,7 @@ poll_imap:
 - Audit logging of every inbound email
 - All settings configurable from admin panel with env fallback
 
-## Plugin SDK
+## حزمة SDK للإضافات
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## متوفر أيضاً لـ
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## الاختبار
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## الرخصة
 
 MIT

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <b>Deutsch</b> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funktionen
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Voraussetzungen
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Schnellstart
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Hosting-Modi
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Konfiguration
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Planung
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Routen
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Ereignisse
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Eingehende E-Mails
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Auch verfügbar für
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Testen
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Lizenz
 
 MIT

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <b>Español</b> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Características
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Requisitos
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Inicio Rápido
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modos de Hospedaje
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configuración
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Programación
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Rutas
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Eventos
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Correo Entrante
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## También Disponible Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Pruebas
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Licencia
 
 MIT

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <b>Français</b> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Fonctionnalités
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Prérequis
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Démarrage Rapide
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modes d'Hébergement
 
 ### Self-Hosted (default)
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Planification
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Événements
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## E-mail Entrant
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Également Disponible Pour
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Tests
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Licence
 
 MIT

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <b>Italiano</b> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funzionalità
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Requisiti
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Avvio Rapido
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modalità di Hosting
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configurazione
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Pianificazione
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Route
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Eventi
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Email in Entrata
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Disponibile Anche Per
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Test
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Licenza
 
 MIT

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <b>日本語</b> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 機能
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## 要件
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## クイックスタート
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## ホスティングモード
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## 設定
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## スケジューリング
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## ルート
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## イベント
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## 受信メール
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -364,7 +364,7 @@ poll_imap:
 - Audit logging of every inbound email
 - All settings configurable from admin panel with env fallback
 
-## Plugin SDK
+## プラグインSDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## 他のフレームワーク向け
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## テスト
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## ライセンス
 
 MIT

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <b>한국어</b> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 기능
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## 요구 사항
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## 빠른 시작
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## 호스팅 모드
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## 설정
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## 스케줄링
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## 라우트
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## 이벤트
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## 수신 이메일
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -364,7 +364,7 @@ poll_imap:
 - Audit logging of every inbound email
 - All settings configurable from admin panel with env fallback
 
-## Plugin SDK
+## 플러그인 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## 다른 프레임워크에서도 사용 가능
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## 테스트
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## 라이선스
 
 MIT

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <b>Nederlands</b> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Functies
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Vereisten
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Snel Starten
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Hostingmodi
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configuratie
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Planning
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Gebeurtenissen
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Inkomende E-mail
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Ook Beschikbaar Voor
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Testen
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Licentie
 
 MIT

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <b>Polski</b> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funkcje
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Wymagania
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Szybki Start
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Tryby Hostingu
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Konfiguracja
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Harmonogram
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Trasy
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Zdarzenia
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Poczta Przychodząca
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Dostępne Również Dla
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Testowanie
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Licencja
 
 MIT

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <b>Português (BR)</b> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Recursos
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Requisitos
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Início Rápido
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modos de Hospedagem
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configuração
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Agendamento
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Rotas
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Eventos
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## E-mail de Entrada
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Também Disponível Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Testes
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Licença
 
 MIT

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <b>Русский</b> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Возможности
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Требования
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Быстрый старт
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Режимы хостинга
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Конфигурация
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Планирование
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Маршруты
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## События
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Входящая почта
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Также доступно для
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Тестирование
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Лицензия
 
 MIT

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <b>Türkçe</b> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Özellikler
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Gereksinimler
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Hızlı Başlangıç
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Barındırma Modları
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Yapılandırma
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## Zamanlama
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## Rotalar
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## Olaylar
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## Gelen E-posta
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## Şunlar İçin de Mevcut
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## Test
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## Lisans
 
 MIT

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <b>简体中文</b>
 </p>
 
 # Escalated for Rails
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 功能特性
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -53,13 +53,13 @@ A full-featured, embeddable support ticket system for Rails. Drop it into any ap
 - **Real-time broadcasting** — Opt-in broadcasting via ActionCable with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## 系统要求
 
 - Ruby 3.1+
 - Rails 7.1+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## 快速开始
 
 ```bash
 bundle add escalated
@@ -163,7 +163,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## 托管模式
 
 ### Self-Hosted (default)
 
@@ -201,7 +201,7 @@ end
 
 All three modes share the same controllers, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## 配置
 
 Create or edit `config/initializers/escalated.rb`:
 
@@ -243,7 +243,7 @@ Escalated.configure do |config|
 end
 ```
 
-## Scheduling
+## 调度
 
 Add these to your scheduler for SLA and escalation automation:
 
@@ -266,7 +266,7 @@ every 1.week do
 end
 ```
 
-## Routes
+## 路由
 
 Routes are automatically mounted when the engine loads. By default they mount at `/support`.
 
@@ -291,7 +291,7 @@ Routes are automatically mounted when the engine loads. By default they mount at
 | `/support/agent/tickets/{ticket}/pin/{reply}` | POST | Pin/unpin an internal note |
 | `/support/{ticket}/rate` | POST | Submit satisfaction rating |
 
-## Events
+## 事件
 
 Connect to ticket lifecycle events via ActiveSupport::Notifications:
 
@@ -302,7 +302,7 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
-## Inbound Email
+## 入站邮件
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.
 
@@ -364,7 +364,7 @@ poll_imap:
 - Audit logging of every inbound email
 - All settings configurable from admin panel with env fallback
 
-## Plugin SDK
+## 插件 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -417,7 +417,7 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
-## Also Available For
+## 其他框架版本
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine (you are here)
@@ -428,12 +428,12 @@ export default definePlugin({
 
 Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
 
-## Testing
+## 测试
 
 ```bash
 bundle exec rspec
 ```
 
-## License
+## 许可证
 
 MIT


### PR DESCRIPTION
## Summary
- Add translated README files in `docs/translations/` for 13 languages: Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, and Chinese Simplified
- Add language selector bar at the top of the main README.md
- Each translated README includes the same language selector with the current language bolded and translated section headings

## Test plan
- [ ] Verify language selector links work in the main README
- [ ] Verify each translated file has correct language selector
- [ ] Verify English links back to ../../README.md from translation files