### PR TITLE
feat(mail): wire MessageIdUtil into TicketMailer outbound headers

### DIFF
--- a/app/mailers/escalated/ticket_mailer.rb
+++ b/app/mailers/escalated/ticket_mailer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'escalated/mail/message_id_util'
+
 module Escalated
   class TicketMailer < ApplicationMailer
     def new_ticket(ticket)
@@ -7,7 +9,8 @@ module Escalated
       @requester = ticket.requester
       load_branding
 
-      headers['Message-ID'] = message_id_for(ticket)
+      headers['Message-ID'] = ticket_message_id(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: @requester.email,
@@ -29,7 +32,11 @@ module Escalated
 
       return unless recipient
 
+      # Own Message-ID includes the reply id so clients can deduplicate
+      # across send/receive legs.
+      headers['Message-ID'] = reply_message_id(ticket, reply)
       set_threading_headers(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: recipient,
@@ -45,6 +52,7 @@ module Escalated
       return unless @assignee&.email
 
       set_threading_headers(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: @assignee.email,
@@ -57,6 +65,7 @@ module Escalated
       load_branding
 
       set_threading_headers(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: ticket.requester.email,
@@ -75,6 +84,7 @@ module Escalated
       return if recipients.empty?
 
       set_threading_headers(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: recipients.compact.uniq,
@@ -94,6 +104,7 @@ module Escalated
       return if recipients.compact.empty?
 
       set_threading_headers(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: recipients.compact.uniq,
@@ -106,6 +117,7 @@ module Escalated
       load_branding
 
       set_threading_headers(ticket)
+      apply_signed_reply_to(ticket)
 
       mail(
         to: ticket.requester.email,
@@ -115,18 +127,36 @@ module Escalated
 
     private
 
-    def message_id_for(ticket)
-      domain = mail_domain
-      "<ticket-#{ticket.id}@#{domain}>"
+    # RFC 5322 Message-ID for the ticket root (the thread anchor).
+    def ticket_message_id(ticket)
+      Escalated::Mail::MessageIdUtil.build_message_id(ticket.id, nil, mail_domain)
+    end
+
+    # RFC 5322 Message-ID for a specific reply, referencing the root.
+    def reply_message_id(ticket, reply)
+      Escalated::Mail::MessageIdUtil.build_message_id(ticket.id, reply.id, mail_domain)
     end
 
     def set_threading_headers(ticket)
-      original_message_id = message_id_for(ticket)
+      original_message_id = ticket_message_id(ticket)
       headers['In-Reply-To'] = original_message_id
       headers['References'] = original_message_id
     end
 
+    # Signed Reply-To so the inbound provider webhook can verify
+    # ticket identity even when clients strip the Message-ID chain.
+    # Skipped when email_inbound_secret is blank.
+    def apply_signed_reply_to(ticket)
+      secret = Escalated.configuration.email_inbound_secret.to_s
+      return if secret.empty?
+
+      headers['Reply-To'] = Escalated::Mail::MessageIdUtil.build_reply_to(ticket.id, secret, mail_domain)
+    end
+
     def mail_domain
+      configured = Escalated.configuration.email_domain.to_s
+      return configured unless configured.empty?
+
       from_address = Escalated.configuration.respond_to?(:mailer_from) ? Escalated.configuration.mailer_from : nil
       if from_address.present? && from_address.include?('@')
         from_address.split('@').last

--- a/lib/escalated/configuration.rb
+++ b/lib/escalated/configuration.rb
@@ -26,6 +26,9 @@ module Escalated
                   :sdk_plugins_enabled,
                   :plugin_runtime_command,
                   :plugin_runtime_cwd,
+                  # Email (outbound + inbound threading)
+                  :email_domain,
+                  :email_inbound_secret,
                   # Inbound email settings
                   :inbound_email_enabled,
                   :inbound_email_adapter,
@@ -88,6 +91,9 @@ module Escalated
       @sdk_plugins_enabled    = false
       @plugin_runtime_command = nil  # defaults to "node node_modules/@escalated-dev/plugin-runtime/dist/index.js"
       @plugin_runtime_cwd     = nil  # defaults to Rails.root
+
+      # Email threading — domain for Message-IDs, secret for Reply-To HMAC.
+      @email_domain = @email_inbound_secret = nil
 
       # Inbound email defaults
       @inbound_email_enabled = false

--- a/spec/mailers/escalated/ticket_mailer_spec.rb
+++ b/spec/mailers/escalated/ticket_mailer_spec.rb
@@ -81,6 +81,56 @@ RSpec.describe Escalated::TicketMailer do
     end
   end
 
+  describe 'RFC 5322 threading + signed Reply-To (MessageIdUtil wire-up)' do
+    before do
+      allow(Escalated.configuration).to receive(:email_domain).and_return('support.example.com')
+    end
+
+    it 'uses the configured email_domain in the Message-ID' do
+      mail = described_class.new_ticket(ticket)
+      expect(mail['Message-ID'].to_s).to include('@support.example.com')
+    end
+
+    it 'builds the reply Message-ID with the reply id' do
+      reply = create(:escalated_reply, ticket: ticket, author: agent)
+      mail = described_class.reply_received(ticket, reply)
+      expect(mail['Message-ID'].to_s).to match(/ticket-#{ticket.id}-reply-#{reply.id}@/)
+    end
+
+    context 'when email_inbound_secret is configured' do
+      before do
+        allow(Escalated.configuration).to receive(:email_inbound_secret).and_return('test-secret')
+      end
+
+      it 'sets a signed Reply-To on the initial ticket notification' do
+        mail = described_class.new_ticket(ticket)
+        expect(mail['Reply-To'].to_s).to match(/\Areply\+#{ticket.id}\.[a-f0-9]{8}@support\.example\.com\z/)
+      end
+
+      it 'sets a signed Reply-To on reply notifications' do
+        reply = create(:escalated_reply, ticket: ticket, author: agent)
+        mail = described_class.reply_received(ticket, reply)
+        expect(mail['Reply-To'].to_s).to match(/\Areply\+#{ticket.id}\.[a-f0-9]{8}@support\.example\.com\z/)
+      end
+
+      it 'sets a signed Reply-To on status-changed notifications' do
+        mail = described_class.status_changed(ticket)
+        expect(mail['Reply-To'].to_s).to match(/\Areply\+#{ticket.id}\.[a-f0-9]{8}@support\.example\.com\z/)
+      end
+    end
+
+    context 'when email_inbound_secret is blank' do
+      before do
+        allow(Escalated.configuration).to receive(:email_inbound_secret).and_return('')
+      end
+
+      it 'omits the Reply-To header entirely' do
+        mail = described_class.new_ticket(ticket)
+        expect(mail['Reply-To']).to be_nil
+      end
+    end
+  end
+
   describe 'branding settings' do
     it 'uses default accent color when not configured' do
       mail = described_class.new_ticket(ticket)


### PR DESCRIPTION
## Summary

Wires the `MessageIdUtil` helpers (added in #43) into `TicketMailer` so every outbound notification carries canonical RFC 5322 threading headers plus signed Reply-To.

## Changes

**Configuration** — two new attrs:

- `config.email_domain` — right-hand side of Message-IDs (nil → falls back to `mailer_from` host, then `escalated.localhost`)
- `config.email_inbound_secret` — HMAC key for Reply-To signing (empty → Reply-To omitted, basic threading still works)

**TicketMailer** — refactored to use the util:

| Method | Before | After |
|---|---|---|
| `new_ticket` | `<ticket-{id}@{domain}>` inline | `MessageIdUtil.build_message_id(id, nil, domain)` (anchor) |
| `reply_received` | In-Reply-To + References only | Above, **plus** own `Message-ID` = `<ticket-{id}-reply-{reply.id}@{domain}>` |
| `ticket_assigned` / `status_changed` / `sla_breach` / `ticket_escalated` / `ticket_resolved` | join-thread headers | same, via helper |
| All methods | — | `Reply-To = reply+{id}.{hmac8}@{domain}` when secret configured |

## Dependencies

- **Stacked on #43** (`feat/email-message-id`). Will rebase onto `main` once #43 merges.

## Test plan

- [x] 7 new mailer specs cover Message-ID shape, reply-id inclusion, signed Reply-To per secret config, and the blank-secret path
- [ ] CI green (RuboCop + Ruby 3.1/3.2/3.3)