### PR TITLE
ci: set least-privilege permissions on CI workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit top-level permissions block (contents: read) to the CI workflow(s) in this repo, resolving the CodeQL actions/missing-workflow-permissions alert. The job(s) only check out the repo and run lint/tests, so contents: read is sufficient. Mirrors the fix merged in escalated-laravel (#126). No functional change to CI.