### PR TITLE
fix: include url in attachment serialization

### DIFF
--- a/app/controllers/escalated/admin/tickets_controller.rb
+++ b/app/controllers/escalated/admin/tickets_controller.rb
@@ -305,6 +305,10 @@ module Escalated
           closed_at: ticket.closed_at&.iso8601,
           reply_count: ticket.replies.count,
           attachment_count: ticket.attachments.count,
+          attachments: ticket.attachments.map do |a|
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
+          end,
           satisfaction_rating: if ticket.satisfaction_rating
                                  {
                                    id: ticket.satisfaction_rating.id,
@@ -335,7 +339,8 @@ module Escalated
                     { name: 'System', is_agent: true }
                   end,
           attachments: reply.attachments.map do |a|
-            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type }
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
           end,
           created_at: reply.created_at&.iso8601
         }

--- a/app/controllers/escalated/agent/tickets_controller.rb
+++ b/app/controllers/escalated/agent/tickets_controller.rb
@@ -307,6 +307,10 @@ module Escalated
           closed_at: ticket.closed_at&.iso8601,
           reply_count: ticket.replies.count,
           attachment_count: ticket.attachments.count,
+          attachments: ticket.attachments.map do |a|
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
+          end,
           satisfaction_rating: if ticket.satisfaction_rating
                                  {
                                    id: ticket.satisfaction_rating.id,
@@ -337,7 +341,8 @@ module Escalated
                     { name: 'System', is_agent: true }
                   end,
           attachments: reply.attachments.map do |a|
-            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type }
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
           end,
           created_at: reply.created_at&.iso8601
         }

--- a/app/controllers/escalated/customer/tickets_controller.rb
+++ b/app/controllers/escalated/customer/tickets_controller.rb
@@ -130,6 +130,10 @@ module Escalated
           updated_at: ticket.updated_at&.iso8601,
           resolved_at: ticket.resolved_at&.iso8601,
           reply_count: ticket.replies.public_replies.count,
+          attachments: ticket.attachments.map do |a|
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
+          end,
           satisfaction_rating: if ticket.satisfaction_rating
                                  {
                                    id: ticket.satisfaction_rating.id,

--- a/app/controllers/escalated/guest/tickets_controller.rb
+++ b/app/controllers/escalated/guest/tickets_controller.rb
@@ -199,6 +199,10 @@ module Escalated
           department: ticket.department ? { id: ticket.department.id, name: ticket.department.name } : nil,
           created_at: ticket.created_at&.iso8601,
           updated_at: ticket.updated_at&.iso8601,
+          attachments: ticket.attachments.map do |a|
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
+          end,
           satisfaction_rating: if ticket.satisfaction_rating
                                  {
                                    id: ticket.satisfaction_rating.id,
@@ -225,7 +229,8 @@ module Escalated
             is_agent: reply.author.respond_to?(:escalated_agent?) ? reply.author.escalated_agent? : false
           },
           attachments: reply.attachments.map do |a|
-            { id: a.id, filename: a.filename, size: a.human_size }
+            { id: a.id, filename: a.filename, size: a.human_size, content_type: a.content_type,
+              url: Services::AttachmentService.url_for(a) }
           end,
           created_at: reply.created_at&.iso8601,
           is_system: reply.is_system


### PR DESCRIPTION
## Summary
- Fixes escalated-dev/escalated#26 — attachment `url` was missing from serialized output
- Added `url` via `AttachmentService.url_for()` to reply attachment serialization in agent, admin, and guest controllers (customer already had it)
- Added ticket-level `attachments` array (with `url`) to ticket detail JSON in all 4 controllers — frontend renders `ticket.attachments` but only `attachment_count` was being sent

## Test plan
- [ ] Verify ticket attachments render with working download links
- [ ] Verify reply attachments render with working download links