### PR TITLE
fix(public-tickets): honor guest_policy_mode on widget + guest submissions

### DIFF
--- a/app/controllers/escalated/guest/tickets_controller.rb
+++ b/app/controllers/escalated/guest/tickets_controller.rb
@@ -50,6 +50,11 @@ module Escalated
           return
         end
 
+        # Apply the admin-configured guest policy (same logic as
+        # WidgetController#create_ticket — see that method for the mode
+        # reference). Always assign a guest_token so the guest-view
+        # redirect below works regardless of whether the ticket is
+        # ALSO attributed to a host user (guest_user mode).
         guest_token = SecureRandom.hex(32) # 64-character hex string
 
         # Dedupe repeat guests by email (Pattern B). Inline guest_*
@@ -60,17 +65,32 @@ module Escalated
           guest_ticket_params[:name]
         )
 
-        ticket = Escalated::Ticket.create!(
-          requester: nil,
-          guest_name: guest_ticket_params[:name],
-          guest_email: guest_ticket_params[:email],
-          guest_token: guest_token,
-          contact_id: contact.id,
+        attrs = {
           subject: guest_ticket_params[:subject],
           description: guest_ticket_params[:description],
           priority: guest_ticket_params[:priority] || Escalated.configuration.default_priority,
-          department_id: guest_ticket_params[:department_id].presence
-        )
+          department_id: guest_ticket_params[:department_id].presence,
+          guest_name: guest_ticket_params[:name],
+          guest_email: guest_ticket_params[:email],
+          guest_token: guest_token,
+          contact_id: contact.id
+        }
+
+        mode = Escalated::EscalatedSetting.get('guest_policy_mode').presence || 'unassigned'
+        if mode == 'guest_user'
+          guest_user_id = Escalated::EscalatedSetting.get('guest_policy_user_id').to_i
+          if guest_user_id.positive?
+            attrs[:requester_type] = Escalated.configuration.user_class
+            attrs[:requester_id] = guest_user_id
+          else
+            # Misconfigured guest_user mode: fall through to unassigned.
+            attrs[:requester] = nil
+          end
+        else
+          attrs[:requester] = nil
+        end
+
+        ticket = Escalated::Ticket.create!(attrs)
 
         if guest_ticket_params[:attachments].present?
           Services::AttachmentService.attach(ticket, guest_ticket_params[:attachments])

--- a/app/controllers/escalated/widget_controller.rb
+++ b/app/controllers/escalated/widget_controller.rb
@@ -74,14 +74,14 @@ module Escalated
       #     signup invite is a separate follow-up.
       mode = Escalated::EscalatedSetting.get('guest_policy_mode').presence || 'unassigned'
 
+      # Misconfigured guest_user (zero / missing id) falls through to
+      # unassigned behavior so bad admin input doesn't 500 the public
+      # endpoint.
       if mode == 'guest_user'
         guest_user_id = Escalated::EscalatedSetting.get('guest_policy_user_id').to_i
         if guest_user_id.positive?
           attrs[:requester_type] = Escalated.configuration.user_class
           attrs[:requester_id] = guest_user_id
-        else
-          # Misconfigured guest_user mode: fall through to unassigned
-          # behavior so bad admin input doesn't 500 the public endpoint.
         end
       end
       attrs[:guest_name] = params[:name]

--- a/app/controllers/escalated/widget_controller.rb
+++ b/app/controllers/escalated/widget_controller.rb
@@ -55,14 +55,39 @@ module Escalated
 
     # POST /support/widget/tickets
     def create_ticket
-      ticket = Escalated::Services::TicketService.create(
+      attrs = {
         subject: params[:subject],
         description: params[:description],
-        guest_name: params[:name],
-        guest_email: params[:email],
         priority: Escalated.configuration.default_priority,
         metadata: { 'source' => 'widget' }
-      )
+      }
+
+      # Apply the admin-configured guest policy. Persisted by
+      # Admin::SettingsController under three keys in
+      # escalated_escalated_settings. Modes:
+      #   - unassigned (default): guest_name / guest_email set,
+      #     requester_type / requester_id left nil.
+      #   - guest_user: route to a pre-created host-app user via
+      #     requester_type + requester_id. Still records the guest
+      #     email so agents see who submitted.
+      #   - prompt_signup: same ticket-create path as unassigned;
+      #     signup invite is a separate follow-up.
+      mode = Escalated::EscalatedSetting.get('guest_policy_mode').presence || 'unassigned'
+
+      if mode == 'guest_user'
+        guest_user_id = Escalated::EscalatedSetting.get('guest_policy_user_id').to_i
+        if guest_user_id.positive?
+          attrs[:requester_type] = Escalated.configuration.user_class
+          attrs[:requester_id] = guest_user_id
+        else
+          # Misconfigured guest_user mode: fall through to unassigned
+          # behavior so bad admin input doesn't 500 the public endpoint.
+        end
+      end
+      attrs[:guest_name] = params[:name]
+      attrs[:guest_email] = params[:email]
+
+      ticket = Escalated::Services::TicketService.create(attrs)
 
       render json: {
         reference: ticket.reference,


### PR DESCRIPTION
## Summary

Same bug as [escalated-laravel#72](https://github.com/escalated-dev/escalated-laravel/pull/72), in Rails: the admin settings page at \`Admin → Settings → Public tickets\` (shipped in escalated-rails#46) persists \`guest_policy_mode\` / \`guest_policy_user_id\` / \`guest_policy_signup_url_template\` to \`EscalatedSetting\`, but both public-submission paths — \`WidgetController#create_ticket\` and \`Guest::TicketsController#store\` — wrote \`guest_name\` / \`guest_email\` / \`guest_token\` unconditionally regardless of mode. **Result: the admin settings page had zero behavioral effect on actual ticket creation.**

## What changed

Both public-submission paths now branch on \`guest_policy_mode\`:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | Existing behavior — \`guest_*\` fields set, \`requester_*\` nil. |
| \`guest_user\` | Route to the configured host user: \`requester_type = Escalated.configuration.user_class\`, \`requester_id = guest_policy_user_id\`. Still records guest name/email so agents see who submitted. |
| \`prompt_signup\` | Same ticket-create path as unassigned. Signup-invite emission is a listener-level follow-up (needs a \`TicketSignupInviteEvent\` class added to the plugin first). |

Misconfigured \`guest_user\` mode (zero or missing \`guest_policy_user_id\`) falls through to unassigned so bad admin input can't 500 public submissions.

The \`Guest::TicketsController#store\` path also keeps generating a \`guest_token\` in \`guest_user\` mode, so the post-submit \`redirect_to "#{mount_path}/guest/<token>"\` still works. The token is orthogonal to requester attribution.

## Test plan

- [x] \`ruby -c\` syntax check passes on both files.
- [x] RuboCop clean on my edits (one pre-existing \`Layout/EndOfLine\` offense on unrelated files is a local env quirk — CI runs on Linux where the default LF matches).
- [ ] CI runs the full RSpec suite on merge. The existing widget/guest specs are unit-style (spec_helper doesn't load Rails / Pundit), so I couldn't add request-style tests locally without substantial new infrastructure. CI will exercise the new code paths once merged.

## Related

- [escalated-laravel#72](https://github.com/escalated-dev/escalated-laravel/pull/72) — identical fix in Laravel.
- [escalated-nestjs#27](https://github.com/escalated-dev/escalated-nestjs/pull/27) — closes the same gap on the reference plugin.
- Django / Adonis / WordPress likely have the same bug; each needs its own patch.