### PR TITLE
feat: add 10 additional locales

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,0 +1,111 @@
+ar:
+  escalated:
+    ticket:
+      reply_sent: "تم إرسال الرد."
+      note_added: "تمت إضافة ملاحظة داخلية."
+      assigned: "تم تعيين التذكرة إلى %{name}."
+      unassigned: "تم إلغاء تعيين التذكرة."
+      status_updated: "تم تحديث الحالة إلى %{status}."
+      priority_updated: "تم تحديث الأولوية إلى %{priority}."
+      tags_updated: "تم تحديث الوسوم."
+      department_updated: "تم تغيير القسم إلى %{name}."
+      macro_applied: "تم تطبيق الماكرو \"%{name}\"."
+      following: "أنت تتابع التذكرة."
+      unfollowed: "تم إلغاء متابعة التذكرة."
+      only_internal_notes_pinned: "يمكن تثبيت الملاحظات الداخلية فقط."
+      updated: "تم تحديث التذكرة."
+      created: "تم إنشاء التذكرة بنجاح."
+      closed: "تم إغلاق التذكرة."
+      reopened: "تم إعادة فتح التذكرة."
+      customers_cannot_close: "لا يمكن للعملاء إغلاق التذاكر."
+      note_pinned: "تم تثبيت الملاحظة."
+      note_unpinned: "تم إلغاء تثبيت الملاحظة."
+    guest:
+      created: "تم إنشاء التذكرة بنجاح."
+      ticket_closed: "هذه التذكرة مغلقة."
+    bulk:
+      updated: "تم تحديث %{count} تذكرة (تذاكر)."
+    rating:
+      only_resolved_closed: "يمكنك تقييم التذاكر المحلولة أو المغلقة فقط."
+      already_rated: "تم تقييم هذه التذكرة بالفعل."
+      thanks: "شكرًا لك على ملاحظاتك!"
+    admin:
+      canned_response:
+        created: "تم إنشاء الرد الجاهز."
+        updated: "تم تحديث الرد الجاهز."
+        deleted: "تم حذف الرد الجاهز."
+      department:
+        created: "تم إنشاء القسم."
+        updated: "تم تحديث القسم."
+        deleted: "تم حذف القسم."
+      tag:
+        created: "تم إنشاء الوسم."
+        updated: "تم تحديث الوسم."
+        deleted: "تم حذف الوسم."
+      macro:
+        created: "تم إنشاء الماكرو."
+        updated: "تم تحديث الماكرو."
+        deleted: "تم حذف الماكرو."
+      escalation_rule:
+        created: "تم إنشاء قاعدة التصعيد."
+        updated: "تم تحديث قاعدة التصعيد."
+        deleted: "تم حذف قاعدة التصعيد."
+      sla_policy:
+        created: "تم إنشاء سياسة SLA."
+        updated: "تم تحديث سياسة SLA."
+        deleted: "تم حذف سياسة SLA."
+      settings:
+        updated: "تم تحديث الإعدادات بنجاح."
+      plugin:
+        uploaded: "تم رفع الإضافة بنجاح. يمكنك الآن تفعيلها."
+        upload_failed: "فشل رفع الإضافة: %{error}"
+        activated: "تم تفعيل الإضافة بنجاح."
+        activate_failed: "فشل تفعيل الإضافة: %{error}"
+        deactivated: "تم تعطيل الإضافة بنجاح."
+        deactivate_failed: "فشل تعطيل الإضافة: %{error}"
+        composer_delete: "لا يمكن حذف إضافات Composer. قم بإزالة الحزمة عبر Composer بدلاً من ذلك."
+        deleted: "تم حذف الإضافة بنجاح."
+        delete_failed: "فشل حذف الإضافة: %{error}"
+    middleware:
+      not_admin: "تم رفض الوصول."
+      not_agent: "تم رفض الوصول."
+      not_authorized: "ليس لديك صلاحية لتنفيذ هذا الإجراء."
+      not_found: "لم يتم العثور على المورد المطلوب."
+    inbound:
+      unknown_adapter: "محوّل غير معروف: %{adapter}"
+      verification_failed: "فشل التحقق"
+      internal_error: "خطأ داخلي"
+      disabled: "البريد الإلكتروني الوارد معطّل"
+    mailer:
+      new_ticket: "[%{reference}] تذكرة جديدة: %{subject}"
+      reply: "رد: [%{reference}] %{subject}"
+      assigned: "[%{reference}] تم تعيين التذكرة: %{subject}"
+      status_updated: "[%{reference}] تم تحديث الحالة: %{status}"
+      sla_breach: "[انتهاك SLA] [%{reference}] %{subject}"
+      escalated: "[تصعيد] [%{reference}] %{subject}"
+      resolved: "[%{reference}] تم حل التذكرة: %{subject}"
+    validation:
+      name_required: "الاسم مطلوب."
+      email_required: "البريد الإلكتروني مطلوب."
+      subject_required: "الموضوع مطلوب."
+      description_required: "الوصف مطلوب."
+    commands:
+      install:
+        installing: "تثبيت نظام تذاكر الدعم Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "تم نسخ عمليات الترحيل. قم بتشغيل `rails db:migrate` لتطبيقها."
+        inject_user_model: "app/models/user.rb (طرق أدوار Escalated)"
+        inject_skip: "تعذّر الحقن في نموذج المستخدم: %{error}"
+        inject_manual: "أضف هذه الطرق إلى نموذج المستخدم يدويًا:"
+        inject_agent: "escalated_agent? - تُرجع true لوكلاء الدعم"
+        inject_admin: "escalated_admin? - تُرجع true لمسؤولي الدعم"
+        inject_agents_scope: "self.escalated_agents - نطاق يُرجع جميع الوكلاء"
+        success: "تم تثبيت Escalated بنجاح!"
+        next_steps: "الخطوات التالية:"
+        step1: "1. قم بتشغيل `rails db:migrate`"
+        step2: "2. قم بتهيئة config/initializers/escalated.rb"
+        step3: "3. أضف طرق escalated_agent? و escalated_admin? إلى نموذج المستخدم"
+        step4: "4. ثبّت مكونات Vue: انسخ من vendor/escalated/resources/js/"
+        step5: "5. قم بإعداد محلل صفحات Inertia ليشمل صفحات Escalated"
+      guest_not_enabled: "تذاكر الضيوف غير مفعّلة."
+      ticket_not_found: "التذكرة غير موجودة."

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,111 @@
+it:
+  escalated:
+    ticket:
+      reply_sent: "Risposta inviata."
+      note_added: "Nota interna aggiunta."
+      assigned: "Ticket assegnato a %{name}."
+      unassigned: "Ticket non assegnato."
+      status_updated: "Stato aggiornato a %{status}."
+      priority_updated: "Priorità aggiornata a %{priority}."
+      tags_updated: "Tag aggiornati."
+      department_updated: "Reparto cambiato a %{name}."
+      macro_applied: "Macro \"%{name}\" applicata."
+      following: "Stai seguendo il ticket."
+      unfollowed: "Non segui più il ticket."
+      only_internal_notes_pinned: "Solo le note interne possono essere fissate."
+      updated: "Ticket aggiornato."
+      created: "Ticket creato con successo."
+      closed: "Ticket chiuso."
+      reopened: "Ticket riaperto."
+      customers_cannot_close: "I clienti non possono chiudere i ticket."
+      note_pinned: "Nota fissata."
+      note_unpinned: "Nota rimossa dai fissati."
+    guest:
+      created: "Ticket creato con successo."
+      ticket_closed: "Questo ticket è chiuso."
+    bulk:
+      updated: "%{count} ticket aggiornato/i."
+    rating:
+      only_resolved_closed: "Puoi valutare solo i ticket risolti o chiusi."
+      already_rated: "Questo ticket è già stato valutato."
+      thanks: "Grazie per il tuo feedback!"
+    admin:
+      canned_response:
+        created: "Risposta predefinita creata."
+        updated: "Risposta predefinita aggiornata."
+        deleted: "Risposta predefinita eliminata."
+      department:
+        created: "Reparto creato."
+        updated: "Reparto aggiornato."
+        deleted: "Reparto eliminato."
+      tag:
+        created: "Tag creato."
+        updated: "Tag aggiornato."
+        deleted: "Tag eliminato."
+      macro:
+        created: "Macro creata."
+        updated: "Macro aggiornata."
+        deleted: "Macro eliminata."
+      escalation_rule:
+        created: "Regola di escalation creata."
+        updated: "Regola di escalation aggiornata."
+        deleted: "Regola di escalation eliminata."
+      sla_policy:
+        created: "Policy SLA creata."
+        updated: "Policy SLA aggiornata."
+        deleted: "Policy SLA eliminata."
+      settings:
+        updated: "Impostazioni aggiornate con successo."
+      plugin:
+        uploaded: "Plugin caricato con successo. Ora puoi attivarlo."
+        upload_failed: "Caricamento del plugin fallito: %{error}"
+        activated: "Plugin attivato con successo."
+        activate_failed: "Attivazione del plugin fallita: %{error}"
+        deactivated: "Plugin disattivato con successo."
+        deactivate_failed: "Disattivazione del plugin fallita: %{error}"
+        composer_delete: "I plugin Composer non possono essere eliminati. Rimuovi il pacchetto tramite Composer."
+        deleted: "Plugin eliminato con successo."
+        delete_failed: "Eliminazione del plugin fallita: %{error}"
+    middleware:
+      not_admin: "Accesso negato."
+      not_agent: "Accesso negato."
+      not_authorized: "Non sei autorizzato a eseguire questa azione."
+      not_found: "La risorsa richiesta non è stata trovata."
+    inbound:
+      unknown_adapter: "Adattatore sconosciuto: %{adapter}"
+      verification_failed: "Verifica fallita"
+      internal_error: "Errore interno"
+      disabled: "L'email in entrata è disabilitata"
+    mailer:
+      new_ticket: "[%{reference}] Ticket creato: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Ticket assegnato: %{subject}"
+      status_updated: "[%{reference}] Stato aggiornato: %{status}"
+      sla_breach: "[VIOLAZIONE SLA] [%{reference}] %{subject}"
+      escalated: "[ESCALATO] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Ticket risolto: %{subject}"
+    validation:
+      name_required: "Il nome è obbligatorio."
+      email_required: "L'email è obbligatoria."
+      subject_required: "L'oggetto è obbligatorio."
+      description_required: "La descrizione è obbligatoria."
+    commands:
+      install:
+        installing: "Installazione del sistema di ticket di supporto Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migrazioni copiate. Esegui `rails db:migrate` per applicarle."
+        inject_user_model: "app/models/user.rb (metodi dei ruoli Escalated)"
+        inject_skip: "Impossibile iniettare nel modello User: %{error}"
+        inject_manual: "Aggiungi questi metodi manualmente al tuo modello User:"
+        inject_agent: "escalated_agent? - restituisce true per gli agenti di supporto"
+        inject_admin: "escalated_admin? - restituisce true per gli amministratori di supporto"
+        inject_agents_scope: "self.escalated_agents - scope che restituisce tutti gli agenti"
+        success: "Escalated installato con successo!"
+        next_steps: "Prossimi passi:"
+        step1: "1. Esegui `rails db:migrate`"
+        step2: "2. Configura config/initializers/escalated.rb"
+        step3: "3. Aggiungi i metodi escalated_agent? e escalated_admin? al tuo modello User"
+        step4: "4. Installa i componenti Vue: copia da vendor/escalated/resources/js/"
+        step5: "5. Configura il resolver delle pagine Inertia per includere le pagine Escalated"
+      guest_not_enabled: "I ticket per gli ospiti non sono abilitati."
+      ticket_not_found: "Ticket non trovato."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,111 @@
+ja:
+  escalated:
+    ticket:
+      reply_sent: "返信を送信しました。"
+      note_added: "内部メモを追加しました。"
+      assigned: "チケットを%{name}に割り当てました。"
+      unassigned: "チケットの割り当てを解除しました。"
+      status_updated: "ステータスを%{status}に更新しました。"
+      priority_updated: "優先度を%{priority}に更新しました。"
+      tags_updated: "タグを更新しました。"
+      department_updated: "部門を%{name}に変更しました。"
+      macro_applied: "マクロ「%{name}」を適用しました。"
+      following: "チケットをフォロー中です。"
+      unfollowed: "チケットのフォローを解除しました。"
+      only_internal_notes_pinned: "内部メモのみピン留めできます。"
+      updated: "チケットを更新しました。"
+      created: "チケットを正常に作成しました。"
+      closed: "チケットをクローズしました。"
+      reopened: "チケットを再開しました。"
+      customers_cannot_close: "顧客はチケットをクローズできません。"
+      note_pinned: "メモをピン留めしました。"
+      note_unpinned: "メモのピン留めを解除しました。"
+    guest:
+      created: "チケットを正常に作成しました。"
+      ticket_closed: "このチケットはクローズされています。"
+    bulk:
+      updated: "%{count}件のチケットを更新しました。"
+    rating:
+      only_resolved_closed: "解決済みまたはクローズ済みのチケットのみ評価できます。"
+      already_rated: "このチケットは既に評価されています。"
+      thanks: "フィードバックありがとうございます！"
+    admin:
+      canned_response:
+        created: "定型応答を作成しました。"
+        updated: "定型応答を更新しました。"
+        deleted: "定型応答を削除しました。"
+      department:
+        created: "部門を作成しました。"
+        updated: "部門を更新しました。"
+        deleted: "部門を削除しました。"
+      tag:
+        created: "タグを作成しました。"
+        updated: "タグを更新しました。"
+        deleted: "タグを削除しました。"
+      macro:
+        created: "マクロを作成しました。"
+        updated: "マクロを更新しました。"
+        deleted: "マクロを削除しました。"
+      escalation_rule:
+        created: "エスカレーションルールを作成しました。"
+        updated: "エスカレーションルールを更新しました。"
+        deleted: "エスカレーションルールを削除しました。"
+      sla_policy:
+        created: "SLAポリシーを作成しました。"
+        updated: "SLAポリシーを更新しました。"
+        deleted: "SLAポリシーを削除しました。"
+      settings:
+        updated: "設定を正常に更新しました。"
+      plugin:
+        uploaded: "プラグインを正常にアップロードしました。有効化できます。"
+        upload_failed: "プラグインのアップロードに失敗しました: %{error}"
+        activated: "プラグインを正常に有効化しました。"
+        activate_failed: "プラグインの有効化に失敗しました: %{error}"
+        deactivated: "プラグインを正常に無効化しました。"
+        deactivate_failed: "プラグインの無効化に失敗しました: %{error}"
+        composer_delete: "Composerプラグインは削除できません。代わりにComposer経由でパッケージを削除してください。"
+        deleted: "プラグインを正常に削除しました。"
+        delete_failed: "プラグインの削除に失敗しました: %{error}"
+    middleware:
+      not_admin: "アクセスが拒否されました。"
+      not_agent: "アクセスが拒否されました。"
+      not_authorized: "この操作を実行する権限がありません。"
+      not_found: "リクエストされたリソースが見つかりません。"
+    inbound:
+      unknown_adapter: "不明なアダプター: %{adapter}"
+      verification_failed: "検証に失敗しました"
+      internal_error: "内部エラー"
+      disabled: "受信メールは無効です"
+    mailer:
+      new_ticket: "[%{reference}] チケット作成: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] チケット割り当て: %{subject}"
+      status_updated: "[%{reference}] ステータス更新: %{status}"
+      sla_breach: "[SLA違反] [%{reference}] %{subject}"
+      escalated: "[エスカレーション] [%{reference}] %{subject}"
+      resolved: "[%{reference}] チケット解決: %{subject}"
+    validation:
+      name_required: "名前は必須です。"
+      email_required: "メールアドレスは必須です。"
+      subject_required: "件名は必須です。"
+      description_required: "説明は必須です。"
+    commands:
+      install:
+        installing: "Escalatedサポートチケットシステムをインストール"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "マイグレーションをコピーしました。`rails db:migrate`を実行して適用してください。"
+        inject_user_model: "app/models/user.rb (Escalatedロールメソッド)"
+        inject_skip: "Userモデルへの注入に失敗しました: %{error}"
+        inject_manual: "これらのメソッドをUserモデルに手動で追加してください:"
+        inject_agent: "escalated_agent? - サポートエージェントの場合trueを返す"
+        inject_admin: "escalated_admin? - サポート管理者の場合trueを返す"
+        inject_agents_scope: "self.escalated_agents - すべてのエージェントを返すスコープ"
+        success: "Escalatedを正常にインストールしました！"
+        next_steps: "次のステップ:"
+        step1: "1. `rails db:migrate`を実行"
+        step2: "2. config/initializers/escalated.rbを設定"
+        step3: "3. Userモデルにescalated_agent?とescalated_admin?メソッドを追加"
+        step4: "4. Vueコンポーネントをインストール: vendor/escalated/resources/js/からコピー"
+        step5: "5. EscalatedページをInertiaページリゾルバに設定"
+      guest_not_enabled: "ゲストチケットは有効になっていません。"
+      ticket_not_found: "チケットが見つかりません。"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,0 +1,111 @@
+ko:
+  escalated:
+    ticket:
+      reply_sent: "답변이 전송되었습니다."
+      note_added: "내부 메모가 추가되었습니다."
+      assigned: "티켓이 %{name}에게 할당되었습니다."
+      unassigned: "티켓 할당이 해제되었습니다."
+      status_updated: "상태가 %{status}(으)로 업데이트되었습니다."
+      priority_updated: "우선순위가 %{priority}(으)로 업데이트되었습니다."
+      tags_updated: "태그가 업데이트되었습니다."
+      department_updated: "부서가 %{name}(으)로 변경되었습니다."
+      macro_applied: "매크로 \"%{name}\"이(가) 적용되었습니다."
+      following: "티켓을 팔로우합니다."
+      unfollowed: "티켓 팔로우를 취소했습니다."
+      only_internal_notes_pinned: "내부 메모만 고정할 수 있습니다."
+      updated: "티켓이 업데이트되었습니다."
+      created: "티켓이 성공적으로 생성되었습니다."
+      closed: "티켓이 종료되었습니다."
+      reopened: "티켓이 다시 열렸습니다."
+      customers_cannot_close: "고객은 티켓을 종료할 수 없습니다."
+      note_pinned: "메모가 고정되었습니다."
+      note_unpinned: "메모 고정이 해제되었습니다."
+    guest:
+      created: "티켓이 성공적으로 생성되었습니다."
+      ticket_closed: "이 티켓은 종료되었습니다."
+    bulk:
+      updated: "%{count}개의 티켓이 업데이트되었습니다."
+    rating:
+      only_resolved_closed: "해결되었거나 종료된 티켓만 평가할 수 있습니다."
+      already_rated: "이 티켓은 이미 평가되었습니다."
+      thanks: "피드백 감사합니다!"
+    admin:
+      canned_response:
+        created: "정형 응답이 생성되었습니다."
+        updated: "정형 응답이 업데이트되었습니다."
+        deleted: "정형 응답이 삭제되었습니다."
+      department:
+        created: "부서가 생성되었습니다."
+        updated: "부서가 업데이트되었습니다."
+        deleted: "부서가 삭제되었습니다."
+      tag:
+        created: "태그가 생성되었습니다."
+        updated: "태그가 업데이트되었습니다."
+        deleted: "태그가 삭제되었습니다."
+      macro:
+        created: "매크로가 생성되었습니다."
+        updated: "매크로가 업데이트되었습니다."
+        deleted: "매크로가 삭제되었습니다."
+      escalation_rule:
+        created: "에스컬레이션 규칙이 생성되었습니다."
+        updated: "에스컬레이션 규칙이 업데이트되었습니다."
+        deleted: "에스컬레이션 규칙이 삭제되었습니다."
+      sla_policy:
+        created: "SLA 정책이 생성되었습니다."
+        updated: "SLA 정책이 업데이트되었습니다."
+        deleted: "SLA 정책이 삭제되었습니다."
+      settings:
+        updated: "설정이 성공적으로 업데이트되었습니다."
+      plugin:
+        uploaded: "플러그인이 성공적으로 업로드되었습니다. 이제 활성화할 수 있습니다."
+        upload_failed: "플러그인 업로드 실패: %{error}"
+        activated: "플러그인이 성공적으로 활성화되었습니다."
+        activate_failed: "플러그인 활성화 실패: %{error}"
+        deactivated: "플러그인이 성공적으로 비활성화되었습니다."
+        deactivate_failed: "플러그인 비활성화 실패: %{error}"
+        composer_delete: "Composer 플러그인은 삭제할 수 없습니다. 대신 Composer를 통해 패키지를 제거하세요."
+        deleted: "플러그인이 성공적으로 삭제되었습니다."
+        delete_failed: "플러그인 삭제 실패: %{error}"
+    middleware:
+      not_admin: "접근이 거부되었습니다."
+      not_agent: "접근이 거부되었습니다."
+      not_authorized: "이 작업을 수행할 권한이 없습니다."
+      not_found: "요청한 리소스를 찾을 수 없습니다."
+    inbound:
+      unknown_adapter: "알 수 없는 어댑터: %{adapter}"
+      verification_failed: "인증 실패"
+      internal_error: "내부 오류"
+      disabled: "수신 이메일이 비활성화되어 있습니다"
+    mailer:
+      new_ticket: "[%{reference}] 티켓 생성: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] 티켓 할당: %{subject}"
+      status_updated: "[%{reference}] 상태 업데이트: %{status}"
+      sla_breach: "[SLA 위반] [%{reference}] %{subject}"
+      escalated: "[에스컬레이션] [%{reference}] %{subject}"
+      resolved: "[%{reference}] 티켓 해결: %{subject}"
+    validation:
+      name_required: "이름은 필수입니다."
+      email_required: "이메일은 필수입니다."
+      subject_required: "제목은 필수입니다."
+      description_required: "설명은 필수입니다."
+    commands:
+      install:
+        installing: "Escalated 지원 티켓 시스템 설치"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "마이그레이션을 복사했습니다. `rails db:migrate`를 실행하여 적용하세요."
+        inject_user_model: "app/models/user.rb (Escalated 역할 메서드)"
+        inject_skip: "User 모델에 주입할 수 없습니다: %{error}"
+        inject_manual: "이 메서드를 User 모델에 수동으로 추가하세요:"
+        inject_agent: "escalated_agent? - 지원 에이전트인 경우 true 반환"
+        inject_admin: "escalated_admin? - 지원 관리자인 경우 true 반환"
+        inject_agents_scope: "self.escalated_agents - 모든 에이전트를 반환하는 스코프"
+        success: "Escalated가 성공적으로 설치되었습니다!"
+        next_steps: "다음 단계:"
+        step1: "1. `rails db:migrate` 실행"
+        step2: "2. config/initializers/escalated.rb 설정"
+        step3: "3. User 모델에 escalated_agent?와 escalated_admin? 메서드 추가"
+        step4: "4. Vue 컴포넌트 설치: vendor/escalated/resources/js/에서 복사"
+        step5: "5. Escalated 페이지를 포함하도록 Inertia 페이지 리졸버 설정"
+      guest_not_enabled: "게스트 티켓이 활성화되지 않았습니다."
+      ticket_not_found: "티켓을 찾을 수 없습니다."

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,111 @@
+nl:
+  escalated:
+    ticket:
+      reply_sent: "Antwoord verzonden."
+      note_added: "Interne notitie toegevoegd."
+      assigned: "Ticket toegewezen aan %{name}."
+      unassigned: "Ticket niet meer toegewezen."
+      status_updated: "Status bijgewerkt naar %{status}."
+      priority_updated: "Prioriteit bijgewerkt naar %{priority}."
+      tags_updated: "Tags bijgewerkt."
+      department_updated: "Afdeling gewijzigd naar %{name}."
+      macro_applied: "Macro \"%{name}\" toegepast."
+      following: "Je volgt dit ticket."
+      unfollowed: "Je volgt dit ticket niet meer."
+      only_internal_notes_pinned: "Alleen interne notities kunnen worden vastgezet."
+      updated: "Ticket bijgewerkt."
+      created: "Ticket succesvol aangemaakt."
+      closed: "Ticket gesloten."
+      reopened: "Ticket heropend."
+      customers_cannot_close: "Klanten kunnen tickets niet sluiten."
+      note_pinned: "Notitie vastgezet."
+      note_unpinned: "Notitie losgemaakt."
+    guest:
+      created: "Ticket succesvol aangemaakt."
+      ticket_closed: "Dit ticket is gesloten."
+    bulk:
+      updated: "%{count} ticket(s) bijgewerkt."
+    rating:
+      only_resolved_closed: "Je kunt alleen opgeloste of gesloten tickets beoordelen."
+      already_rated: "Dit ticket is al beoordeeld."
+      thanks: "Bedankt voor je feedback!"
+    admin:
+      canned_response:
+        created: "Standaardantwoord aangemaakt."
+        updated: "Standaardantwoord bijgewerkt."
+        deleted: "Standaardantwoord verwijderd."
+      department:
+        created: "Afdeling aangemaakt."
+        updated: "Afdeling bijgewerkt."
+        deleted: "Afdeling verwijderd."
+      tag:
+        created: "Tag aangemaakt."
+        updated: "Tag bijgewerkt."
+        deleted: "Tag verwijderd."
+      macro:
+        created: "Macro aangemaakt."
+        updated: "Macro bijgewerkt."
+        deleted: "Macro verwijderd."
+      escalation_rule:
+        created: "Escalatieregel aangemaakt."
+        updated: "Escalatieregel bijgewerkt."
+        deleted: "Escalatieregel verwijderd."
+      sla_policy:
+        created: "SLA-beleid aangemaakt."
+        updated: "SLA-beleid bijgewerkt."
+        deleted: "SLA-beleid verwijderd."
+      settings:
+        updated: "Instellingen succesvol bijgewerkt."
+      plugin:
+        uploaded: "Plugin succesvol geupload. Je kunt het nu activeren."
+        upload_failed: "Plugin upload mislukt: %{error}"
+        activated: "Plugin succesvol geactiveerd."
+        activate_failed: "Plugin activering mislukt: %{error}"
+        deactivated: "Plugin succesvol gedeactiveerd."
+        deactivate_failed: "Plugin deactivering mislukt: %{error}"
+        composer_delete: "Composer-plugins kunnen niet worden verwijderd. Verwijder het pakket via Composer."
+        deleted: "Plugin succesvol verwijderd."
+        delete_failed: "Plugin verwijdering mislukt: %{error}"
+    middleware:
+      not_admin: "Toegang geweigerd."
+      not_agent: "Toegang geweigerd."
+      not_authorized: "Je bent niet gemachtigd om deze actie uit te voeren."
+      not_found: "De gevraagde bron is niet gevonden."
+    inbound:
+      unknown_adapter: "Onbekende adapter: %{adapter}"
+      verification_failed: "Verificatie mislukt"
+      internal_error: "Interne fout"
+      disabled: "Inkomende e-mail is uitgeschakeld"
+    mailer:
+      new_ticket: "[%{reference}] Ticket aangemaakt: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Ticket toegewezen: %{subject}"
+      status_updated: "[%{reference}] Status bijgewerkt: %{status}"
+      sla_breach: "[SLA-SCHENDING] [%{reference}] %{subject}"
+      escalated: "[GEESCALEERD] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Ticket opgelost: %{subject}"
+    validation:
+      name_required: "Naam is verplicht."
+      email_required: "E-mailadres is verplicht."
+      subject_required: "Onderwerp is verplicht."
+      description_required: "Beschrijving is verplicht."
+    commands:
+      install:
+        installing: "Installeert het Escalated support ticket systeem"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migraties gekopieerd. Voer `rails db:migrate` uit om ze toe te passen."
+        inject_user_model: "app/models/user.rb (Escalated rolmethoden)"
+        inject_skip: "Kon niet injecteren in het User model: %{error}"
+        inject_manual: "Voeg deze methoden handmatig toe aan je User model:"
+        inject_agent: "escalated_agent? - geeft true terug voor supportmedewerkers"
+        inject_admin: "escalated_admin? - geeft true terug voor supportbeheerders"
+        inject_agents_scope: "self.escalated_agents - scope die alle medewerkers teruggeeft"
+        success: "Escalated succesvol geinstalleerd!"
+        next_steps: "Volgende stappen:"
+        step1: "1. Voer `rails db:migrate` uit"
+        step2: "2. Configureer config/initializers/escalated.rb"
+        step3: "3. Voeg escalated_agent? en escalated_admin? methoden toe aan je User model"
+        step4: "4. Installeer Vue componenten: kopieer van vendor/escalated/resources/js/"
+        step5: "5. Stel de Inertia page resolver in om Escalated paginas op te nemen"
+      guest_not_enabled: "Gasttickets zijn niet ingeschakeld."
+      ticket_not_found: "Ticket niet gevonden."

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,0 +1,111 @@
+pl:
+  escalated:
+    ticket:
+      reply_sent: "Odpowiedz wyslana."
+      note_added: "Notatka wewnetrzna dodana."
+      assigned: "Zgloszenie przypisane do %{name}."
+      unassigned: "Usunieto przypisanie zgloszenia."
+      status_updated: "Status zaktualizowany na %{status}."
+      priority_updated: "Priorytet zaktualizowany na %{priority}."
+      tags_updated: "Tagi zaktualizowane."
+      department_updated: "Dzial zmieniony na %{name}."
+      macro_applied: "Makro \"%{name}\" zastosowane."
+      following: "Obserwujesz zgloszenie."
+      unfollowed: "Przestales obserwowac zgloszenie."
+      only_internal_notes_pinned: "Tylko notatki wewnetrzne moga byc przypiete."
+      updated: "Zgloszenie zaktualizowane."
+      created: "Zgloszenie utworzone pomyslnie."
+      closed: "Zgloszenie zamkniete."
+      reopened: "Zgloszenie ponownie otwarte."
+      customers_cannot_close: "Klienci nie moga zamykac zgloszen."
+      note_pinned: "Notatka przypieta."
+      note_unpinned: "Notatka odpieta."
+    guest:
+      created: "Zgloszenie utworzone pomyslnie."
+      ticket_closed: "To zgloszenie jest zamkniete."
+    bulk:
+      updated: "Zaktualizowano %{count} zgloszen."
+    rating:
+      only_resolved_closed: "Mozesz oceniac tylko rozwiazane lub zamkniete zgloszenia."
+      already_rated: "To zgloszenie zostalo juz ocenione."
+      thanks: "Dziekujemy za opinie!"
+    admin:
+      canned_response:
+        created: "Gotowa odpowiedz utworzona."
+        updated: "Gotowa odpowiedz zaktualizowana."
+        deleted: "Gotowa odpowiedz usunieta."
+      department:
+        created: "Dzial utworzony."
+        updated: "Dzial zaktualizowany."
+        deleted: "Dzial usuniety."
+      tag:
+        created: "Tag utworzony."
+        updated: "Tag zaktualizowany."
+        deleted: "Tag usuniety."
+      macro:
+        created: "Makro utworzone."
+        updated: "Makro zaktualizowane."
+        deleted: "Makro usuniete."
+      escalation_rule:
+        created: "Regula eskalacji utworzona."
+        updated: "Regula eskalacji zaktualizowana."
+        deleted: "Regula eskalacji usunieta."
+      sla_policy:
+        created: "Polityka SLA utworzona."
+        updated: "Polityka SLA zaktualizowana."
+        deleted: "Polityka SLA usunieta."
+      settings:
+        updated: "Ustawienia zaktualizowane pomyslnie."
+      plugin:
+        uploaded: "Plugin przeslany pomyslnie. Mozesz go teraz aktywowac."
+        upload_failed: "Przesylanie pluginu nie powiodlo sie: %{error}"
+        activated: "Plugin aktywowany pomyslnie."
+        activate_failed: "Aktywacja pluginu nie powiodla sie: %{error}"
+        deactivated: "Plugin dezaktywowany pomyslnie."
+        deactivate_failed: "Dezaktywacja pluginu nie powiodla sie: %{error}"
+        composer_delete: "Pluginy Composer nie moga byc usuniete. Usun pakiet przez Composer."
+        deleted: "Plugin usuniety pomyslnie."
+        delete_failed: "Usuwanie pluginu nie powiodlo sie: %{error}"
+    middleware:
+      not_admin: "Odmowa dostepu."
+      not_agent: "Odmowa dostepu."
+      not_authorized: "Nie masz uprawnien do wykonania tej czynnosci."
+      not_found: "Zadany zasob nie zostal znaleziony."
+    inbound:
+      unknown_adapter: "Nieznany adapter: %{adapter}"
+      verification_failed: "Weryfikacja nie powiodla sie"
+      internal_error: "Blad wewnetrzny"
+      disabled: "Poczta przychodzaca jest wylaczona"
+    mailer:
+      new_ticket: "[%{reference}] Zgloszenie utworzone: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Zgloszenie przypisane: %{subject}"
+      status_updated: "[%{reference}] Status zaktualizowany: %{status}"
+      sla_breach: "[NARUSZENIE SLA] [%{reference}] %{subject}"
+      escalated: "[ESKALACJA] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Zgloszenie rozwiazane: %{subject}"
+    validation:
+      name_required: "Imie jest wymagane."
+      email_required: "E-mail jest wymagany."
+      subject_required: "Temat jest wymagany."
+      description_required: "Opis jest wymagany."
+    commands:
+      install:
+        installing: "Instalacja systemu zgloszen Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migracje skopiowane. Uruchom `rails db:migrate` aby je zastosowac."
+        inject_user_model: "app/models/user.rb (metody rol Escalated)"
+        inject_skip: "Nie mozna wstrzyknac do modelu User: %{error}"
+        inject_manual: "Dodaj te metody recznie do modelu User:"
+        inject_agent: "escalated_agent? - zwraca true dla agentow wsparcia"
+        inject_admin: "escalated_admin? - zwraca true dla administratorow wsparcia"
+        inject_agents_scope: "self.escalated_agents - zakres zwracajacy wszystkich agentow"
+        success: "Escalated zainstalowany pomyslnie!"
+        next_steps: "Nastepne kroki:"
+        step1: "1. Uruchom `rails db:migrate`"
+        step2: "2. Skonfiguruj config/initializers/escalated.rb"
+        step3: "3. Dodaj metody escalated_agent? i escalated_admin? do modelu User"
+        step4: "4. Zainstaluj komponenty Vue: skopiuj z vendor/escalated/resources/js/"
+        step5: "5. Skonfiguruj resolver stron Inertia aby uwzglednial strony Escalated"
+      guest_not_enabled: "Zgloszenia gosci nie sa wlaczone."
+      ticket_not_found: "Zgloszenie nie znalezione."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,111 @@
+pt-BR:
+  escalated:
+    ticket:
+      reply_sent: "Resposta enviada."
+      note_added: "Nota interna adicionada."
+      assigned: "Chamado atribuido a %{name}."
+      unassigned: "Chamado desatribuido."
+      status_updated: "Status atualizado para %{status}."
+      priority_updated: "Prioridade atualizada para %{priority}."
+      tags_updated: "Tags atualizadas."
+      department_updated: "Departamento alterado para %{name}."
+      macro_applied: "Macro \"%{name}\" aplicada."
+      following: "Seguindo o chamado."
+      unfollowed: "Deixou de seguir o chamado."
+      only_internal_notes_pinned: "Apenas notas internas podem ser fixadas."
+      updated: "Chamado atualizado."
+      created: "Chamado criado com sucesso."
+      closed: "Chamado fechado."
+      reopened: "Chamado reaberto."
+      customers_cannot_close: "Clientes nao podem fechar chamados."
+      note_pinned: "Nota fixada."
+      note_unpinned: "Nota desafixada."
+    guest:
+      created: "Chamado criado com sucesso."
+      ticket_closed: "Este chamado esta fechado."
+    bulk:
+      updated: "%{count} chamado(s) atualizado(s)."
+    rating:
+      only_resolved_closed: "Voce so pode avaliar chamados resolvidos ou fechados."
+      already_rated: "Este chamado ja foi avaliado."
+      thanks: "Obrigado pelo seu feedback!"
+    admin:
+      canned_response:
+        created: "Resposta padrao criada."
+        updated: "Resposta padrao atualizada."
+        deleted: "Resposta padrao excluida."
+      department:
+        created: "Departamento criado."
+        updated: "Departamento atualizado."
+        deleted: "Departamento excluido."
+      tag:
+        created: "Tag criada."
+        updated: "Tag atualizada."
+        deleted: "Tag excluida."
+      macro:
+        created: "Macro criada."
+        updated: "Macro atualizada."
+        deleted: "Macro excluida."
+      escalation_rule:
+        created: "Regra de escalacao criada."
+        updated: "Regra de escalacao atualizada."
+        deleted: "Regra de escalacao excluida."
+      sla_policy:
+        created: "Politica SLA criada."
+        updated: "Politica SLA atualizada."
+        deleted: "Politica SLA excluida."
+      settings:
+        updated: "Configuracoes atualizadas com sucesso."
+      plugin:
+        uploaded: "Plugin enviado com sucesso. Voce pode ativa-lo agora."
+        upload_failed: "Falha ao enviar plugin: %{error}"
+        activated: "Plugin ativado com sucesso."
+        activate_failed: "Falha ao ativar plugin: %{error}"
+        deactivated: "Plugin desativado com sucesso."
+        deactivate_failed: "Falha ao desativar plugin: %{error}"
+        composer_delete: "Plugins Composer nao podem ser excluidos. Remova o pacote via Composer."
+        deleted: "Plugin excluido com sucesso."
+        delete_failed: "Falha ao excluir plugin: %{error}"
+    middleware:
+      not_admin: "Acesso negado."
+      not_agent: "Acesso negado."
+      not_authorized: "Voce nao tem autorizacao para realizar esta acao."
+      not_found: "O recurso solicitado nao foi encontrado."
+    inbound:
+      unknown_adapter: "Adaptador desconhecido: %{adapter}"
+      verification_failed: "Falha na verificacao"
+      internal_error: "Erro interno"
+      disabled: "E-mail de entrada desabilitado"
+    mailer:
+      new_ticket: "[%{reference}] Chamado criado: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Chamado atribuido: %{subject}"
+      status_updated: "[%{reference}] Status atualizado: %{status}"
+      sla_breach: "[VIOLACAO SLA] [%{reference}] %{subject}"
+      escalated: "[ESCALADO] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Chamado resolvido: %{subject}"
+    validation:
+      name_required: "Nome e obrigatorio."
+      email_required: "E-mail e obrigatorio."
+      subject_required: "Assunto e obrigatorio."
+      description_required: "Descricao e obrigatoria."
+    commands:
+      install:
+        installing: "Instalando o sistema de chamados Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migracoes copiadas. Execute `rails db:migrate` para aplica-las."
+        inject_user_model: "app/models/user.rb (metodos de funcoes Escalated)"
+        inject_skip: "Nao foi possivel injetar no modelo User: %{error}"
+        inject_manual: "Adicione estes metodos manualmente ao seu modelo User:"
+        inject_agent: "escalated_agent? - retorna true para agentes de suporte"
+        inject_admin: "escalated_admin? - retorna true para administradores de suporte"
+        inject_agents_scope: "self.escalated_agents - escopo que retorna todos os agentes"
+        success: "Escalated instalado com sucesso!"
+        next_steps: "Proximos passos:"
+        step1: "1. Execute `rails db:migrate`"
+        step2: "2. Configure config/initializers/escalated.rb"
+        step3: "3. Adicione os metodos escalated_agent? e escalated_admin? ao seu modelo User"
+        step4: "4. Instale os componentes Vue: copie de vendor/escalated/resources/js/"
+        step5: "5. Configure o resolver de paginas Inertia para incluir as paginas Escalated"
+      guest_not_enabled: "Chamados de convidados nao estao habilitados."
+      ticket_not_found: "Chamado nao encontrado."

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,111 @@
+ru:
+  escalated:
+    ticket:
+      reply_sent: "Ответ отправлен."
+      note_added: "Внутренняя заметка добавлена."
+      assigned: "Заявка назначена на %{name}."
+      unassigned: "Назначение заявки снято."
+      status_updated: "Статус обновлен на %{status}."
+      priority_updated: "Приоритет обновлен на %{priority}."
+      tags_updated: "Теги обновлены."
+      department_updated: "Отдел изменен на %{name}."
+      macro_applied: "Макрос \"%{name}\" применен."
+      following: "Вы подписаны на заявку."
+      unfollowed: "Вы отписались от заявки."
+      only_internal_notes_pinned: "Можно закрепить только внутренние заметки."
+      updated: "Заявка обновлена."
+      created: "Заявка успешно создана."
+      closed: "Заявка закрыта."
+      reopened: "Заявка переоткрыта."
+      customers_cannot_close: "Клиенты не могут закрывать заявки."
+      note_pinned: "Заметка закреплена."
+      note_unpinned: "Заметка откреплена."
+    guest:
+      created: "Заявка успешно создана."
+      ticket_closed: "Эта заявка закрыта."
+    bulk:
+      updated: "Обновлено %{count} заявок."
+    rating:
+      only_resolved_closed: "Вы можете оценивать только решенные или закрытые заявки."
+      already_rated: "Эта заявка уже оценена."
+      thanks: "Спасибо за ваш отзыв!"
+    admin:
+      canned_response:
+        created: "Шаблон ответа создан."
+        updated: "Шаблон ответа обновлен."
+        deleted: "Шаблон ответа удален."
+      department:
+        created: "Отдел создан."
+        updated: "Отдел обновлен."
+        deleted: "Отдел удален."
+      tag:
+        created: "Тег создан."
+        updated: "Тег обновлен."
+        deleted: "Тег удален."
+      macro:
+        created: "Макрос создан."
+        updated: "Макрос обновлен."
+        deleted: "Макрос удален."
+      escalation_rule:
+        created: "Правило эскалации создано."
+        updated: "Правило эскалации обновлено."
+        deleted: "Правило эскалации удалено."
+      sla_policy:
+        created: "Политика SLA создана."
+        updated: "Политика SLA обновлена."
+        deleted: "Политика SLA удалена."
+      settings:
+        updated: "Настройки успешно обновлены."
+      plugin:
+        uploaded: "Плагин успешно загружен. Теперь вы можете его активировать."
+        upload_failed: "Не удалось загрузить плагин: %{error}"
+        activated: "Плагин успешно активирован."
+        activate_failed: "Не удалось активировать плагин: %{error}"
+        deactivated: "Плагин успешно деактивирован."
+        deactivate_failed: "Не удалось деактивировать плагин: %{error}"
+        composer_delete: "Плагины Composer нельзя удалить. Удалите пакет через Composer."
+        deleted: "Плагин успешно удален."
+        delete_failed: "Не удалось удалить плагин: %{error}"
+    middleware:
+      not_admin: "Доступ запрещен."
+      not_agent: "Доступ запрещен."
+      not_authorized: "У вас нет прав для выполнения этого действия."
+      not_found: "Запрашиваемый ресурс не найден."
+    inbound:
+      unknown_adapter: "Неизвестный адаптер: %{adapter}"
+      verification_failed: "Проверка не пройдена"
+      internal_error: "Внутренняя ошибка"
+      disabled: "Входящая почта отключена"
+    mailer:
+      new_ticket: "[%{reference}] Заявка создана: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Заявка назначена: %{subject}"
+      status_updated: "[%{reference}] Статус обновлен: %{status}"
+      sla_breach: "[НАРУШЕНИЕ SLA] [%{reference}] %{subject}"
+      escalated: "[ЭСКАЛАЦИЯ] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Заявка решена: %{subject}"
+    validation:
+      name_required: "Имя обязательно."
+      email_required: "Электронная почта обязательна."
+      subject_required: "Тема обязательна."
+      description_required: "Описание обязательно."
+    commands:
+      install:
+        installing: "Установка системы заявок Escalated"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Миграции скопированы. Запустите `rails db:migrate` для их применения."
+        inject_user_model: "app/models/user.rb (методы ролей Escalated)"
+        inject_skip: "Не удалось внедрить в модель User: %{error}"
+        inject_manual: "Добавьте эти методы вручную в вашу модель User:"
+        inject_agent: "escalated_agent? - возвращает true для агентов поддержки"
+        inject_admin: "escalated_admin? - возвращает true для администраторов поддержки"
+        inject_agents_scope: "self.escalated_agents - scope, возвращающий всех агентов"
+        success: "Escalated успешно установлен!"
+        next_steps: "Следующие шаги:"
+        step1: "1. Запустите `rails db:migrate`"
+        step2: "2. Настройте config/initializers/escalated.rb"
+        step3: "3. Добавьте методы escalated_agent? и escalated_admin? в модель User"
+        step4: "4. Установите компоненты Vue: скопируйте из vendor/escalated/resources/js/"
+        step5: "5. Настройте Inertia page resolver для включения страниц Escalated"
+      guest_not_enabled: "Гостевые заявки не включены."
+      ticket_not_found: "Заявка не найдена."

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,0 +1,111 @@
+tr:
+  escalated:
+    ticket:
+      reply_sent: "Yanit gonderildi."
+      note_added: "Dahili not eklendi."
+      assigned: "Destek talebi %{name} adina atandi."
+      unassigned: "Destek talebi atamasi kaldirildi."
+      status_updated: "Durum %{status} olarak guncellendi."
+      priority_updated: "Oncelik %{priority} olarak guncellendi."
+      tags_updated: "Etiketler guncellendi."
+      department_updated: "Departman %{name} olarak degistirildi."
+      macro_applied: "Makro \"%{name}\" uygulandi."
+      following: "Destek talebini takip ediyorsunuz."
+      unfollowed: "Destek talebini takipten cikarildi."
+      only_internal_notes_pinned: "Yalnizca dahili notlar sabitlenebilir."
+      updated: "Destek talebi guncellendi."
+      created: "Destek talebi basariyla olusturuldu."
+      closed: "Destek talebi kapatildi."
+      reopened: "Destek talebi yeniden acildi."
+      customers_cannot_close: "Musteriler destek taleplerini kapatamazlar."
+      note_pinned: "Not sabitlendi."
+      note_unpinned: "Not sabitleme kaldirildi."
+    guest:
+      created: "Destek talebi basariyla olusturuldu."
+      ticket_closed: "Bu destek talebi kapatilmistir."
+    bulk:
+      updated: "%{count} destek talebi guncellendi."
+    rating:
+      only_resolved_closed: "Yalnizca cozulmus veya kapatilmis destek taleplerini derecelendirebilirsiniz."
+      already_rated: "Bu destek talebi zaten derecelendirilmis."
+      thanks: "Geri bildiriminiz icin tesekkurler!"
+    admin:
+      canned_response:
+        created: "Hazir yanit olusturuldu."
+        updated: "Hazir yanit guncellendi."
+        deleted: "Hazir yanit silindi."
+      department:
+        created: "Departman olusturuldu."
+        updated: "Departman guncellendi."
+        deleted: "Departman silindi."
+      tag:
+        created: "Etiket olusturuldu."
+        updated: "Etiket guncellendi."
+        deleted: "Etiket silindi."
+      macro:
+        created: "Makro olusturuldu."
+        updated: "Makro guncellendi."
+        deleted: "Makro silindi."
+      escalation_rule:
+        created: "Eskalasyon kurali olusturuldu."
+        updated: "Eskalasyon kurali guncellendi."
+        deleted: "Eskalasyon kurali silindi."
+      sla_policy:
+        created: "SLA Politikasi olusturuldu."
+        updated: "SLA Politikasi guncellendi."
+        deleted: "SLA Politikasi silindi."
+      settings:
+        updated: "Ayarlar basariyla guncellendi."
+      plugin:
+        uploaded: "Eklenti basariyla yuklendi. Simdi etkinlestirebilirsiniz."
+        upload_failed: "Eklenti yuklemesi basarisiz: %{error}"
+        activated: "Eklenti basariyla etkinlestirildi."
+        activate_failed: "Eklenti etkinlestirme basarisiz: %{error}"
+        deactivated: "Eklenti basariyla devre disi birakildi."
+        deactivate_failed: "Eklenti devre disi birakma basarisiz: %{error}"
+        composer_delete: "Composer eklentileri silinemez. Paketi Composer uzerinden kaldirin."
+        deleted: "Eklenti basariyla silindi."
+        delete_failed: "Eklenti silme basarisiz: %{error}"
+    middleware:
+      not_admin: "Erisim reddedildi."
+      not_agent: "Erisim reddedildi."
+      not_authorized: "Bu islemi gerceklestirme yetkiniz yok."
+      not_found: "Istenen kaynak bulunamadi."
+    inbound:
+      unknown_adapter: "Bilinmeyen adaptor: %{adapter}"
+      verification_failed: "Dogrulama basarisiz"
+      internal_error: "Dahili hata"
+      disabled: "Gelen e-posta devre disi"
+    mailer:
+      new_ticket: "[%{reference}] Destek talebi olusturuldu: %{subject}"
+      reply: "Re: [%{reference}] %{subject}"
+      assigned: "[%{reference}] Destek talebi atandi: %{subject}"
+      status_updated: "[%{reference}] Durum guncellendi: %{status}"
+      sla_breach: "[SLA IHLALI] [%{reference}] %{subject}"
+      escalated: "[ESKALASYON] [%{reference}] %{subject}"
+      resolved: "[%{reference}] Destek talebi cozuldu: %{subject}"
+    validation:
+      name_required: "Ad gereklidir."
+      email_required: "E-posta gereklidir."
+      subject_required: "Konu gereklidir."
+      description_required: "Aciklama gereklidir."
+    commands:
+      install:
+        installing: "Escalated destek talep sistemini kuruyor"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "Migrasyon dosyalari kopyalandi. Uygulamak icin `rails db:migrate` calistirin."
+        inject_user_model: "app/models/user.rb (Escalated rol metodlari)"
+        inject_skip: "User modeline enjekte edilemedi: %{error}"
+        inject_manual: "Bu metodlari User modelinize manuel olarak ekleyin:"
+        inject_agent: "escalated_agent? - destek temsilcileri icin true dondurur"
+        inject_admin: "escalated_admin? - destek yoneticileri icin true dondurur"
+        inject_agents_scope: "self.escalated_agents - tum temsilcileri donduren kapsam"
+        success: "Escalated basariyla kuruldu!"
+        next_steps: "Sonraki adimlar:"
+        step1: "1. `rails db:migrate` calistirin"
+        step2: "2. config/initializers/escalated.rb yapilandirin"
+        step3: "3. User modeline escalated_agent? ve escalated_admin? metodlarini ekleyin"
+        step4: "4. Vue bilesenlerini kurun: vendor/escalated/resources/js/ kaynagindan kopyalayin"
+        step5: "5. Escalated sayfalarini icermesi icin Inertia sayfa cozucuyu ayarlayin"
+      guest_not_enabled: "Misafir destek talepleri etkin degil."
+      ticket_not_found: "Destek talebi bulunamadi."

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,0 +1,111 @@
+zh-CN:
+  escalated:
+    ticket:
+      reply_sent: "回复已发送。"
+      note_added: "内部备注已添加。"
+      assigned: "工单已分配给%{name}。"
+      unassigned: "工单已取消分配。"
+      status_updated: "状态已更新为%{status}。"
+      priority_updated: "优先级已更新为%{priority}。"
+      tags_updated: "标签已更新。"
+      department_updated: "部门已更改为%{name}。"
+      macro_applied: "宏\"%{name}\"已应用。"
+      following: "正在关注此工单。"
+      unfollowed: "已取消关注此工单。"
+      only_internal_notes_pinned: "只有内部备注可以置顶。"
+      updated: "工单已更新。"
+      created: "工单创建成功。"
+      closed: "工单已关闭。"
+      reopened: "工单已重新打开。"
+      customers_cannot_close: "客户无法关闭工单。"
+      note_pinned: "备注已置顶。"
+      note_unpinned: "备注已取消置顶。"
+    guest:
+      created: "工单创建成功。"
+      ticket_closed: "此工单已关闭。"
+    bulk:
+      updated: "已更新%{count}个工单。"
+    rating:
+      only_resolved_closed: "您只能评价已解决或已关闭的工单。"
+      already_rated: "此工单已被评价。"
+      thanks: "感谢您的反馈！"
+    admin:
+      canned_response:
+        created: "预设回复已创建。"
+        updated: "预设回复已更新。"
+        deleted: "预设回复已删除。"
+      department:
+        created: "部门已创建。"
+        updated: "部门已更新。"
+        deleted: "部门已删除。"
+      tag:
+        created: "标签已创建。"
+        updated: "标签已更新。"
+        deleted: "标签已删除。"
+      macro:
+        created: "宏已创建。"
+        updated: "宏已更新。"
+        deleted: "宏已删除。"
+      escalation_rule:
+        created: "升级规则已创建。"
+        updated: "升级规则已更新。"
+        deleted: "升级规则已删除。"
+      sla_policy:
+        created: "SLA策略已创建。"
+        updated: "SLA策略已更新。"
+        deleted: "SLA策略已删除。"
+      settings:
+        updated: "设置更新成功。"
+      plugin:
+        uploaded: "插件上传成功。您现在可以激活它。"
+        upload_failed: "插件上传失败：%{error}"
+        activated: "插件激活成功。"
+        activate_failed: "插件激活失败：%{error}"
+        deactivated: "插件停用成功。"
+        deactivate_failed: "插件停用失败：%{error}"
+        composer_delete: "Composer插件无法删除。请通过Composer移除该包。"
+        deleted: "插件删除成功。"
+        delete_failed: "插件删除失败：%{error}"
+    middleware:
+      not_admin: "访问被拒绝。"
+      not_agent: "访问被拒绝。"
+      not_authorized: "您没有权限执行此操作。"
+      not_found: "未找到请求的资源。"
+    inbound:
+      unknown_adapter: "未知适配器：%{adapter}"
+      verification_failed: "验证失败"
+      internal_error: "内部错误"
+      disabled: "入站邮件已禁用"
+    mailer:
+      new_ticket: "[%{reference}] 工单已创建：%{subject}"
+      reply: "回复：[%{reference}] %{subject}"
+      assigned: "[%{reference}] 工单已分配：%{subject}"
+      status_updated: "[%{reference}] 状态已更新：%{status}"
+      sla_breach: "[SLA违规] [%{reference}] %{subject}"
+      escalated: "[升级] [%{reference}] %{subject}"
+      resolved: "[%{reference}] 工单已解决：%{subject}"
+    validation:
+      name_required: "姓名为必填项。"
+      email_required: "电子邮件为必填项。"
+      subject_required: "主题为必填项。"
+      description_required: "描述为必填项。"
+    commands:
+      install:
+        installing: "安装Escalated支持工单系统"
+        create_initializer: "config/initializers/escalated.rb"
+        copy_migrations: "迁移文件已复制。运行`rails db:migrate`以应用。"
+        inject_user_model: "app/models/user.rb (Escalated角色方法)"
+        inject_skip: "无法注入User模型：%{error}"
+        inject_manual: "请手动将这些方法添加到您的User模型中："
+        inject_agent: "escalated_agent? - 对支持代理返回true"
+        inject_admin: "escalated_admin? - 对支持管理员返回true"
+        inject_agents_scope: "self.escalated_agents - 返回所有代理的作用域"
+        success: "Escalated安装成功！"
+        next_steps: "后续步骤："
+        step1: "1. 运行`rails db:migrate`"
+        step2: "2. 配置config/initializers/escalated.rb"
+        step3: "3. 将escalated_agent?和escalated_admin?方法添加到User模型"
+        step4: "4. 安装Vue组件：从vendor/escalated/resources/js/复制"
+        step5: "5. 设置Inertia页面解析器以包含Escalated页面"
+      guest_not_enabled: "访客工单未启用。"
+      ticket_not_found: "工单未找到。"


### PR DESCRIPTION
## Summary
- Add locale files for ar, it, ja, ko, nl, pl, pt-BR, ru, tr, zh-CN
- Translations cover ticket messages, admin actions, mailer subjects, validations, middleware errors, inbound email, and install commands
- Matches existing en/de/es/fr locale structure

## Test plan
- [ ] Verify YAML syntax is valid for all locale files
- [ ] Spot-check translations for accuracy