### PR TITLE
fix(inbound): honor guest_policy_mode on inbound-email-created tickets

### DIFF
--- a/lib/escalated/services/inbound_email_service.rb
+++ b/lib/escalated/services/inbound_email_service.rb
@@ -168,11 +168,13 @@ module Escalated
               metadata: { channel: 'email', original_message_id: message.message_id }
             )
           else
-            # Guest ticket (follows guest/tickets_controller.rb pattern)
+            # Guest ticket — apply the admin-configured guest policy
+            # (same branching as WidgetController#create_ticket). See
+            # app/controllers/escalated/widget_controller.rb for the
+            # reference impl.
             guest_token = SecureRandom.hex(32)
 
-            ticket = Escalated::Ticket.create!(
-              requester: nil,
+            attrs = {
               guest_name: message.from_name || message.from_email,
               guest_email: message.from_email,
               guest_token: guest_token,
@@ -180,7 +182,22 @@ module Escalated
               description: description,
               priority: Escalated.configuration.default_priority,
               metadata: { channel: 'email', original_message_id: message.message_id }
-            )
+            }
+
+            mode = Escalated::EscalatedSetting.get('guest_policy_mode').presence || 'unassigned'
+            if mode == 'guest_user'
+              guest_user_id = Escalated::EscalatedSetting.get('guest_policy_user_id').to_i
+              if guest_user_id.positive?
+                attrs[:requester_type] = Escalated.configuration.user_class
+                attrs[:requester_id] = guest_user_id
+              else
+                attrs[:requester] = nil
+              end
+            else
+              attrs[:requester] = nil
+            end
+
+            ticket = Escalated::Ticket.create!(attrs)
 
             # Dispatch notifications manually since we bypassed TicketService.create
             Services::NotificationService.dispatch(:ticket_created, ticket: ticket)


### PR DESCRIPTION
## Summary

Second wave of the widget↔settings-disconnection sweep. Mirror of [escalated-nestjs#28](https://github.com/escalated-dev/escalated-nestjs/pull/28) and [escalated-laravel#73](https://github.com/escalated-dev/escalated-laravel/pull/73).

When an inbound email arrives from a sender not in the configured user model, \`InboundEmailService\` created a guest ticket with \`requester: nil\` + \`guest_*\` fields **unconditionally**, ignoring the admin-configured \`guest_policy_mode\`.

## What changed

Now branches on the persisted \`guest_policy\`:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | Existing behavior — \`requester: nil\`, \`guest_*\` fields set. |
| \`guest_user\` | \`requester_type = Escalated.configuration.user_class\`, \`requester_id = guest_policy_user_id\`. Still records \`guest_name\` / \`guest_email\` so agents see who sent the email. |
| \`prompt_signup\` | Same unassigned path for ticket creation. Signup-invite emission is a listener-level follow-up. |

Misconfigured \`guest_user\` (zero user id) falls through to unassigned so bad admin input can't 500 inbound webhooks.

## Test plan

- [x] \`ruby -c\` syntax check passes.
- [ ] CI runs the full RSpec suite. The unit-style spec harness used in this repo doesn't load the full Rails stack, so adding new service-level tests here would require new infrastructure (same constraint as [#47](https://github.com/escalated-dev/escalated-rails/pull/47)). CI will exercise the widget/guest specs to catch regressions in the \`EscalatedSetting\` read pattern.

Local rubocop flags \`Layout/EndOfLine\` on the edit (expects CRLF); CI runs on Linux with LF default — same env quirk as on #47.

## Related

- NestJS #28, Laravel #73 (this sweep).
- Django / Adonis / WordPress have the same bug; each needs its own patch.