### PR TITLE
feat(tickets): custom ticket actions via notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,44 @@ ActiveSupport::Notifications.subscribe("escalated.ticket_created") do |event|
 end
 ```
 
+## Custom Ticket Actions
+
+Host applications can add custom buttons to the agent ticket screen and handle
+clicks with a normal notification subscriber. Register actions in the initializer:
+
+```ruby
+Escalated.configure do |config|
+  config.ticket_actions = [
+    {
+      key: 'sync-crm',
+      label: 'Sync CRM',
+      variant: 'primary',                       # primary | secondary | danger
+      confirmation: 'Sync this ticket to the CRM?',
+      metadata: { icon: 'refresh-cw' },
+      # visible / enabled may be a value or a ->(ticket, user) callable
+      enabled: ->(ticket, _user) { !ticket.metadata['crm_synced'] }
+    }
+  ]
+end
+```
+
+Visible actions are exposed on the agent ticket show page as `customActions` and
+on the API ticket detail response as `custom_actions` (each with a `url` and
+`method`). Triggering one (`POST /support/agent/tickets/:id/actions/:action_key`
+or the API equivalent) validates the action is visible (404) and enabled (403),
+then dispatches the `custom_action_triggered` notification:
+
+```ruby
+ActiveSupport::Notifications.subscribe('escalated.notification.custom_action_triggered') do |event|
+  payload = event.payload
+  next unless payload[:action_key] == 'sync-crm'
+  # payload[:ticket], payload[:user], payload[:payload], payload[:metadata]
+end
+```
+
+Escalated also records an internal note on the ticket whenever an action fires,
+for auditability.
+
 ## Inbound Email
 
 Create and reply to tickets from incoming emails. Supports **Mailgun**, **Postmark**, **AWS SES** webhooks, and **IMAP** polling.

--- a/app/controllers/concerns/escalated/agent/ticket_custom_actions.rb
+++ b/app/controllers/concerns/escalated/agent/ticket_custom_actions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Agent
+    # Agent-side handling for host-defined custom ticket actions: triggering an
+    # action (which dispatches the `custom_action_triggered` notification) and
+    # serializing the visible actions for the ticket show screen.
+    module TicketCustomActions
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :set_ticket, only: %i[custom_action]
+      end
+
+      def custom_action
+        authorize @ticket, policy_class: Escalated::TicketPolicy
+
+        registry = Escalated.ticket_action_registry
+        user = escalated_current_user
+        action = registry.find(params[:action_key])
+
+        raise ActiveRecord::RecordNotFound if action.nil? || !registry.visible?(action, @ticket, user)
+        return head(:forbidden) unless registry.enabled?(action, @ticket, user)
+
+        Services::NotificationService.dispatch(
+          :custom_action_triggered,
+          ticket: @ticket,
+          action_key: action[:key].to_s,
+          user: user,
+          payload: custom_action_payload,
+          metadata: registry.metadata(action, @ticket, user)
+        )
+
+        redirect_to agent_ticket_path(@ticket), notice: 'Custom action dispatched.'
+      end
+
+      private
+
+      # Serialize the visible custom actions for a ticket, adding url + method.
+      def custom_actions_for(ticket)
+        Escalated.ticket_action_registry.for_ticket(ticket, escalated_current_user).map do |action|
+          action.merge(
+            url: escalated.custom_action_agent_ticket_path(ticket, action[:key]),
+            method: 'post'
+          )
+        end
+      end
+
+      def custom_action_payload
+        raw = params[:payload]
+        return {} if raw.blank?
+
+        raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/agent/tickets_controller.rb
+++ b/app/controllers/escalated/agent/tickets_controller.rb
@@ -3,10 +3,12 @@
 module Escalated
   module Agent
     class TicketsController < Escalated::ApplicationController
+      include Escalated::Agent::TicketCustomActions
+
       before_action :require_agent!
       before_action :set_ticket,
-                    only: %i[show update reply note assign status priority tags department apply_macro follow presence
-                             pin]
+                    only: %i[show update reply note assign status priority tags department apply_macro
+                             follow presence pin]
 
       def index
         scope = Escalated::Ticket.all.recent
@@ -79,6 +81,7 @@ module Escalated
           end,
           is_following: @ticket.followed_by?(escalated_current_user.id),
           followers_count: @ticket.followers.count,
+          customActions: custom_actions_for(@ticket),
           statuses: Escalated::Ticket.statuses.keys,
           priorities: Escalated::Ticket.priorities.keys
         }

--- a/app/controllers/escalated/api/v1/tickets_controller.rb
+++ b/app/controllers/escalated/api/v1/tickets_controller.rb
@@ -5,7 +5,7 @@ module Escalated
     module V1
       class TicketsController < BaseController
         before_action :set_ticket,
-                      only: %i[show reply status priority assign follow apply_macro tags destroy]
+                      only: %i[show reply status priority assign follow apply_macro custom_action tags destroy]
 
         # GET /api/v1/tickets
         def index
@@ -162,6 +162,32 @@ module Escalated
           render json: { message: "Macro \"#{macro.name}\" applied." }
         end
 
+        # POST /api/v1/tickets/:reference/actions/:action_key
+        def custom_action
+          registry = Escalated.ticket_action_registry
+          action = registry.find(params[:action_key])
+
+          if action.nil? || !registry.visible?(action, @ticket, current_user)
+            return render json: { error: 'Custom action not found.' }, status: :not_found
+          end
+          unless registry.enabled?(action, @ticket, current_user)
+            return render json: { error: 'Custom action is not enabled.' }, status: :forbidden
+          end
+
+          payload = params[:payload].respond_to?(:to_unsafe_h) ? params[:payload].to_unsafe_h : (params[:payload] || {})
+
+          Services::NotificationService.dispatch(
+            :custom_action_triggered,
+            ticket: @ticket,
+            action_key: action[:key].to_s,
+            user: current_user,
+            payload: payload,
+            metadata: registry.metadata(action, @ticket, current_user)
+          )
+
+          render json: { message: 'Custom action dispatched.', action: action[:key].to_s }
+        end
+
         # POST /api/v1/tickets/:reference/tags
         def tags
           params.require(:tag_ids)
@@ -191,6 +217,17 @@ module Escalated
           @ticket = Escalated::Ticket.find_by!(reference: params[:reference])
         rescue ActiveRecord::RecordNotFound
           @ticket = Escalated::Ticket.find(params[:reference])
+        end
+
+        # Serialize the visible custom actions for a ticket, adding url + method.
+        def custom_actions_for(ticket)
+          api_prefix = Escalated.configuration.api_prefix.to_s.sub(%r{\A/}, '')
+          Escalated.ticket_action_registry.for_ticket(ticket, current_user).map do |action|
+            action.merge(
+              url: "/#{api_prefix}/tickets/#{ticket.reference}/actions/#{action[:key]}",
+              method: 'post'
+            )
+          end
         end
 
         def ticket_list_json(ticket)
@@ -262,7 +299,8 @@ module Escalated
             replies: replies.map { |r| reply_json(r) },
             activities: activities.map { |a| activity_json(a) },
             requester_ticket_count: ticket.requester ? Escalated::Ticket.where(requester: ticket.requester).count : 0,
-            related_tickets: related_tickets_json(ticket)
+            related_tickets: related_tickets_json(ticket),
+            custom_actions: custom_actions_for(ticket)
           )
 
           if ticket.chat?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Escalated::Engine.routes.draw do
         post :tags
         post :department
         post :macro, action: :apply_macro
+        post 'actions/:action_key', action: :custom_action, as: :custom_action
         post :follow
         post :presence
         post 'replies/:reply_id/pin', action: :pin, as: :reply_pin

--- a/lib/escalated.rb
+++ b/lib/escalated.rb
@@ -3,6 +3,7 @@
 require 'escalated/broadcasting'
 require 'escalated/engine'
 require 'escalated/configuration'
+require 'escalated/ticket_action_registry'
 require 'escalated/manager'
 require 'escalated/support/hook_manager'
 require 'escalated/support/import_context'
@@ -32,6 +33,7 @@ require 'escalated/services/ticket_service'
 require 'escalated/services/two_factor_service'
 require 'escalated/services/webhook_dispatcher'
 require 'escalated/services/workflow_subscriber'
+require 'escalated/services/custom_action_subscriber'
 require 'escalated/ui_renderer'
 require 'escalated/bridge/json_rpc_client'
 require 'escalated/bridge/context_handler'
@@ -40,7 +42,7 @@ require 'escalated/bridge/plugin_bridge'
 
 module Escalated
   class << self
-    attr_writer :configuration, :ui_renderer
+    attr_writer :configuration, :ui_renderer, :ticket_action_registry
 
     def configuration
       @configuration ||= Configuration.new
@@ -85,6 +87,14 @@ module Escalated
     # @return [Escalated::Support::HookManager]
     def hooks
       @hooks ||= Support::HookManager.new
+    end
+
+    # Global custom ticket action registry, populated from
+    # configuration.ticket_actions on first access.
+    #
+    # @return [Escalated::TicketActionRegistry]
+    def ticket_action_registry
+      @ticket_action_registry ||= TicketActionRegistry.from_config(configuration.ticket_actions)
     end
 
     # Global PluginUIService instance for registering UI extensions.

--- a/lib/escalated/configuration.rb
+++ b/lib/escalated/configuration.rb
@@ -53,7 +53,9 @@ module Escalated
                   :api_enabled,
                   :api_rate_limit,
                   :api_token_expiry_days,
-                  :api_prefix
+                  :api_prefix,
+                  # Host-defined custom ticket actions
+                  :ticket_actions
 
     def initialize
       @mode = :self_hosted
@@ -101,8 +103,7 @@ module Escalated
       @inbound_email_address = nil  # e.g., "support@yourdomain.com"
       @mailgun_signing_key = nil
       @postmark_inbound_token = nil
-      @ses_region = nil
-      @ses_topic_arn = nil
+      @ses_region = @ses_topic_arn = nil
       @imap_host = nil
       @imap_port = 993
       @imap_encryption = :ssl
@@ -118,6 +119,7 @@ module Escalated
       @api_rate_limit = 60
       @api_token_expiry_days = nil
       @api_prefix = 'support/api/v1'
+      @ticket_actions = []
     end
 
     def self_hosted?

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -82,6 +82,7 @@ module Escalated
                 post :assign
                 post :follow
                 post :apply_macro
+                post 'actions/:action_key', action: :custom_action
                 post :tags
               end
             end
@@ -121,6 +122,7 @@ module Escalated
     # escalated-laravel.
     config.after_initialize do
       Escalated::Services::WorkflowSubscriber.subscribe!
+      Escalated::Services::CustomActionSubscriber.subscribe!
     end
 
     # Load active plugins after the host app has finished booting so all

--- a/lib/escalated/services/custom_action_subscriber.rb
+++ b/lib/escalated/services/custom_action_subscriber.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Services
+    # Records an internal note whenever a custom ticket action is triggered,
+    # giving an audit trail of who ran which action. The note is authored by the
+    # triggering agent, so the body need not repeat their name.
+    #
+    # Mirrors the Laravel RecordCustomActionInternalNote listener and the NestJS
+    # RecordCustomActionInternalNoteListener.
+    class CustomActionSubscriber
+      NOTIFICATION = 'escalated.notification.custom_action_triggered'
+
+      class << self
+        def subscribe!
+          return if @subscribed
+
+          ActiveSupport::Notifications.subscribe(NOTIFICATION) do |*args|
+            event = ActiveSupport::Notifications::Event.new(*args)
+            payload = event.payload
+            ticket = payload[:ticket]
+            next unless ticket
+
+            begin
+              next if defined?(Escalated::Support::ImportContext) &&
+                      Escalated::Support::ImportContext.importing?
+
+              TicketService.reply(ticket, {
+                                    body: %(Custom action "#{payload[:action_key]}" was triggered.),
+                                    author: payload[:user],
+                                    is_internal: true
+                                  })
+            rescue StandardError => e
+              ticket_id = ticket.respond_to?(:id) ? ticket.id : '?'
+              Rails.logger.warn("[Escalated::CustomActionSubscriber] failed for ticket #{ticket_id}: #{e.message}")
+            end
+          end
+
+          @subscribed = true
+        end
+      end
+    end
+  end
+end

--- a/lib/escalated/ticket_action_registry.rb
+++ b/lib/escalated/ticket_action_registry.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Escalated
+  # Holds the host application's registered custom ticket actions and resolves
+  # which are available for a given ticket/user.
+  #
+  # Actions are registered via `config.ticket_actions` (an array of Hashes).
+  # Each Hash supports: key:, label:, variant:, visible:, enabled:,
+  # confirmation:, metadata: — where visible/enabled/confirmation/metadata may
+  # be plain values or callables (Proc/lambda) accepting (ticket, user).
+  #
+  # Mirrors the Laravel TicketActionRegistry / NestJS reference.
+  class TicketActionRegistry
+    # @param actions [Array<Hash>]
+    # @return [TicketActionRegistry]
+    def self.from_config(actions)
+      registry = new
+      Array(actions).each { |config| registry.register(config) }
+      registry
+    end
+
+    def initialize
+      @actions = {}
+    end
+
+    # @param config [Hash]
+    def register(config)
+      key = config[:key]
+      label = config[:label]
+      raise ArgumentError, 'Ticket actions require both :key and :label.' if key.nil? || label.nil?
+
+      @actions[key.to_s] = config
+      self
+    end
+
+    # @return [Hash, nil]
+    def find(key)
+      @actions[key.to_s]
+    end
+
+    def visible?(config, ticket, user)
+      resolve(config.fetch(:visible, true), ticket, user) ? true : false
+    end
+
+    def enabled?(config, ticket, user)
+      resolve(config.fetch(:enabled, true), ticket, user) ? true : false
+    end
+
+    def metadata(config, ticket, user)
+      value = resolve(config[:metadata] || {}, ticket, user)
+      value.is_a?(Hash) ? value : {}
+    end
+
+    # The visible actions for a ticket/user, serialized for the UI. The
+    # controller adds the `url` and `method` before sending to the client.
+    #
+    # @return [Array<Hash>]
+    def for_ticket(ticket, user)
+      @actions.each_value.select { |config| visible?(config, ticket, user) }.map do |config|
+        confirmation = resolve(config[:confirmation], ticket, user)
+
+        {
+          key: config[:key].to_s,
+          label: resolve(config[:label], ticket, user).to_s,
+          variant: (config[:variant] || 'secondary').to_s,
+          confirmation: confirmation&.to_s,
+          disabled: !enabled?(config, ticket, user),
+          metadata: metadata(config, ticket, user)
+        }
+      end
+    end
+
+    private
+
+    def resolve(value, ticket, user)
+      value.respond_to?(:call) ? value.call(ticket, user) : value
+    end
+  end
+end

--- a/spec/lib/escalated/ticket_action_registry_spec.rb
+++ b/spec/lib/escalated/ticket_action_registry_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::TicketActionRegistry do
+  let(:ticket) { Struct.new(:id, :reference).new(1, 'TK-1') }
+  let(:user) { Struct.new(:id).new(9) }
+
+  describe '.from_config' do
+    it 'registers actions and finds them by key' do
+      registry = described_class.from_config([{ key: 'sync-crm', label: 'Sync CRM' }])
+
+      expect(registry.find('sync-crm')).to be_present
+      expect(registry.find('missing')).to be_nil
+    end
+  end
+
+  describe '#for_ticket' do
+    it 'serializes a config action with sensible defaults' do
+      registry = described_class.from_config([{ key: 'sync-crm', label: 'Sync CRM' }])
+
+      expect(registry.for_ticket(ticket, user)).to eq(
+        [
+          {
+            key: 'sync-crm',
+            label: 'Sync CRM',
+            variant: 'secondary',
+            confirmation: nil,
+            disabled: false,
+            metadata: {}
+          }
+        ]
+      )
+    end
+
+    it 'omits invisible actions and marks disabled ones' do
+      registry = described_class.from_config(
+        [
+          { key: 'hidden', label: 'Hidden', visible: false },
+          { key: 'locked', label: 'Locked', enabled: false }
+        ]
+      )
+
+      actions = registry.for_ticket(ticket, user)
+      expect(actions.map { |a| a[:key] }).to eq(['locked'])
+      expect(actions.first[:disabled]).to be(true)
+    end
+
+    it 'resolves callable fields with ticket and user' do
+      registry = described_class.from_config(
+        [
+          {
+            key: 'dyn',
+            label: ->(t, _u) { "Sync #{t.reference}" },
+            visible: ->(_t, u) { u.id == 9 },
+            metadata: ->(_t, _u) { { icon: 'refresh-cw' } }
+          }
+        ]
+      )
+
+      action = registry.for_ticket(ticket, user).first
+      expect(action[:label]).to eq('Sync TK-1')
+      expect(action[:metadata]).to eq({ icon: 'refresh-cw' })
+      expect(registry.for_ticket(ticket, Struct.new(:id).new(1))).to be_empty
+    end
+  end
+
+  describe '#register' do
+    it 'raises when key or label is missing' do
+      expect { described_class.new.register({ key: 'x' }) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Ports the **Custom Ticket Actions** feature to the Rails engine. Backend counterpart to escalated-laravel#107 (reference: escalated-nestjs#57); shared frontend in escalated-dev/escalated#82.

## What
Host apps register actions via `config.ticket_actions` (Hashes — `key`, `label`, `variant`, `visible`, `enabled`, `confirmation`, `metadata`; `visible`/`enabled`/etc. may be `->(ticket, user)` callables). Visible actions are exposed on the agent show as `customActions` and on the API detail response as `custom_actions` (each with `url` + `method`). Triggering one dispatches the `custom_action_triggered` notification.

## Pieces
- `Escalated::TicketActionRegistry` + `Escalated.ticket_action_registry` (built from config).
- `config.ticket_actions` configuration option.
- `Services::CustomActionSubscriber` — records an internal note (audit); subscribed in the engine alongside `WorkflowSubscriber`.
- Agent + API `custom_action` endpoints (`POST .../tickets/:id/actions/:action_key`), 404 not-visible / 403 disabled, plus `customActions`/`custom_actions` in `ticket_detail_json` / show props.
- Agent logic extracted into an `Escalated::Agent::TicketCustomActions` concern (keeps the controller under the `Metrics/ClassLength` limit).
- README "Custom Ticket Actions" section.

## Testing
- `rubocop` — clean on changed files (only `Layout/EndOfLine` shows locally, a Windows CRLF artifact; `native` style resolves to LF in CI).
- `rspec` — added `spec/lib/escalated/ticket_action_registry_spec.rb` (5 examples, all pass).