### PR TITLE
feat(i18n): consume central translations from escalated-locale gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Consume central translations from the `escalated-locale` gem; plugin-local `config/locales/*.yml` and a new `config/locales/overrides/` directory still override central keys (last-loaded wins)
 - SAML and JWT validation in SSO service
 - Full automation system matching Laravel AutomationRunner
 - Ticket type validation, scope, and controller filtering

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'escalated-locale',
+    git: 'https://github.com/escalated-dev/escalated-locale.git',
+    glob: 'packages/rubygems/escalated-locale.gemspec',
+    tag: 'v0.1.1'
+
 gem 'rexml'
 gem 'tzinfo-data'
 

--- a/README.md
+++ b/README.md
@@ -418,6 +418,25 @@ export default definePlugin({
 - [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
 - [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
 
+## Internationalization
+
+Translations are sourced from the central [`escalated-locale`](https://github.com/escalated-dev/escalated-locale)
+RubyGem, which is the canonical source of truth for every Escalated
+plugin in the portfolio. The engine appends the gem's `locales/*.yml`
+files to `I18n.load_path` automatically — you do not need to require
+anything in your host app.
+
+Override order (last wins):
+
+1. `escalated-locale` gem — central, portfolio-wide
+2. `config/locales/*.yml` inside this engine — plugin-local overrides
+3. `config/locales/overrides/*.yml` inside this engine — host-specific
+   tweaks that should not be upstreamed
+4. The host application's own `config/locales/*.yml`
+
+Missing keys in the lower layers fall through to the central gem via
+`I18n.fallbacks`.
+
 ## Also Available For
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package

--- a/config/locales/overrides/README.md
+++ b/config/locales/overrides/README.md
@@ -1,0 +1,14 @@
+# Locale overrides
+
+Drop `*.yml` files in this directory to override individual keys from
+the central `escalated-locale` gem or the plugin-local
+`config/locales/*.yml` files.
+
+Rails I18n loads translations in this order (last wins):
+
+1. `escalated-locale` gem (canonical, portfolio-wide)
+2. `config/locales/*.yml` (plugin-local)
+3. `config/locales/overrides/*.yml` (this directory)
+
+Files here are intended for host-specific tweaks that should not be
+upstreamed to the shared gem.

--- a/escalated.gemspec
+++ b/escalated.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*', 'app/**/*', 'config/**/*', 'db/**/*', 'resources/**/*', 'stubs/**/*', 'LICENSE',
                    'README.md']
 
+  spec.add_dependency 'escalated-locale', '~> 0.1'
   spec.add_dependency 'inertia_rails', '>= 3.0'
   spec.add_dependency 'pundit', '>= 2.0'
   spec.add_dependency 'rails', '>= 7.0'

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -23,10 +23,8 @@ module Escalated
       begin
         central_spec = Gem::Specification.find_by_name('escalated-locale')
         central_path = File.join(central_spec.gem_dir, 'locales')
-        if File.directory?(central_path)
-          config.i18n.load_path += Dir[File.join(central_path, '*.yml')]
-        end
-      rescue Gem::MissingSpecError, Gem::LoadError
+        config.i18n.load_path += Dir[File.join(central_path, '*.yml')] if File.directory?(central_path)
+      rescue Gem::LoadError
         # The central gem is optional at boot — if it's not yet installed
         # (e.g. during early CI before publish) fall back to plugin-local
         # translations only. A warning is logged so this isn't silent.

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -9,7 +9,34 @@ module Escalated
     end
 
     initializer 'escalated.i18n' do
+      # Load translations in priority order so the *last* path wins per
+      # Rails I18n's load semantics:
+      #
+      #   1. Central translations from the escalated-locale gem
+      #      (canonical source of truth for the whole portfolio).
+      #   2. Plugin-local config/locales/*.yml — these override central
+      #      keys, allowing per-host customization without forking the
+      #      shared gem.
+      #
+      # Host applications can still place their own files in
+      # config/locales/ to override either source.
+      begin
+        central_spec = Gem::Specification.find_by_name('escalated-locale')
+        central_path = File.join(central_spec.gem_dir, 'locales')
+        if File.directory?(central_path)
+          config.i18n.load_path += Dir[File.join(central_path, '*.yml')]
+        end
+      rescue Gem::MissingSpecError, Gem::LoadError
+        # The central gem is optional at boot — if it's not yet installed
+        # (e.g. during early CI before publish) fall back to plugin-local
+        # translations only. A warning is logged so this isn't silent.
+        warn '[Escalated::Engine] escalated-locale gem not found; ' \
+             'using plugin-local translations only.'
+      end
+
       config.i18n.load_path += Dir[root.join('config', 'locales', '*.yml')]
+      config.i18n.load_path += Dir[root.join('config', 'locales', 'overrides', '*.yml')]
+      config.i18n.fallbacks = true
     end
 
     initializer 'escalated.assets' do |app|


### PR DESCRIPTION
## Summary

Wire `escalated-rails` to consume translations from the new central
[`escalated-locale`](https://github.com/escalated-dev/escalated-locale)
RubyGem so every plugin in the portfolio shares a single source of
truth for i18n strings.

- **Gemspec**: add `escalated-locale ~> 0.1` runtime dependency.
- **Engine**: in the `escalated.i18n` initializer, locate the gem via
  `Gem::Specification.find_by_name('escalated-locale')` and prepend
  its `locales/*.yml` files to `I18n.load_path`. Plugin-local
  `config/locales/*.yml` and a new `config/locales/overrides/`
  directory are appended after, so they win per Rails I18n's
  last-loaded-wins semantics. `I18n.fallbacks = true` lets missing
  keys fall through to central.
- **Overrides scaffold**: add `config/locales/overrides/.gitkeep` and a
  short README so hosts have an obvious place to drop tweaks that
  shouldn't be upstreamed to the shared gem.
- **Docs**: new "Internationalization" section in README and an entry
  under `[Unreleased]` in CHANGELOG.

No translation content is modified in this PR — the existing 14
plugin-local YAML files stay in place as overrides. They can be
trimmed once central coverage is confirmed.

## Status

**Blocked on escalated-locale v0.1.0 RubyGems publish.** The new gem
is being bootstrapped from `packages/rubygems/escalated-locale.gemspec`
in the central repo and has not yet been pushed to RubyGems. CI will
fail at `bundle install` until it is — the engine code is written to
degrade gracefully (warns and falls back to plugin-local translations)
when the gem is not yet installed, but Bundler resolution itself will
still error.

## Test plan

- [ ] `escalated-locale` v0.1.0 published to RubyGems
- [ ] `bundle install` resolves on this branch
- [ ] `bundle exec rspec` is green
- [ ] Boot a host app with this branch and confirm translations load
      from the central gem (e.g. `I18n.t('escalated.tickets.status.open')`
      returns the central value when no plugin-local key shadows it)
- [ ] Drop a key in `config/locales/overrides/en.yml` and confirm it
      wins over both plugin-local and central
- [ ] Mark PR ready for review and merge