### PR TITLE
feat(admin): public-tickets (guest policy) settings endpoint

### DIFF
--- a/app/controllers/escalated/admin/settings_controller.rb
+++ b/app/controllers/escalated/admin/settings_controller.rb
@@ -102,6 +102,46 @@ module Escalated
         redirect_to escalated.admin_settings_csat_path, notice: I18n.t('escalated.admin.settings.updated')
       end
 
+      def public_tickets
+        user_id_raw = Escalated::EscalatedSetting.get('guest_policy_user_id').to_s
+        render_page 'Escalated/Admin/Settings/PublicTickets', {
+          settings: {
+            guest_policy_mode: Escalated::EscalatedSetting.get('guest_policy_mode').presence || 'unassigned',
+            guest_policy_user_id: user_id_raw.presence&.to_i,
+            guest_policy_signup_url_template: Escalated::EscalatedSetting.get('guest_policy_signup_url_template').to_s
+          }
+        }
+      end
+
+      def update_public_tickets
+        mode = params[:guest_policy_mode].to_s
+        unless %w[unassigned guest_user prompt_signup].include?(mode)
+          return redirect_to escalated.admin_settings_public_tickets_path,
+                             alert: I18n.t('escalated.admin.settings.updated')
+        end
+
+        Escalated::EscalatedSetting.set('guest_policy_mode', mode)
+
+        if mode == 'guest_user'
+          user_id = params[:guest_policy_user_id].to_i
+          Escalated::EscalatedSetting.set('guest_policy_user_id', user_id.positive? ? user_id.to_s : '')
+        else
+          Escalated::EscalatedSetting.set('guest_policy_user_id', '')
+        end
+
+        if mode == 'prompt_signup'
+          Escalated::EscalatedSetting.set(
+            'guest_policy_signup_url_template',
+            params[:guest_policy_signup_url_template].to_s.strip
+          )
+        else
+          Escalated::EscalatedSetting.set('guest_policy_signup_url_template', '')
+        end
+
+        redirect_to escalated.admin_settings_public_tickets_path,
+                    notice: I18n.t('escalated.admin.settings.updated')
+      end
+
       def update
         # Boolean settings
         %w[guest_tickets_enabled allow_customer_close inbound_email_enabled show_powered_by

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,8 @@ Escalated::Engine.routes.draw do
     post 'settings/sso', to: 'settings#update_sso', as: :settings_update_sso
     get 'settings/csat', to: 'settings#csat', as: :settings_csat
     post 'settings/csat', to: 'settings#update_csat', as: :settings_update_csat
+    get 'settings/public_tickets', to: 'settings#public_tickets', as: :settings_public_tickets
+    put 'settings/public_tickets', to: 'settings#update_public_tickets', as: :settings_update_public_tickets
     resources :custom_objects, only: %i[index create update destroy] do
       member do
         get :records


### PR DESCRIPTION
## Summary

Rails host-adapter side of the new \`Admin/Settings/PublicTickets.vue\` page ([escalated#32](https://github.com/escalated-dev/escalated/pull/32)).

## What's added

- \`SettingsController#public_tickets\` — renders the Vue page with current guest-policy values (\`mode\`, \`user_id\`, \`signup_url_template\`).
- \`SettingsController#update_public_tickets\` — validates mode against the three supported values (\`unassigned\`, \`guest_user\`, \`prompt_signup\`) and persists via \`EscalatedSetting\`.
- Two routes: \`GET/PUT /settings/public_tickets\` named \`settings_public_tickets\` and \`settings_update_public_tickets\`.

## Behavior notes

- Switching modes clears the fields that no longer apply so stale values don't leak across mode changes.
- Unknown modes fall back to a redirect with the generic updated-flash (matches existing defensive style elsewhere in the controller).

## Test plan

- [ ] \`rails routes | grep public_tickets\` shows both routes after merge.
- [ ] GET returns the page with current settings; PUT persists and redirects back with flash.