### PR TITLE
ci: make RuboCop green + least-privilege workflow permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/MethodLength:
   Max: 50
   Exclude:
     - "lib/escalated/services/hook_registry.rb"
+    - "lib/escalated/configuration.rb"
 
 Metrics/AbcSize:
   Max: 100
@@ -83,6 +84,14 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 
 Rails/WhereNotWithMultipleConditions:
+  Enabled: false
+
+# Pending cop (rubocop-rails) that rewrites plain `params[:id]` reads to
+# `params.expect(...)`. We have not adopted Rails 8 strong-parameters `expect`,
+# and its autocorrect changes behaviour on simple lookups (raises on missing),
+# so keep it off — consistent with the other opinionated Rails cops disabled
+# above. Revisit as a deliberate migration.
+Rails/StrongParametersExpect:
   Enabled: false
 
 Lint/UnderscorePrefixedVariableName:

--- a/app/controllers/escalated/customer/tickets_controller.rb
+++ b/app/controllers/escalated/customer/tickets_controller.rb
@@ -162,7 +162,7 @@ module Escalated
             chat_session_id: session&.id,
             chat_started_at: session&.started_at&.iso8601,
             chat_messages: ticket.replies.public_replies.chronological.includes(:author)
-                           .map { |r| chat_message_json(r) },
+                                 .map { |r| chat_message_json(r) },
             chat_metadata: session&.metadata
           )
         end

--- a/app/controllers/escalated/guest/tickets_controller.rb
+++ b/app/controllers/escalated/guest/tickets_controller.rb
@@ -256,7 +256,7 @@ module Escalated
             chat_session_id: session&.id,
             chat_started_at: session&.started_at&.iso8601,
             chat_messages: ticket.replies.where(is_internal: false, is_system: false)
-                           .order(created_at: :asc).includes(:author).map { |r| guest_chat_message_json(r) },
+                                 .order(created_at: :asc).includes(:author).map { |r| guest_chat_message_json(r) },
             chat_metadata: session&.metadata
           )
         end

--- a/app/services/escalated/reporting_service.rb
+++ b/app/services/escalated/reporting_service.rb
@@ -16,9 +16,9 @@ module Escalated
         {
           date: date.strftime('%Y-%m-%d'),
           frt_breaches: day_tickets.where(sla_breached: true, first_response_at: nil)
-                        .where(sla_first_response_due_at: day_range).count,
+                                   .where(sla_first_response_due_at: day_range).count,
           resolution_breaches: day_tickets.where(sla_breached: true, resolved_at: nil)
-                               .where(sla_resolution_due_at: day_range).count,
+                                          .where(sla_resolution_due_at: day_range).count,
           total_breaches: day_tickets.where(sla_breached: true).where(updated_at: day_range).count
         }
       end

--- a/spec/lib/escalated/ticket_action_registry_spec.rb
+++ b/spec/lib/escalated/ticket_action_registry_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Escalated::TicketActionRegistry do
       )
 
       actions = registry.for_ticket(ticket, user)
-      expect(actions.map { |a| a[:key] }).to eq(['locked'])
+      expect(actions.pluck(:key)).to eq(['locked'])
       expect(actions.first[:disabled]).to be(true)
     end
 


### PR DESCRIPTION
Makes the rails RuboCop CI green (it has been red on `main`, which blocked the workflow-permissions PR #62) and folds in that permissions change.

## Root cause

rails CI runs `bundle exec rubocop`, but `rubocop-rails` is unpinned in the Gemfile, so CI resolves a newer version than `Gemfile.lock` (2.34.3). That newer version enables the **pending** `Rails/StrongParametersExpect` cop, which flags 65 plain `params[:id]` reads across controllers as "use `params.expect(...)`". (These do not reproduce on a local 2.34.3 run, which is why the failure looked mysterious.)

## Changes

- **Disable `Rails/StrongParametersExpect`** in `.rubocop.yml`. Autocorrecting `find(params[:id])` → `params.expect(:id)` changes behaviour (raises on missing) and assumes Rails 8 strong-params, which this codebase hasn't adopted. Disabling it is consistent with the other opinionated Rails cops already turned off in this config. Revisit as a deliberate migration.
- **Align 4 multiline method chains** (`Layout/MultilineMethodCallIndentation`) in the customer/guest ticket controllers and reporting service.
- **`pluck(:key)`** instead of `map { |a| a[:key] }` in one spec (`Rails/Pluck`).
- **Exclude the config defaults initializer** from `Metrics/MethodLength` (it's 51/50, a flat assignment list — same treatment as `hook_registry.rb`).
- **Add `permissions: { contents: read }`** to `run-tests.yml` (the original intent of #62, which this supersedes).

The modified spec passes locally (5 examples, 0 failures); the chain-alignment changes are whitespace-only.
