### PR TITLE
fix(newsletter): UUID-safe user-id columns in newsletter migrations

### DIFF
--- a/db/migrate/056_create_escalated_newsletter_lists.rb
+++ b/db/migrate/056_create_escalated_newsletter_lists.rb
@@ -9,7 +9,7 @@ class CreateEscalatedNewsletterLists < ActiveRecord::Migration[7.0]
       t.text :description
       t.string :kind, null: false, limit: 16
       t.json :filter_json
-      t.bigint :created_by
+      t.column :created_by, Escalated.user_id_type
       t.timestamps
     end
 

--- a/db/migrate/057_create_escalated_newsletter_list_members.rb
+++ b/db/migrate/057_create_escalated_newsletter_list_members.rb
@@ -10,7 +10,7 @@ class CreateEscalatedNewsletterListMembers < ActiveRecord::Migration[7.0]
       t.bigint :list_id, null: false
       t.bigint :contact_id, null: false
       t.datetime :added_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
-      t.bigint :added_by
+      t.column :added_by, Escalated.user_id_type
     end
 
     # Explicit short name — the auto-generated name exceeds the 64-char index

--- a/db/migrate/058_create_escalated_newsletter_templates.rb
+++ b/db/migrate/058_create_escalated_newsletter_templates.rb
@@ -10,7 +10,7 @@ class CreateEscalatedNewsletterTemplates < ActiveRecord::Migration[7.0]
       t.string :subject_template, limit: 998
       t.text :body_markdown, null: false
       t.json :merge_fields_schema
-      t.bigint :created_by
+      t.column :created_by, Escalated.user_id_type
       t.timestamps
     end
 

--- a/db/migrate/059_create_escalated_newsletters.rb
+++ b/db/migrate/059_create_escalated_newsletters.rb
@@ -18,8 +18,8 @@ class CreateEscalatedNewsletters < ActiveRecord::Migration[7.0]
       t.string :status, null: false, limit: 16, default: 'draft'
       t.datetime :scheduled_at
       t.datetime :sent_at
-      t.bigint :created_by
-      t.bigint :sent_by
+      t.column :created_by, Escalated.user_id_type
+      t.column :sent_by, Escalated.user_id_type
       t.integer :summary_total, default: 0
       t.integer :summary_sent, default: 0
       t.integer :summary_opened, default: 0


### PR DESCRIPTION
Newsletter `created_by`/`added_by`/`sent_by` used `t.bigint`, reintroducing the integer-only host-user-key assumption. Switches them to `Escalated.user_id_type` (the same helper as `tickets.requester_id` / `assigned_to`), so uuid/string-keyed hosts work; FK columns stay `bigint`. Resolver spec (which runs the migrations) green.