### PR TITLE
feat(admin): users-management page with admin/agent role toggles

### DIFF
--- a/app/controllers/escalated/admin/users_controller.rb
+++ b/app/controllers/escalated/admin/users_controller.rb
@@ -11,9 +11,10 @@ module Escalated
       before_action :require_admin!
 
       def index
-        scope = user_class.all
+        search = filter_params[:search].to_s.strip
+        scope  = user_class.all
 
-        if (search = params[:search].to_s.strip).present?
+        if search.present?
           term = "%#{search}%"
           conditions = ['email LIKE ?']
           values     = [term]
@@ -33,14 +34,15 @@ module Escalated
             data: result[:data].map { |u| user_json(u) },
             meta: result[:meta]
           },
-          filters: { search: params[:search].to_s },
+          filters: { search: search },
           currentUserId: current_user&.id
         }
       end
 
       def update_role
-        role  = params[:role].to_s
-        value = ActiveModel::Type::Boolean.new.cast(params[:value])
+        attrs = role_params
+        role  = attrs[:role].to_s
+        value = ActiveModel::Type::Boolean.new.cast(attrs[:value])
 
         unless %w[admin agent].include?(role)
           redirect_back_or_to(escalated.admin_users_path,
@@ -82,6 +84,14 @@ module Escalated
       end
 
       private
+
+      def filter_params
+        params.permit(:search)
+      end
+
+      def role_params
+        params.permit(:role, :value)
+      end
 
       def user_class
         Escalated.configuration.user_model

--- a/app/controllers/escalated/admin/users_controller.rb
+++ b/app/controllers/escalated/admin/users_controller.rb
@@ -51,7 +51,7 @@ module Escalated
           return
         end
 
-        target = user_class.find(params[:user_id])
+        target = user_class.find(params.expect(:user_id))
 
         # Don't let an admin demote themselves and lock themselves out of
         # the admin panel they're trying to use.

--- a/app/controllers/escalated/admin/users_controller.rb
+++ b/app/controllers/escalated/admin/users_controller.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Admin
+    # Surface enough of the host User table for an admin to grant or revoke
+    # agent / admin access from the panel. The default install pins this to
+    # the `is_admin` and `is_agent` columns the install generator tells hosts
+    # to add — hosts using a different role implementation (Pundit, custom
+    # role column, etc.) should override this controller in their own routes.
+    class UsersController < Escalated::ApplicationController
+      before_action :require_admin!
+
+      def index
+        scope = user_class.all
+
+        if (search = params[:search].to_s.strip).present?
+          term = "%#{search}%"
+          conditions = ['email LIKE ?']
+          values     = [term]
+          if column_exists?('name')
+            conditions << 'name LIKE ?'
+            values     << term
+          end
+          scope = scope.where(conditions.join(' OR '), *values)
+        end
+
+        scope = scope.order(is_admin: :desc, is_agent: :desc, id: :asc)
+
+        result = paginate(scope, per_page: 20)
+
+        render_page 'Escalated/Admin/Users/Index', {
+          users: {
+            data: result[:data].map { |u| user_json(u) },
+            meta: result[:meta]
+          },
+          filters: { search: params[:search].to_s },
+          currentUserId: current_user&.id
+        }
+      end
+
+      def update_role
+        role  = params[:role].to_s
+        value = ActiveModel::Type::Boolean.new.cast(params[:value])
+
+        unless %w[admin agent].include?(role)
+          redirect_back_or_to(escalated.admin_users_path,
+                              alert: I18n.t('escalated.admin.user.invalid_role',
+                                            default: 'Invalid role.'))
+          return
+        end
+
+        target = user_class.find(params[:user_id])
+
+        # Don't let an admin demote themselves and lock themselves out of
+        # the admin panel they're trying to use.
+        if role == 'admin' && !value && current_user && current_user.id.to_s == target.id.to_s
+          flash[:error] = I18n.t('escalated.admin.user.cannot_self_demote',
+                                 default: 'You cannot remove your own admin role.')
+          redirect_back_or_to(escalated.admin_users_path)
+          return
+        end
+
+        updates = {}
+        if role == 'admin'
+          updates[:is_admin] = value
+          # Admins are agents; flipping admin off does not also revoke agent
+          # (an ex-admin can still answer tickets unless explicitly demoted).
+          updates[:is_agent] = true if value
+        else
+          updates[:is_agent] = value
+          if !value && target.respond_to?(:is_admin) && target.is_admin
+            # Revoking agent from an admin would leave the admin gate on
+            # but the agent gate off — confusing. Demote them fully.
+            updates[:is_admin] = false
+          end
+        end
+
+        target.update!(updates)
+
+        flash[:success] = I18n.t('escalated.admin.user.updated', default: 'User updated.')
+        redirect_back_or_to(escalated.admin_users_path)
+      end
+
+      private
+
+      def user_class
+        Escalated.configuration.user_model
+      end
+
+      def column_exists?(name)
+        user_class.column_names.include?(name)
+      rescue StandardError
+        true
+      end
+
+      def user_json(user)
+        {
+          id: user.id,
+          name: user.respond_to?(:name) ? user.name : nil,
+          email: user.email,
+          is_admin: user.respond_to?(:is_admin) && user.is_admin ? true : false,
+          is_agent: user.respond_to?(:is_agent) && user.is_agent ? true : false
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,10 @@ Escalated::Engine.routes.draw do
     resources :roles, only: %i[index create update destroy]
     resources :audit_logs, only: [:index]
 
+    # Users (host User model: list + grant/revoke admin/agent flags)
+    get 'users', to: 'users#index', as: :users
+    patch 'users/:user_id/role', to: 'users#update_role', as: :user_role
+
     # Phase 2
     resources :custom_fields, only: %i[index create update destroy] do
       collection do

--- a/spec/controllers/escalated/admin/users_controller_spec.rb
+++ b/spec/controllers/escalated/admin/users_controller_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Mirrors escalated-laravel's tests/Feature/Admin/UserControllerTest.php (PR #94)
+# for the host User management surface.
+RSpec.describe 'Escalated::Admin::UsersController', type: :request do
+  let(:admin)     { create(:user, :admin,    email: 'admin@example.com') }
+  let(:agent)     { create(:user, :agent,    email: 'agent@example.com') }
+  let(:customer)  { create(:user,            email: 'customer@example.com') }
+
+  before do
+    allow(Escalated.configuration).to receive(:notification_channels).and_return([])
+  end
+
+  def sign_in_as(user)
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Escalated::ApplicationController)
+      .to receive(:current_user).and_return(user)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe 'GET /support/admin/users' do
+    it 'lists users with their admin/agent flags for an admin' do
+      admin
+      customer
+      agent
+
+      sign_in_as(admin)
+      get '/support/admin/users'
+
+      expect(response).to have_http_status(:ok)
+      body = response.body
+      expect(body).to include('admin@example.com')
+      expect(body).to include('customer@example.com')
+      expect(body).to include('agent@example.com')
+    end
+
+    it 'blocks non-admins from the user list' do
+      sign_in_as(agent)
+      get '/support/admin/users'
+
+      # require_admin! redirects to the host root with an alert.
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'filters users by search term' do
+      admin
+      jane = create(:user, email: 'jane@acme.test', name: 'Jane Acme')
+      bob  = create(:user, email: 'bob@globex.test', name: 'Bob Globex')
+
+      sign_in_as(admin)
+      get '/support/admin/users', params: { search: 'acme' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(jane.email)
+      expect(response.body).not_to include(bob.email)
+    end
+  end
+
+  describe 'PATCH /support/admin/users/:user_id/role' do
+    it 'promotes a user to admin (sets is_admin and is_agent)' do
+      target = create(:user, email: 'someone@example.com')
+
+      sign_in_as(admin)
+      patch "/support/admin/users/#{target.id}/role",
+            params: { role: 'admin', value: true }
+
+      expect(response).to have_http_status(:redirect)
+      target.reload
+      expect(target.is_admin).to be true
+      expect(target.is_agent).to be true
+    end
+
+    it 'promotes a user to agent only' do
+      target = create(:user, email: 'someone2@example.com')
+
+      sign_in_as(admin)
+      patch "/support/admin/users/#{target.id}/role",
+            params: { role: 'agent', value: true }
+
+      expect(response).to have_http_status(:redirect)
+      target.reload
+      expect(target.is_agent).to be true
+      expect(target.is_admin).to be false
+    end
+
+    it 'prevents admins from demoting themselves' do
+      sign_in_as(admin)
+      patch "/support/admin/users/#{admin.id}/role",
+            params: { role: 'admin', value: false }
+
+      expect(response).to have_http_status(:redirect)
+      admin.reload
+      expect(admin.is_admin).to be true
+    end
+
+    it 'demotes an admin and turns off agent in one step' do
+      target = create(:user, :admin, email: 'someone3@example.com')
+
+      sign_in_as(admin)
+      patch "/support/admin/users/#{target.id}/role",
+            params: { role: 'agent', value: false }
+
+      expect(response).to have_http_status(:redirect)
+      target.reload
+      expect(target.is_agent).to be false
+      expect(target.is_admin).to be false
+    end
+  end
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -15,11 +15,20 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
 
   def escalated_agent?
+    return true if respond_to?(:is_agent) && is_agent
+    return true if respond_to?(:is_admin) && is_admin
+
     %w[agent admin].include?(role)
   end
 
-  def admin?
+  def escalated_admin?
+    return true if respond_to?(:is_admin) && is_admin
+
     role == 'admin'
+  end
+
+  def admin?
+    escalated_admin?
   end
 
   def to_s

--- a/spec/dummy/db/migrate/20260510000000_add_role_flags_to_users.rb
+++ b/spec/dummy/db/migrate/20260510000000_add_role_flags_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRoleFlagsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :is_admin, :boolean, default: false, null: false
+    add_column :users, :is_agent, :boolean, default: false, null: false
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,10 +8,13 @@ FactoryBot.define do
 
     trait :agent do
       role { 'agent' }
+      is_agent { true }
     end
 
     trait :admin do
       role { 'admin' }
+      is_admin { true }
+      is_agent { true }
     end
   end
 end


### PR DESCRIPTION
## Summary

Mirrors [`escalated-laravel#94`](https://github.com/escalated-dev/escalated-laravel/pull/94) (commit `1b2c5b3e16a68056f1f9f90a6df6c733393a4519`). Adds an admin "Users" surface so an admin can list users and grant or revoke `is_admin` / `is_agent` flags on the host User model — feature parity with the Laravel host plugin.

## What was added

- **`app/controllers/escalated/admin/users_controller.rb`** — two actions behind `require_admin!`:
  - `index` renders `Escalated/Admin/Users/Index` with `users` (paginated, 20/page, ordered by `is_admin desc, is_agent desc, id asc`, LIKE search across `name` + `email`), `filters`, and `currentUserId`.
  - `update_role` writes `is_admin` / `is_agent` with the cascade from the Laravel reference: promoting to admin also sets `is_agent`; revoking agent on an admin demotes both; an admin cannot demote themselves (flash error, no write).
- **Routes** in `config/routes.rb` inside the `:admin` namespace: `GET /support/admin/users` (`admin_users`) and `PATCH /support/admin/users/:user_id/role` (`admin_user_role`).
- **Request spec** at `spec/controllers/escalated/admin/users_controller_spec.rb` mirroring the 7 Pest cases (list-for-admin, non-admin forbidden, promote-to-admin cascades, promote-to-agent-only, self-demote blocked, agent-toggle-demotes-admin, search filter).
- **Dummy app**: new migration `20260510000000_add_role_flags_to_users.rb` adds `is_admin` / `is_agent` boolean columns so the dummy User exercises the same surface the docker host-app demo uses; `escalated_admin?` / `escalated_agent?` now consider those columns first and fall back to the legacy `role` string; factory traits set both for backward compatibility with existing specs.

## Deviations from the Laravel pattern

- **`@escalated-dev/escalated` bump:** the repo ships no `package.json` (frontend integration is documented per-host in the README), so there was nothing to bump. The feature relies on the page that ships in `@escalated-dev/escalated@0.8.0`; hosts pick that up via their own `package.json`.
- **Auth signature:** Laravel uses `EnsureIsAdmin` middleware; the Rails engine convention is the `require_admin!` `before_action` already used by `RolesController`, `AuditLogsController`, etc. — mirrored, not reinvented.
- **Pagination shape:** Laravel returns Eloquent paginator JSON (`data`, `links`, `meta`); the engine reuses the existing `paginate` helper from `ApplicationController` and returns `{ data: [...], meta: {...} }`. The Vue page only reads `users.data` (and `users.links` if present), so the contract holds.

## Test plan

- [x] `bundle exec rubocop` on the 6 touched files — clean.
- [x] Spec file is well-formed (full suite cannot run locally on Windows due to a pre-existing UTF-8 / Psych issue in the central locale gem; CI runs on Ubuntu and is unaffected).
- [ ] CI `run-tests` job green (matrix Ruby 3.1 / 3.2 / 3.3).
- [ ] Manual smoke (host app): admin can hit `/support/admin/users`, toggle Admin / Agent on a target, see flags persist; admin cannot toggle their own Admin off.
