### PR TITLE
feat(contact): Contact model for public-ticket dedupe (Pattern B)

### DIFF
--- a/app/controllers/escalated/guest/tickets_controller.rb
+++ b/app/controllers/escalated/guest/tickets_controller.rb
@@ -52,11 +52,20 @@ module Escalated
 
         guest_token = SecureRandom.hex(32) # 64-character hex string
 
+        # Dedupe repeat guests by email (Pattern B). Inline guest_*
+        # fields remain populated for the backwards-compat dual-read
+        # period.
+        contact = Escalated::Contact.find_or_create_by_email(
+          guest_ticket_params[:email],
+          guest_ticket_params[:name]
+        )
+
         ticket = Escalated::Ticket.create!(
           requester: nil,
           guest_name: guest_ticket_params[:name],
           guest_email: guest_ticket_params[:email],
           guest_token: guest_token,
+          contact_id: contact.id,
           subject: guest_ticket_params[:subject],
           description: guest_ticket_params[:description],
           priority: guest_ticket_params[:priority] || Escalated.configuration.default_priority,

--- a/app/models/escalated/contact.rb
+++ b/app/models/escalated/contact.rb
@@ -11,7 +11,7 @@ module Escalated
   class Contact < ApplicationRecord
     self.table_name = Escalated.table_name('contacts')
 
-    has_many :tickets, class_name: 'Escalated::Ticket', foreign_key: :contact_id,
+    has_many :tickets, class_name: 'Escalated::Ticket',
                        dependent: :nullify
 
     validates :email, presence: true, uniqueness: { case_sensitive: false }
@@ -23,9 +23,7 @@ module Escalated
         normalized = email.to_s.strip.downcase
         existing = find_by(email: normalized)
         if existing
-          if existing.name.blank? && name.present?
-            existing.update!(name: name)
-          end
+          existing.update!(name: name) if existing.name.blank? && name.present?
           return existing
         end
         create!(email: normalized, name: name, user_id: nil, metadata: {})
@@ -42,7 +40,7 @@ module Escalated
     def promote_to_user!(user_id, user_type = 'User')
       link_to_user!(user_id)
       Escalated::Ticket.where(contact_id: id)
-                      .update_all(requester_id: user_id, requester_type: user_type)
+                       .update_all(requester_id: user_id, requester_type: user_type)
       self
     end
 

--- a/app/models/escalated/contact.rb
+++ b/app/models/escalated/contact.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Escalated
+  # First-class identity for guest requesters. Deduped by email
+  # (unique index, case-insensitive). Links to a host-app user via
+  # `user_id` once the guest accepts a signup invite.
+  #
+  # Coexists with the inline guest_* columns on Ticket for one
+  # release; the backfill migration populates `contact_id` for
+  # existing rows. New code should write via Contact.
+  class Contact < ApplicationRecord
+    self.table_name = Escalated.table_name('contacts')
+
+    has_many :tickets, class_name: 'Escalated::Ticket', foreign_key: :contact_id,
+                       dependent: :nullify
+
+    validates :email, presence: true, uniqueness: { case_sensitive: false }
+
+    before_validation :normalize_email
+
+    class << self
+      def find_or_create_by_email(email, name = nil)
+        normalized = email.to_s.strip.downcase
+        existing = find_by(email: normalized)
+        if existing
+          if existing.name.blank? && name.present?
+            existing.update!(name: name)
+          end
+          return existing
+        end
+        create!(email: normalized, name: name, user_id: nil, metadata: {})
+      end
+    end
+
+    def link_to_user!(user_id)
+      update!(user_id: user_id)
+      self
+    end
+
+    # Link to a host-app user and back-stamp requester_* on all
+    # prior tickets owned by this contact.
+    def promote_to_user!(user_id, user_type = 'User')
+      link_to_user!(user_id)
+      Escalated::Ticket.where(contact_id: id)
+                      .update_all(requester_id: user_id, requester_type: user_type)
+      self
+    end
+
+    private
+
+    def normalize_email
+      self.email = email.to_s.strip.downcase if email.present?
+    end
+  end
+end

--- a/app/models/escalated/ticket.rb
+++ b/app/models/escalated/ticket.rb
@@ -5,6 +5,7 @@ module Escalated
     self.table_name = Escalated.table_name('tickets')
 
     belongs_to :requester, polymorphic: true, optional: true
+    belongs_to :contact, class_name: 'Escalated::Contact', optional: true
     belongs_to :assignee,
                class_name: Escalated.configuration.user_class,
                optional: true,

--- a/db/migrate/045_create_escalated_contacts.rb
+++ b/db/migrate/045_create_escalated_contacts.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Adds a first-class Contact entity for guest requesters, mirroring the
+# escalated-nestjs Contact design (Pattern B). Enables email-level dedupe
+# across tickets and a clean "promote to user" flow.
+#
+# Keeps the inline guest_name/guest_email/guest_token columns on tickets
+# for backwards compatibility (Pattern A). A follow-up backfill migration
+# populates contact_id for existing tickets; the dual-read period lets
+# callers transition without a flag day.
+class CreateEscalatedContacts < ActiveRecord::Migration[7.0]
+  def up
+    contacts_table = "#{Escalated.configuration.table_prefix}contacts"
+    tickets_table = "#{Escalated.configuration.table_prefix}tickets"
+
+    create_table contacts_table do |t|
+      t.string :email, null: false, limit: 320
+      t.string :name, null: true
+      t.bigint :user_id, null: true,
+                         comment: 'Linked host-app user id once the contact creates an account'
+      t.json :metadata, default: {}
+      t.timestamps
+    end
+
+    add_index contacts_table, :email, unique: true
+    add_index contacts_table, :user_id
+
+    add_column tickets_table, :contact_id, :bigint, null: true
+    add_foreign_key tickets_table, contacts_table, column: :contact_id, on_delete: :nullify
+    add_index tickets_table, :contact_id
+  end
+
+  def down
+    contacts_table = "#{Escalated.configuration.table_prefix}contacts"
+    tickets_table = "#{Escalated.configuration.table_prefix}tickets"
+
+    remove_foreign_key tickets_table, column: :contact_id
+    remove_index tickets_table, :contact_id
+    remove_column tickets_table, :contact_id
+    drop_table contacts_table
+  end
+end

--- a/db/migrate/046_backfill_contact_ids_on_escalated_tickets.rb
+++ b/db/migrate/046_backfill_contact_ids_on_escalated_tickets.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Backfills contact_id on existing tickets that have a guest_email.
+# Idempotent: the unique email index on contacts prevents duplicates,
+# and tickets already carrying a contact_id are skipped.
+class BackfillContactIdsOnEscalatedTickets < ActiveRecord::Migration[7.0]
+  def up
+    contacts_table = "#{Escalated.configuration.table_prefix}contacts"
+    tickets_table = "#{Escalated.configuration.table_prefix}tickets"
+
+    seen = {} # normalized email => contact id
+
+    connection.execute(<<~SQL.squish).each do |row|
+      SELECT id, guest_email, guest_name
+      FROM #{tickets_table}
+      WHERE guest_email IS NOT NULL
+        AND contact_id IS NULL
+    SQL
+      id = row['id']
+      email = row['guest_email'].to_s.strip.downcase
+      next if email.empty?
+
+      unless seen.key?(email)
+        existing = connection.select_one(
+          "SELECT id FROM #{contacts_table} WHERE email = #{connection.quote(email)}",
+        )
+        seen[email] = if existing
+                        existing['id']
+                      else
+                        now = connection.quote(Time.current)
+                        name = connection.quote(row['guest_name'].presence)
+                        connection.insert(<<~SQL.squish)
+                          INSERT INTO #{contacts_table} (email, name, user_id, metadata, created_at, updated_at)
+                          VALUES (#{connection.quote(email)}, #{name}, NULL, '{}', #{now}, #{now})
+                        SQL
+                      end
+      end
+
+      connection.execute(<<~SQL.squish)
+        UPDATE #{tickets_table}
+        SET contact_id = #{seen[email]}
+        WHERE id = #{id}
+      SQL
+    end
+  end
+
+  def down
+    tickets_table = "#{Escalated.configuration.table_prefix}tickets"
+    connection.execute("UPDATE #{tickets_table} SET contact_id = NULL")
+  end
+end

--- a/lib/escalated/services/ticket_service.rb
+++ b/lib/escalated/services/ticket_service.rb
@@ -5,6 +5,7 @@ module Escalated
     class TicketService
       class << self
         def create(params)
+          params = resolve_contact_params(params)
           ticket = driver.create_ticket(params)
 
           if Escalated.configuration.notification_channels.include?(:email)
@@ -189,6 +190,23 @@ module Escalated
 
         def driver
           Escalated.driver
+        end
+
+        # Resolve/create a Contact when inline guest_email is provided
+        # and no contact_id is set. Mutates a local copy of the hash
+        # so callers passing symbol keys or string keys both work.
+        def resolve_contact_params(params)
+          params = params.dup
+          # Already linked to a Contact — nothing to do.
+          return params if params[:contact_id].present? || params['contact_id'].present?
+
+          guest_email = params[:guest_email] || params['guest_email']
+          return params if guest_email.blank?
+
+          guest_name = params[:guest_name] || params['guest_name']
+          contact = Escalated::Contact.find_or_create_by_email(guest_email, guest_name)
+          params[:contact_id] = contact.id
+          params
         end
       end
     end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :escalated_contact, class: 'Escalated::Contact' do
+    sequence(:email) { |n| "contact#{n}@example.com" }
+    name { Faker::Name.name }
+    user_id { nil }
+    metadata { {} }
+  end
+end

--- a/spec/models/escalated/contact_spec.rb
+++ b/spec/models/escalated/contact_spec.rb
@@ -74,4 +74,28 @@ RSpec.describe Escalated::Contact, type: :model do
       expect(t2.reload.requester_id).to eq(555)
     end
   end
+
+  describe 'tickets association' do
+    it 'has_many tickets via contact_id' do
+      contact = create(:escalated_contact)
+      t1 = create(:escalated_ticket, contact: contact, requester: nil)
+      t2 = create(:escalated_ticket, contact: contact, requester: nil)
+      # Unrelated ticket
+      create(:escalated_ticket, requester: nil)
+
+      expect(contact.tickets.map(&:id)).to contain_exactly(t1.id, t2.id)
+    end
+  end
+
+  describe 'repeat-submission dedupe (Pattern B)' do
+    it 'yields one Contact row even when find_or_create_by_email is called with different casing / whitespace' do
+      c1 = described_class.find_or_create_by_email('alice@example.com', 'Alice')
+      c2 = described_class.find_or_create_by_email('  ALICE@Example.COM  ', 'Alice')
+      c3 = described_class.find_or_create_by_email('alice@example.com', 'Different')
+
+      expect(c1.id).to eq(c2.id)
+      expect(c2.id).to eq(c3.id)
+      expect(described_class.where(email: 'alice@example.com').count).to eq(1)
+    end
+  end
 end

--- a/spec/models/escalated/contact_spec.rb
+++ b/spec/models/escalated/contact_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Contact, type: :model do
+  describe 'associations' do
+    it { is_expected.to have_many(:tickets).class_name('Escalated::Ticket').dependent(:nullify) }
+  end
+
+  describe 'validations' do
+    subject { build(:escalated_contact) }
+
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+  end
+
+  describe 'before_validation normalize_email' do
+    it 'lowercases and trims whitespace' do
+      c = described_class.create!(email: '  UPPER@Case.COM ', metadata: {})
+      expect(c.email).to eq('upper@case.com')
+    end
+  end
+
+  describe '.find_or_create_by_email' do
+    it 'creates a new contact for a never-seen email' do
+      c = described_class.find_or_create_by_email('new@user.com', 'New User')
+      expect(c.email).to eq('new@user.com')
+      expect(c.name).to eq('New User')
+    end
+
+    it 'normalizes case + whitespace on create' do
+      c = described_class.find_or_create_by_email('  MIX@Case.COM ')
+      expect(c.email).to eq('mix@case.com')
+    end
+
+    it 'returns the existing contact for a repeat email' do
+      first = described_class.find_or_create_by_email('alice@example.com', 'Alice')
+      second = described_class.find_or_create_by_email('ALICE@example.com')
+      expect(second.id).to eq(first.id)
+    end
+
+    it 'fills in a blank name on an existing contact when one is provided' do
+      create(:escalated_contact, email: 'alice@example.com', name: nil)
+      result = described_class.find_or_create_by_email('alice@example.com', 'Alice')
+      expect(result.name).to eq('Alice')
+    end
+
+    it 'does not overwrite a non-blank existing name' do
+      create(:escalated_contact, email: 'alice@example.com', name: 'Alice')
+      result = described_class.find_or_create_by_email('alice@example.com', 'Different')
+      expect(result.name).to eq('Alice')
+    end
+  end
+
+  describe '#link_to_user!' do
+    it 'sets user_id on the contact' do
+      c = create(:escalated_contact, user_id: nil)
+      c.link_to_user!(555)
+      expect(c.reload.user_id).to eq(555)
+    end
+  end
+
+  describe '#promote_to_user!' do
+    it 'links contact and back-stamps requester_id on prior tickets' do
+      contact = create(:escalated_contact, user_id: nil)
+      t1 = create(:escalated_ticket, contact: contact, requester: nil)
+      t2 = create(:escalated_ticket, contact: contact, requester: nil)
+
+      contact.promote_to_user!(555, 'User')
+
+      expect(contact.reload.user_id).to eq(555)
+      expect(t1.reload.requester_id).to eq(555)
+      expect(t1.requester_type).to eq('User')
+      expect(t2.reload.requester_id).to eq(555)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Rails port of the Pattern B design from [escalated-nestjs#17](https://github.com/escalated-dev/escalated-nestjs/pull/17) and [escalated-laravel#67](https://github.com/escalated-dev/escalated-laravel/pull/67). See [rollout status doc](https://github.com/escalated-dev/escalated/blob/feat/public-ticket-system/docs/superpowers/plans/2026-04-24-public-tickets-rollout-status.md).

## Changes

- **Migration 045** — creates \`escalated_contacts\` (unique email, nullable user_id, json metadata) + adds \`contact_id\` FK on \`escalated_tickets\` (on_delete: nullify)
- **Migration 046** — idempotent backfill of \`contact_id\` for tickets that already have a \`guest_email\`
- **Escalated::Contact** model — \`.find_or_create_by_email\`, \`#link_to_user!\`, \`#promote_to_user!\`
- **Escalated::Ticket** — gains \`belongs_to :contact, optional: true\`
- **Factory + 11 RSpec tests** (associations, validations, normalization, dedupe, name fill, promote)

## Test plan

- [x] \`bundle exec rspec spec/models/escalated/contact_spec.rb\` — 11 passed
- [ ] CI with real \`csv\` gem available (local env missing, unrelated)

## Backwards compatibility

Inline \`guest_name\` / \`guest_email\` / \`guest_token\` columns preserved; controllers writing inline fields keep working. Follow-up PRs will migrate write paths and then drop the inline columns.