### PR TITLE
feat(newsletters): complete HTTP layer (Rails)

### DIFF
--- a/app/controllers/concerns/escalated/newsletter_access.rb
+++ b/app/controllers/concerns/escalated/newsletter_access.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Escalated
+  module NewsletterAccess
+    extend ActiveSupport::Concern
+
+    private
+
+    def ensure_newsletters_enabled!
+      return if Escalated.configuration.enable_newsletters?
+
+      head :not_found
+    end
+
+    def require_newsletter_permission!(slug)
+      return if newsletter_permission_granted?(slug)
+
+      render_page 'Escalated/Error', {
+        status: 403,
+        message: I18n.t('escalated.middleware.not_authorized')
+      }, status: :forbidden
+    end
+
+    def require_newsletter_send_permission!
+      require_newsletter_permission!('newsletters.send')
+    end
+
+    def newsletter_permission_granted?(slug)
+      user = escalated_current_user
+      return false unless user
+
+      return true if user.respond_to?(:has_permission?) && user.has_permission?(slug)
+
+      roles = newsletter_roles_for(user)
+      return true if roles.nil? && current_user_data&.dig(:is_admin)
+      return false if roles.blank?
+
+      roles.any? do |role|
+        role.respond_to?(:has_permission?) && role.has_permission?(slug)
+      end
+    end
+
+    def newsletter_roles_for(user)
+      if user.respond_to?(:escalated_roles)
+        user.escalated_roles
+      elsif user.respond_to?(:roles)
+        user.roles
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/newsletter_lists_controller.rb
+++ b/app/controllers/escalated/admin/newsletter_lists_controller.rb
@@ -15,11 +15,27 @@ module Escalated
       def index
         lists = Escalated::NewsletterList
                 .left_joins(:members)
-                .select("#{Escalated::NewsletterList.table_name}.*, COUNT(#{Escalated::NewsletterListMember.table_name}.id) AS member_count")
+                .select("#{Escalated::NewsletterList.table_name}.*, COUNT(#{Escalated::NewsletterListMember.table_name}.id) AS member_count") # rubocop:disable Layout/LineLength
                 .group("#{Escalated::NewsletterList.table_name}.id")
                 .map { |list| list_json(list) }
 
         render_page 'Escalated/Admin/Newsletters/Lists/Index', { lists: lists }
+      end
+
+      def show
+        members = paginate(@list.members.includes(:contact).order(id: :desc), per_page: 100)
+        match_count = if @list.kind == 'dynamic'
+                        Escalated::Newsletter::ContactSegmentResolver.new.count_matches(@list.filter_json || { 'rules' => [] }) # rubocop:disable Layout/LineLength
+                      else
+                        0
+                      end
+
+        render_page 'Escalated/Admin/Newsletters/Lists/Show', {
+          list: list_json(@list),
+          members: members[:data],
+          meta: members[:meta],
+          matchCount: match_count
+        }
       end
 
       def create
@@ -32,22 +48,6 @@ module Escalated
 
         list = Escalated::NewsletterList.create!(data.merge(created_by: escalated_current_user&.id))
         redirect_to admin_newsletters_list_path(list)
-      end
-
-      def show
-        members = paginate(@list.members.includes(:contact).order(id: :desc), per_page: 100)
-        match_count = if @list.kind == 'dynamic'
-                        Escalated::Newsletter::ContactSegmentResolver.new.count_matches(@list.filter_json || { 'rules' => [] })
-                      else
-                        0
-                      end
-
-        render_page 'Escalated/Admin/Newsletters/Lists/Show', {
-          list: list_json(@list),
-          members: members[:data],
-          meta: members[:meta],
-          matchCount: match_count
-        }
       end
 
       def update
@@ -68,7 +68,7 @@ module Escalated
 
         contact_id = params[:contact_id]
         unless contact_id.present? && Escalated::Contact.exists?(contact_id)
-          return render plain: 'contact_id is invalid', status: :unprocessable_entity
+          return render plain: 'contact_id is invalid', status: :unprocessable_content
         end
 
         Escalated::NewsletterListMember.find_or_create_by!(list_id: @list.id, contact_id: contact_id) do |member|
@@ -86,7 +86,7 @@ module Escalated
 
       def import
         return unless static_list!
-        return render plain: 'file is required', status: :unprocessable_entity unless params[:file].respond_to?(:path)
+        return render plain: 'file is required', status: :unprocessable_content unless params[:file].respond_to?(:path)
 
         imported = 0
         CSV.foreach(params[:file].path) do |row|
@@ -121,14 +121,14 @@ module Escalated
         end
         return data if errors.empty?
 
-        render plain: errors.join(', '), status: :unprocessable_entity
+        render plain: errors.join(', '), status: :unprocessable_content
         nil
       end
 
       def static_list!
         return true if @list.kind == 'static'
 
-        render plain: 'Dynamic lists are filter-driven', status: :unprocessable_entity
+        render plain: 'Dynamic lists are filter-driven', status: :unprocessable_content
         false
       end
 

--- a/app/controllers/escalated/admin/newsletter_lists_controller.rb
+++ b/app/controllers/escalated/admin/newsletter_lists_controller.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Escalated
+  module Admin
+    class NewsletterListsController < Escalated::ApplicationController
+      include Escalated::NewsletterAccess
+
+      before_action :require_admin!
+      before_action :ensure_newsletters_enabled!
+      before_action -> { require_newsletter_permission!('newsletters.manage') }
+      before_action :set_list, only: %i[show update destroy add_member remove_member import]
+
+      def index
+        lists = Escalated::NewsletterList
+                .left_joins(:members)
+                .select("#{Escalated::NewsletterList.table_name}.*, COUNT(#{Escalated::NewsletterListMember.table_name}.id) AS member_count")
+                .group("#{Escalated::NewsletterList.table_name}.id")
+                .map { |list| list_json(list) }
+
+        render_page 'Escalated/Admin/Newsletters/Lists/Index', { lists: lists }
+      end
+
+      def create
+        render_page 'Escalated/Admin/Newsletters/Lists/Create', {}
+      end
+
+      def store
+        data = list_params(require_kind: true)
+        return unless data
+
+        list = Escalated::NewsletterList.create!(data.merge(created_by: escalated_current_user&.id))
+        redirect_to admin_newsletters_list_path(list)
+      end
+
+      def show
+        members = paginate(@list.members.includes(:contact).order(id: :desc), per_page: 100)
+        match_count = if @list.kind == 'dynamic'
+                        Escalated::Newsletter::ContactSegmentResolver.new.count_matches(@list.filter_json || { 'rules' => [] })
+                      else
+                        0
+                      end
+
+        render_page 'Escalated/Admin/Newsletters/Lists/Show', {
+          list: list_json(@list),
+          members: members[:data],
+          meta: members[:meta],
+          matchCount: match_count
+        }
+      end
+
+      def update
+        data = list_params(require_kind: false)
+        return unless data
+
+        @list.update!(data.except(:kind))
+        redirect_to admin_newsletters_list_path(@list)
+      end
+
+      def destroy
+        @list.destroy!
+        redirect_to admin_newsletters_lists_path
+      end
+
+      def add_member
+        return unless static_list!
+
+        contact_id = params[:contact_id]
+        unless contact_id.present? && Escalated::Contact.exists?(contact_id)
+          return render plain: 'contact_id is invalid', status: :unprocessable_entity
+        end
+
+        Escalated::NewsletterListMember.find_or_create_by!(list_id: @list.id, contact_id: contact_id) do |member|
+          member.added_by = escalated_current_user&.id
+        end
+        redirect_to admin_newsletters_list_path(@list)
+      end
+
+      def remove_member
+        return unless static_list!
+
+        Escalated::NewsletterListMember.where(list_id: @list.id, contact_id: params[:contact_id]).delete_all
+        redirect_to admin_newsletters_list_path(@list)
+      end
+
+      def import
+        return unless static_list!
+        return render plain: 'file is required', status: :unprocessable_entity unless params[:file].respond_to?(:path)
+
+        imported = 0
+        CSV.foreach(params[:file].path) do |row|
+          email = row.first.to_s.strip
+          next unless email.match?(URI::MailTo::EMAIL_REGEXP)
+
+          contact = Escalated::Contact.find_or_create_by!(email: email)
+          Escalated::NewsletterListMember.find_or_create_by!(list_id: @list.id, contact_id: contact.id) do |member|
+            member.added_by = escalated_current_user&.id
+          end
+          imported += 1
+        end
+
+        redirect_to admin_newsletters_list_path(@list), notice: "Imported #{imported} contacts"
+      end
+
+      private
+
+      def set_list
+        @list = Escalated::NewsletterList.find(params[:id] || params[:list_id])
+      end
+
+      def list_params(require_kind:)
+        data = params.permit(:name, :description, :kind, filter_json: {}).to_h.symbolize_keys
+        errors = []
+        errors << 'name is required' if require_kind && data[:name].blank?
+        errors << 'name is too long' if data[:name].to_s.length > 255
+        if require_kind
+          errors << 'kind is invalid' unless %w[static dynamic].include?(data[:kind].to_s)
+        elsif data.key?(:kind)
+          data.delete(:kind)
+        end
+        return data if errors.empty?
+
+        render plain: errors.join(', '), status: :unprocessable_entity
+        nil
+      end
+
+      def static_list!
+        return true if @list.kind == 'static'
+
+        render plain: 'Dynamic lists are filter-driven', status: :unprocessable_entity
+        false
+      end
+
+      def list_json(list)
+        list.as_json.merge(
+          'member_count' => list.respond_to?(:member_count) ? list.member_count.to_i : list.members.count,
+          'opted_out_count' => opted_out_count(list)
+        )
+      end
+
+      def opted_out_count(list)
+        Escalated::NewsletterListMember
+          .joins(:contact)
+          .where(list_id: list.id)
+          .where.not(Escalated::Contact.table_name => { marketing_opt_out_at: nil })
+          .count
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/newsletter_settings_controller.rb
+++ b/app/controllers/escalated/admin/newsletter_settings_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Admin
+    class NewsletterSettingsController < Escalated::ApplicationController
+      include Escalated::NewsletterAccess
+
+      KEYS = {
+        default_from: 'string',
+        default_reply_to: 'string',
+        default_theme: 'string',
+        rate_limit_per_minute: 'number',
+        batch_size: 'number',
+        tracking_enabled: 'boolean'
+      }.freeze
+
+      before_action :require_admin!
+      before_action :ensure_newsletters_enabled!
+      before_action -> { require_newsletter_permission!('newsletters.manage') }
+
+      def show
+        settings = KEYS.each_key.to_h { |key| [key, setting_value(key)] }
+
+        render_page 'Escalated/Admin/Newsletters/Settings', {
+          settings: settings,
+          themes: %w[default branded]
+        }
+      end
+
+      def update
+        data = settings_params
+        return unless data
+
+        KEYS.each do |key, type|
+          value = data[key]
+          stored = type == 'boolean' ? boolean_value(value).to_s : value.to_s
+          Escalated::EscalatedSetting.set("newsletter.#{key}", stored)
+        end
+
+        redirect_to admin_newsletters_settings_path
+      end
+
+      private
+
+      def settings_params
+        data = params.permit(*KEYS.keys).to_h.symbolize_keys
+        errors = []
+        errors << 'default_from is invalid' if data[:default_from].present? && !valid_email?(data[:default_from])
+        errors << 'default_reply_to is invalid' if data[:default_reply_to].present? && !valid_email?(data[:default_reply_to])
+        errors << 'default_theme is required' if data[:default_theme].blank?
+        errors << 'default_theme is too long' if data[:default_theme].to_s.length > 64
+        rate = data[:rate_limit_per_minute].to_i
+        batch = data[:batch_size].to_i
+        errors << 'rate_limit_per_minute is invalid' unless rate.between?(1, 10_000)
+        errors << 'batch_size is invalid' unless batch.between?(1, 1000)
+        errors << 'tracking_enabled is required' unless data.key?(:tracking_enabled)
+        return data.merge(rate_limit_per_minute: rate, batch_size: batch) if errors.empty?
+
+        render plain: errors.join(', '), status: :unprocessable_entity
+        nil
+      end
+
+      def setting_value(key)
+        Escalated::EscalatedSetting.get("newsletter.#{key}", configuration_default(key))
+      end
+
+      def configuration_default(key)
+        Escalated.configuration.public_send("newsletter_#{key}")
+      end
+
+      def boolean_value(value)
+        %w[1 true on yes].include?(value.to_s.downcase) ? 1 : 0
+      end
+
+      def valid_email?(email)
+        email.to_s.match?(URI::MailTo::EMAIL_REGEXP)
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/newsletter_settings_controller.rb
+++ b/app/controllers/escalated/admin/newsletter_settings_controller.rb
@@ -19,7 +19,7 @@ module Escalated
       before_action -> { require_newsletter_permission!('newsletters.manage') }
 
       def show
-        settings = KEYS.each_key.to_h { |key| [key, setting_value(key)] }
+        settings = KEYS.each_key.index_with { |key| setting_value(key) }
 
         render_page 'Escalated/Admin/Newsletters/Settings', {
           settings: settings,
@@ -46,7 +46,9 @@ module Escalated
         data = params.permit(*KEYS.keys).to_h.symbolize_keys
         errors = []
         errors << 'default_from is invalid' if data[:default_from].present? && !valid_email?(data[:default_from])
-        errors << 'default_reply_to is invalid' if data[:default_reply_to].present? && !valid_email?(data[:default_reply_to])
+        if data[:default_reply_to].present? && !valid_email?(data[:default_reply_to])
+          errors << 'default_reply_to is invalid'
+        end
         errors << 'default_theme is required' if data[:default_theme].blank?
         errors << 'default_theme is too long' if data[:default_theme].to_s.length > 64
         rate = data[:rate_limit_per_minute].to_i
@@ -56,7 +58,7 @@ module Escalated
         errors << 'tracking_enabled is required' unless data.key?(:tracking_enabled)
         return data.merge(rate_limit_per_minute: rate, batch_size: batch) if errors.empty?
 
-        render plain: errors.join(', '), status: :unprocessable_entity
+        render plain: errors.join(', '), status: :unprocessable_content
         nil
       end
 

--- a/app/controllers/escalated/admin/newsletter_templates_controller.rb
+++ b/app/controllers/escalated/admin/newsletter_templates_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Escalated
+  module Admin
+    class NewsletterTemplatesController < Escalated::ApplicationController
+      include Escalated::NewsletterAccess
+
+      before_action :require_admin!
+      before_action :ensure_newsletters_enabled!
+      before_action -> { require_newsletter_permission!('newsletters.manage') }
+      before_action :set_template, only: %i[show update destroy]
+
+      def index
+        render_page 'Escalated/Admin/Newsletters/Templates/Index', {
+          templates: Escalated::NewsletterTemplate.order(created_at: :desc)
+        }
+      end
+
+      def create
+        render_page 'Escalated/Admin/Newsletters/Templates/Create', { themes: themes }
+      end
+
+      def store
+        data = template_params
+        return unless data
+
+        Escalated::NewsletterTemplate.create!(data.merge(created_by: escalated_current_user&.id))
+        redirect_to admin_newsletters_templates_path
+      end
+
+      def show
+        render_page 'Escalated/Admin/Newsletters/Templates/Show', {
+          template: @template,
+          themes: themes,
+          isNew: false
+        }
+      end
+
+      def update
+        data = template_params
+        return unless data
+
+        @template.update!(data)
+        redirect_to admin_newsletters_template_path(@template)
+      end
+
+      def destroy
+        @template.destroy!
+        redirect_to admin_newsletters_templates_path
+      end
+
+      private
+
+      def set_template
+        @template = Escalated::NewsletterTemplate.find(params[:id])
+      end
+
+      def template_params
+        data = params.permit(:name, :theme, :subject_template, :body_markdown, merge_fields_schema: {}).to_h.symbolize_keys
+        errors = []
+        errors << 'name is required' if data[:name].blank?
+        errors << 'name is too long' if data[:name].to_s.length > 255
+        errors << 'theme is required' if data[:theme].blank?
+        errors << 'theme is too long' if data[:theme].to_s.length > 64
+        errors << 'subject_template is too long' if data[:subject_template].to_s.length > 998
+        errors << 'body_markdown is required' if data[:body_markdown].blank?
+        return data if errors.empty?
+
+        render plain: errors.join(', '), status: :unprocessable_entity
+        nil
+      end
+
+      def themes
+        roots = [
+          Escalated.configuration.newsletter_themes_dir,
+          File.expand_path('../../../views/escalated/newsletter_themes', __dir__)
+        ].compact
+        found = roots.flat_map do |root|
+          next [] unless File.directory?(root)
+
+          Dir[File.join(root, '*.html.erb')].map { |path| File.basename(path, '.html.erb') }
+        end.uniq
+        found.presence || %w[default branded]
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/newsletter_templates_controller.rb
+++ b/app/controllers/escalated/admin/newsletter_templates_controller.rb
@@ -16,6 +16,14 @@ module Escalated
         }
       end
 
+      def show
+        render_page 'Escalated/Admin/Newsletters/Templates/Show', {
+          template: @template,
+          themes: themes,
+          isNew: false
+        }
+      end
+
       def create
         render_page 'Escalated/Admin/Newsletters/Templates/Create', { themes: themes }
       end
@@ -26,14 +34,6 @@ module Escalated
 
         Escalated::NewsletterTemplate.create!(data.merge(created_by: escalated_current_user&.id))
         redirect_to admin_newsletters_templates_path
-      end
-
-      def show
-        render_page 'Escalated/Admin/Newsletters/Templates/Show', {
-          template: @template,
-          themes: themes,
-          isNew: false
-        }
       end
 
       def update
@@ -56,7 +56,8 @@ module Escalated
       end
 
       def template_params
-        data = params.permit(:name, :theme, :subject_template, :body_markdown, merge_fields_schema: {}).to_h.symbolize_keys
+        data = params.permit(:name, :theme, :subject_template, :body_markdown,
+                             merge_fields_schema: {}).to_h.symbolize_keys
         errors = []
         errors << 'name is required' if data[:name].blank?
         errors << 'name is too long' if data[:name].to_s.length > 255
@@ -66,7 +67,7 @@ module Escalated
         errors << 'body_markdown is required' if data[:body_markdown].blank?
         return data if errors.empty?
 
-        render plain: errors.join(', '), status: :unprocessable_entity
+        render plain: errors.join(', '), status: :unprocessable_content
         nil
       end
 

--- a/app/controllers/escalated/admin/newsletters_controller.rb
+++ b/app/controllers/escalated/admin/newsletters_controller.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Escalated
+  module Admin
+    class NewslettersController < Escalated::ApplicationController
+      include Escalated::NewsletterAccess
+
+      before_action :require_admin!
+      before_action :ensure_newsletters_enabled!
+      before_action -> { require_newsletter_permission!('newsletters.manage') }
+      before_action :set_newsletter, only: %i[show edit update destroy]
+      before_action :require_newsletter_send_permission!, only: :test
+
+      def index
+        tab = params[:tab].presence || 'drafts'
+        statuses = case tab
+                   when 'scheduled' then %w[scheduled sending paused]
+                   when 'sent' then %w[sent failed]
+                   else %w[draft]
+                   end
+        scope = Escalated::Newsletter.includes(:target_list).where(status: statuses).order(created_at: :desc)
+        result = paginate(scope, per_page: 50)
+
+        render_page 'Escalated/Admin/Newsletters/Index', {
+          newsletters: result[:data],
+          meta: result[:meta],
+          tab: tab
+        }
+      end
+
+      def create
+        render_page 'Escalated/Admin/Newsletters/Compose', compose_props
+      end
+
+      def store
+        data = newsletter_params
+        return unless data
+        return unless authorize_send_status!(data)
+
+        newsletter = Escalated::Newsletter.create!(data.merge(created_by: escalated_current_user&.id))
+        Escalated::Newsletter::Planner.new.plan(newsletter) if data[:status] == 'sending'
+
+        redirect_to admin_newsletters_show_path(newsletter)
+      end
+
+      def preview
+        data = preview_params
+        return unless data
+
+        newsletter = Escalated::Newsletter.new(data.merge(
+                                                 subject: data[:subject].presence || '',
+                                                 theme: data[:theme].presence || 'default',
+                                                 from_email: data[:from_email].presence || 'preview@example.test'
+                                               ))
+        newsletter.id = 0
+        contact = Escalated::Contact.new(email: 'preview@example.test', name: 'Preview User')
+        contact.id = 0
+        delivery = Escalated::NewsletterDelivery.new(
+          newsletter_id: 0,
+          contact_id: 0,
+          email_at_send: contact.email,
+          tracking_token: 'preview',
+          status: 'pending'
+        )
+        delivery.association(:newsletter).target = newsletter
+        delivery.association(:contact).target = contact
+
+        render json: { html: Escalated::Newsletter::Renderer.new.render(delivery) }
+      end
+
+      def test
+        data = newsletter_params
+        return unless data
+
+        user = escalated_current_user
+        newsletter = Escalated::Newsletter.new(data)
+        newsletter.id = 0
+        contact = Escalated::Contact.new(email: user.email, name: user.respond_to?(:name) ? user.name : 'Tester')
+        contact.id = user.id
+        delivery = Escalated::NewsletterDelivery.new(
+          newsletter_id: 0,
+          contact_id: contact.id,
+          email_at_send: contact.email,
+          tracking_token: SecureRandom.alphanumeric(40),
+          status: 'pending',
+          is_test: true
+        )
+        delivery.association(:newsletter).target = newsletter
+        delivery.association(:contact).target = contact
+
+        html = Escalated::Newsletter::Renderer.new.render(delivery)
+        ActionMailer::Base.mail(
+          to: user.email,
+          from: formatted_from(data),
+          reply_to: data[:reply_to].presence,
+          subject: "[TEST] #{data[:subject]}",
+          body: html,
+          content_type: 'text/html'
+        ).deliver
+
+        render json: { ok: true }
+      end
+
+      def show
+        tab = params[:tab].presence || 'overview'
+        deliveries = @newsletter.deliveries
+                                .includes(:contact)
+                                .where(is_test: false)
+        deliveries = deliveries.where(status: params[:status]) if params[:status].present?
+        result = paginate(deliveries.order(id: :desc), per_page: 100)
+
+        render_page 'Escalated/Admin/Newsletters/Show', {
+          newsletter: @newsletter.tap { |n| n.association(:target_list).load_target },
+          deliveries: result[:data],
+          meta: result[:meta],
+          topClicks: [],
+          tab: tab
+        }
+      end
+
+      def edit
+        unless %w[draft scheduled].include?(@newsletter.status)
+          return render plain: 'Only drafts and scheduled newsletters can be edited', status: :unprocessable_entity
+        end
+
+        render_page 'Escalated/Admin/Newsletters/Edit', compose_props.merge(newsletter: @newsletter)
+      end
+
+      def update
+        data = newsletter_params
+        return unless data
+        return unless authorize_send_status!(data)
+
+        @newsletter.update!(data)
+        Escalated::Newsletter::Planner.new.plan(@newsletter) if data[:status] == 'sending'
+
+        redirect_to admin_newsletters_show_path(@newsletter)
+      end
+
+      def destroy
+        unless @newsletter.status == 'draft'
+          return render plain: 'Only drafts can be deleted', status: :unprocessable_entity
+        end
+
+        @newsletter.destroy!
+        redirect_to admin_newsletters_path
+      end
+
+      private
+
+      def set_newsletter
+        @newsletter = Escalated::Newsletter.find(params[:id])
+      end
+
+      def authorize_send_status!(data)
+        return true unless %w[scheduled sending].include?(data[:status].to_s)
+
+        require_newsletter_send_permission!
+        return false if performed?
+
+        if mail_configured?
+          true
+        else
+          redirect_back_or_to(admin_newsletters_path, alert: 'Outbound mail is not configured.')
+          false
+        end
+      end
+
+      def newsletter_params
+        data = params.permit(:subject, :from_email, :from_name, :reply_to, :target_list_id, :template_id,
+                             :theme, :body_markdown, :status, :scheduled_at).to_h.symbolize_keys
+        validate_newsletter_params(data)
+      end
+
+      def preview_params
+        data = params.permit(:subject, :body_markdown, :theme, :target_list_id, :from_email).to_h.symbolize_keys
+        errors = []
+        errors << 'subject is too long' if data[:subject].present? && data[:subject].length > 998
+        errors << 'from_email is invalid' if data[:from_email].present? && !valid_email?(data[:from_email])
+        return data if errors.empty?
+
+        render json: { errors: errors }, status: :unprocessable_entity
+        nil
+      end
+
+      def validate_newsletter_params(data)
+        errors = []
+        errors << 'subject is required' if data[:subject].blank?
+        errors << 'subject is too long' if data[:subject].to_s.length > 998
+        errors << 'from_email is required' if data[:from_email].blank?
+        errors << 'from_email is invalid' if data[:from_email].present? && !valid_email?(data[:from_email])
+        errors << 'from_email is too long' if data[:from_email].to_s.length > 320
+        errors << 'from_name is too long' if data[:from_name].to_s.length > 255
+        errors << 'reply_to is invalid' if data[:reply_to].present? && !valid_email?(data[:reply_to])
+        errors << 'reply_to is too long' if data[:reply_to].to_s.length > 320
+        errors << 'target_list_id is required' if data[:target_list_id].blank?
+        unless data[:target_list_id].blank? || Escalated::NewsletterList.exists?(data[:target_list_id])
+          errors << 'target_list_id does not exist'
+        end
+        unless data[:template_id].blank? || Escalated::NewsletterTemplate.exists?(data[:template_id])
+          errors << 'template_id does not exist'
+        end
+        errors << 'theme is too long' if data[:theme].to_s.length > 64
+        status = data[:status].presence || 'draft'
+        errors << 'status is invalid' unless %w[draft scheduled sending].include?(status)
+        if data[:scheduled_at].present?
+          begin
+            scheduled_at = Time.zone.parse(data[:scheduled_at].to_s)
+            errors << 'scheduled_at must be after now' if scheduled_at <= Time.current
+            data[:scheduled_at] = scheduled_at
+          rescue ArgumentError
+            errors << 'scheduled_at is invalid'
+          end
+        end
+        return validation_failed(errors) if errors.any?
+
+        data[:status] = status
+        data[:target_list_id] = data[:target_list_id].to_i
+        data[:template_id] = data[:template_id].presence&.to_i
+        data
+      end
+
+      def validation_failed(errors)
+        render plain: errors.join(', '), status: :unprocessable_entity
+        nil
+      end
+
+      def compose_props
+        {
+          lists: Escalated::NewsletterList
+            .left_joins(:members)
+            .select("#{Escalated::NewsletterList.table_name}.id, #{Escalated::NewsletterList.table_name}.name, COUNT(#{Escalated::NewsletterListMember.table_name}.id) AS member_count")
+            .group("#{Escalated::NewsletterList.table_name}.id", "#{Escalated::NewsletterList.table_name}.name"),
+          templates: Escalated::NewsletterTemplate.select(:id, :name),
+          themes: discover_themes,
+          mailConfigured: mail_configured?,
+          canSend: true,
+          defaultFromEmail: Escalated.configuration.newsletter_default_from,
+          defaultReplyTo: Escalated.configuration.newsletter_default_reply_to,
+          defaultTheme: Escalated.configuration.newsletter_default_theme
+        }
+      end
+
+      def discover_themes
+        roots = [
+          Escalated.configuration.newsletter_themes_dir,
+          File.expand_path('../../../views/escalated/newsletter_themes', __dir__)
+        ].compact
+        themes = roots.flat_map do |root|
+          next [] unless File.directory?(root)
+
+          Dir[File.join(root, '*.html.erb')].map { |path| File.basename(path, '.html.erb') }
+        end.uniq
+        themes.presence || %w[default branded]
+      end
+
+      def mail_configured?
+        ActionMailer::Base.delivery_method.present? && ActionMailer::Base.delivery_method != :test
+      end
+
+      def valid_email?(email)
+        email.to_s.match?(URI::MailTo::EMAIL_REGEXP)
+      end
+
+      def formatted_from(data)
+        return data[:from_email] if data[:from_name].blank?
+
+        %("#{data[:from_name]}" <#{data[:from_email]}>)
+      end
+    end
+  end
+end

--- a/app/controllers/escalated/admin/newsletters_controller.rb
+++ b/app/controllers/escalated/admin/newsletters_controller.rb
@@ -30,6 +30,31 @@ module Escalated
         }
       end
 
+      def show
+        tab = params[:tab].presence || 'overview'
+        deliveries = @newsletter.deliveries
+                                .includes(:contact)
+                                .where(is_test: false)
+        deliveries = deliveries.where(status: params[:status]) if params[:status].present?
+        result = paginate(deliveries.order(id: :desc), per_page: 100)
+
+        render_page 'Escalated/Admin/Newsletters/Show', {
+          newsletter: @newsletter.tap { |n| n.association(:target_list).load_target },
+          deliveries: result[:data],
+          meta: result[:meta],
+          topClicks: [],
+          tab: tab
+        }
+      end
+
+      def edit
+        unless %w[draft scheduled].include?(@newsletter.status)
+          return render plain: 'Only drafts and scheduled newsletters can be edited', status: :unprocessable_content
+        end
+
+        render_page 'Escalated/Admin/Newsletters/Edit', compose_props.merge(newsletter: @newsletter)
+      end
+
       def create
         render_page 'Escalated/Admin/Newsletters/Compose', compose_props
       end
@@ -103,31 +128,6 @@ module Escalated
         render json: { ok: true }
       end
 
-      def show
-        tab = params[:tab].presence || 'overview'
-        deliveries = @newsletter.deliveries
-                                .includes(:contact)
-                                .where(is_test: false)
-        deliveries = deliveries.where(status: params[:status]) if params[:status].present?
-        result = paginate(deliveries.order(id: :desc), per_page: 100)
-
-        render_page 'Escalated/Admin/Newsletters/Show', {
-          newsletter: @newsletter.tap { |n| n.association(:target_list).load_target },
-          deliveries: result[:data],
-          meta: result[:meta],
-          topClicks: [],
-          tab: tab
-        }
-      end
-
-      def edit
-        unless %w[draft scheduled].include?(@newsletter.status)
-          return render plain: 'Only drafts and scheduled newsletters can be edited', status: :unprocessable_entity
-        end
-
-        render_page 'Escalated/Admin/Newsletters/Edit', compose_props.merge(newsletter: @newsletter)
-      end
-
       def update
         data = newsletter_params
         return unless data
@@ -141,7 +141,7 @@ module Escalated
 
       def destroy
         unless @newsletter.status == 'draft'
-          return render plain: 'Only drafts can be deleted', status: :unprocessable_entity
+          return render plain: 'Only drafts can be deleted', status: :unprocessable_content
         end
 
         @newsletter.destroy!
@@ -181,7 +181,7 @@ module Escalated
         errors << 'from_email is invalid' if data[:from_email].present? && !valid_email?(data[:from_email])
         return data if errors.empty?
 
-        render json: { errors: errors }, status: :unprocessable_entity
+        render json: { errors: errors }, status: :unprocessable_content
         nil
       end
 
@@ -223,16 +223,16 @@ module Escalated
       end
 
       def validation_failed(errors)
-        render plain: errors.join(', '), status: :unprocessable_entity
+        render plain: errors.join(', '), status: :unprocessable_content
         nil
       end
 
       def compose_props
         {
           lists: Escalated::NewsletterList
-            .left_joins(:members)
-            .select("#{Escalated::NewsletterList.table_name}.id, #{Escalated::NewsletterList.table_name}.name, COUNT(#{Escalated::NewsletterListMember.table_name}.id) AS member_count")
-            .group("#{Escalated::NewsletterList.table_name}.id", "#{Escalated::NewsletterList.table_name}.name"),
+                 .left_joins(:members)
+                 .select("#{Escalated::NewsletterList.table_name}.id, #{Escalated::NewsletterList.table_name}.name, COUNT(#{Escalated::NewsletterListMember.table_name}.id) AS member_count") # rubocop:disable Layout/LineLength
+                 .group("#{Escalated::NewsletterList.table_name}.id", "#{Escalated::NewsletterList.table_name}.name"),
           templates: Escalated::NewsletterTemplate.select(:id, :name),
           themes: discover_themes,
           mailConfigured: mail_configured?,

--- a/app/controllers/escalated/application_controller.rb
+++ b/app/controllers/escalated/application_controller.rb
@@ -39,7 +39,10 @@ module Escalated
           plugins_enabled: Escalated.configuration.plugins_enabled?,
           knowledge_base_enabled: Escalated::EscalatedSetting.knowledge_base_enabled?,
           knowledge_base_public: Escalated::EscalatedSetting.knowledge_base_public?,
-          knowledge_base_feedback_enabled: Escalated::EscalatedSetting.knowledge_base_feedback_enabled?
+          knowledge_base_feedback_enabled: Escalated::EscalatedSetting.knowledge_base_feedback_enabled?,
+          features: {
+            newsletters: Escalated.configuration.enable_newsletters?
+          }
         },
         flash: {
           success: flash[:success],

--- a/app/controllers/escalated/application_controller.rb
+++ b/app/controllers/escalated/application_controller.rb
@@ -42,7 +42,8 @@ module Escalated
           knowledge_base_feedback_enabled: Escalated::EscalatedSetting.knowledge_base_feedback_enabled?,
           features: {
             newsletters: Escalated.configuration.enable_newsletters?
-          }
+          },
+          permissions: user_permission_slugs(current_user&.id)
         },
         flash: {
           success: flash[:success],
@@ -56,6 +57,15 @@ module Escalated
       shared[:plugin_ui] = Escalated.plugin_ui.to_shared_data if Escalated.configuration.plugins_enabled?
 
       inertia_share(**shared)
+    end
+
+    def user_permission_slugs(user_id)
+      return [] if user_id.blank?
+
+      Escalated::Permission.joins(roles: :users)
+                           .where(escalated_role_users: { user_id: user_id })
+                           .distinct
+                           .pluck(:slug)
     end
 
     def current_user_data

--- a/app/controllers/escalated/newsletter_esp_webhook_controller.rb
+++ b/app/controllers/escalated/newsletter_esp_webhook_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Escalated
+  class NewsletterEspWebhookController < ActionController::API
+    include Escalated::NewsletterAccess
+
+    before_action :ensure_newsletters_enabled!
+
+    def postmark
+      token = token_from_message_id(params[:MessageID].to_s)
+      case params[:RecordType].to_s
+      when 'Open'
+        tracker.record_open(token)
+      when 'Click'
+        tracker.record_click(token, params[:OriginalLink].to_s)
+      when 'Bounce'
+        tracker.record_bounce(token, postmark_hard_bounce?(params[:Type].to_s) ? 'hard' : 'soft',
+                              params[:Description].to_s)
+      when 'SpamComplaint'
+        tracker.record_complaint(token)
+      end
+
+      render json: { ok: true }
+    end
+
+    def mailgun
+      event = params.dig('event-data', 'event').to_s
+      token = token_from_message_id(params.dig('event-data', 'message', 'headers', 'message-id').to_s)
+      case event
+      when 'opened'
+        tracker.record_open(token)
+      when 'clicked'
+        tracker.record_click(token, params.dig('event-data', 'url').to_s)
+      when 'failed'
+        type = params.dig('event-data', 'severity') == 'permanent' ? 'hard' : 'soft'
+        tracker.record_bounce(token, type, params.dig('event-data', 'delivery-status', 'description').to_s)
+      when 'complained'
+        tracker.record_complaint(token)
+      end
+
+      render json: { ok: true }
+    end
+
+    def ses
+      body = params[:Message]
+      body = JSON.parse(body) if body.is_a?(String)
+      body = body.to_unsafe_h if body.respond_to?(:to_unsafe_h)
+      body ||= {}
+      token = token_from_message_id(body.dig('mail', 'messageId').to_s)
+      case body['eventType']
+      when 'Open'
+        tracker.record_open(token)
+      when 'Click'
+        tracker.record_click(token, body.dig('click', 'link').to_s)
+      when 'Bounce'
+        type = body.dig('bounce', 'bounceType') == 'Permanent' ? 'hard' : 'soft'
+        tracker.record_bounce(token, type, body.dig('bounce', 'bounceSubType'))
+      when 'Complaint'
+        tracker.record_complaint(token)
+      end
+
+      render json: { ok: true }
+    end
+
+    def sendgrid
+      events = request.request_parameters
+      events = JSON.parse(request.raw_post) if events.blank? && request.raw_post.present?
+      Array(events).each do |event|
+        token = token_from_message_id((event['smtp-id'] || event['sg_message_id']).to_s)
+        case event['event']
+        when 'open'
+          tracker.record_open(token)
+        when 'click'
+          tracker.record_click(token, event['url'].to_s)
+        when 'bounce'
+          tracker.record_bounce(token, event['type'] == 'blocked' ? 'hard' : 'soft', event['reason'])
+        when 'dropped'
+          tracker.record_bounce(token, 'hard', event['reason'])
+        when 'spamreport'
+          tracker.record_complaint(token)
+        end
+      end
+
+      render json: { ok: true }
+    end
+
+    private
+
+    def tracker
+      @tracker ||= Escalated::Newsletter::Tracker.new
+    end
+
+    def postmark_hard_bounce?(type)
+      %w[HardBounce BadEmailAddress BlockedRecipient].include?(type)
+    end
+
+    def token_from_message_id(message_id)
+      return Regexp.last_match(1) if message_id.match(/n-\d+-([A-Za-z0-9]+)@/)
+
+      local_part = message_id.split('@').first.to_s
+      return Regexp.last_match(1) if local_part.match(/^n-\d+-([A-Za-z0-9]+)$/)
+
+      ''
+    end
+  end
+end

--- a/app/controllers/escalated/newsletter_tracking_controller.rb
+++ b/app/controllers/escalated/newsletter_tracking_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module Escalated
+  class NewsletterTrackingController < Escalated::ApplicationController
+    include Escalated::NewsletterAccess
+
+    PIXEL_BYTES = Base64.decode64(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8//8/AwAF/gL+3MxZ5wAAAABJRU5ErkJggg=='
+    ).freeze
+
+    before_action :ensure_newsletters_enabled!
+
+    def open
+      token = params[:token].to_s.sub(/\.(gif|png|jpg)\z/i, '')
+      Escalated::Newsletter::Tracker.new.record_open(token)
+
+      render plain: PIXEL_BYTES, status: :ok, content_type: 'image/png',
+             headers: { 'Cache-Control' => 'private, no-store, max-age=0' }
+    end
+
+    def click
+      decoded = decode_destination(params[:u].to_s)
+      return render plain: 'Bad request', status: :bad_request unless decoded
+
+      Escalated::Newsletter::Tracker.new.record_click(params[:token], decoded)
+      redirect_to decoded, allow_other_host: true
+    end
+
+    private
+
+    def decode_destination(encoded)
+      decoded = Base64.urlsafe_decode64(encoded)
+      uri = URI.parse(decoded)
+      return nil unless %w[http https].include?(uri.scheme.to_s.downcase)
+
+      decoded
+    rescue ArgumentError, URI::InvalidURIError
+      nil
+    end
+  end
+end

--- a/app/controllers/escalated/newsletter_unsubscribe_controller.rb
+++ b/app/controllers/escalated/newsletter_unsubscribe_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Escalated
+  class NewsletterUnsubscribeController < Escalated::ApplicationController
+    include Escalated::NewsletterAccess
+
+    skip_forgery_protection only: :store
+    before_action :ensure_newsletters_enabled!
+
+    def show
+      delivery = find_delivery
+      render 'escalated/newsletters/unsubscribe', locals: {
+        token: params[:token],
+        email: delivery&.email_at_send,
+        confirmed: false
+      }
+    end
+
+    def store
+      return render plain: 'Too Many Requests', status: :too_many_requests unless throttle_unsubscribe!
+
+      delivery = find_delivery
+      delivery&.contact&.update!(marketing_opt_out_at: Time.current)
+
+      render 'escalated/newsletters/unsubscribe', locals: {
+        token: params[:token],
+        email: delivery&.email_at_send,
+        confirmed: true
+      }
+    end
+
+    private
+
+    def find_delivery
+      Escalated::NewsletterDelivery.includes(:contact).find_by(tracking_token: params[:token])
+    end
+
+    def throttle_unsubscribe!
+      key = "escalated.newsletter.unsubscribe.#{request.remote_ip}.#{Time.current.to_i / 60}"
+      self.class.unsubscribe_counters[key] = self.class.unsubscribe_counters[key].to_i + 1
+      self.class.unsubscribe_counters[key] <= 60
+    end
+
+    def self.unsubscribe_counters
+      @unsubscribe_counters ||= {}
+    end
+  end
+end

--- a/app/controllers/escalated/newsletter_unsubscribe_controller.rb
+++ b/app/controllers/escalated/newsletter_unsubscribe_controller.rb
@@ -29,6 +29,10 @@ module Escalated
       }
     end
 
+    def self.unsubscribe_counters
+      @unsubscribe_counters ||= {}
+    end
+
     private
 
     def find_delivery
@@ -39,10 +43,6 @@ module Escalated
       key = "escalated.newsletter.unsubscribe.#{request.remote_ip}.#{Time.current.to_i / 60}"
       self.class.unsubscribe_counters[key] = self.class.unsubscribe_counters[key].to_i + 1
       self.class.unsubscribe_counters[key] <= 60
-    end
-
-    def self.unsubscribe_counters
-      @unsubscribe_counters ||= {}
     end
   end
 end

--- a/app/controllers/escalated/newsletter_view_in_browser_controller.rb
+++ b/app/controllers/escalated/newsletter_view_in_browser_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Escalated
+  class NewsletterViewInBrowserController < Escalated::ApplicationController
+    include Escalated::NewsletterAccess
+
+    UNAVAILABLE_HTML = '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Email unavailable</title></head><body><p>This email is no longer available.</p></body></html>'
+
+    before_action :ensure_newsletters_enabled!
+
+    def show
+      delivery = Escalated::NewsletterDelivery.includes(:contact, newsletter: :template)
+                                              .find_by(tracking_token: params[:token])
+      html = delivery ? Escalated::Newsletter::Renderer.new.render(delivery) : UNAVAILABLE_HTML
+
+      render html: html.html_safe, status: :ok, content_type: 'text/html'
+    end
+  end
+end

--- a/app/controllers/escalated/newsletter_view_in_browser_controller.rb
+++ b/app/controllers/escalated/newsletter_view_in_browser_controller.rb
@@ -4,7 +4,7 @@ module Escalated
   class NewsletterViewInBrowserController < Escalated::ApplicationController
     include Escalated::NewsletterAccess
 
-    UNAVAILABLE_HTML = '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Email unavailable</title></head><body><p>This email is no longer available.</p></body></html>'
+    UNAVAILABLE_HTML = '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Email unavailable</title></head><body><p>This email is no longer available.</p></body></html>' # rubocop:disable Layout/LineLength
 
     before_action :ensure_newsletters_enabled!
 
@@ -13,7 +13,7 @@ module Escalated
                                               .find_by(tracking_token: params[:token])
       html = delivery ? Escalated::Newsletter::Renderer.new.render(delivery) : UNAVAILABLE_HTML
 
-      render html: html.html_safe, status: :ok, content_type: 'text/html'
+      render body: html, status: :ok, content_type: 'text/html'
     end
   end
 end

--- a/app/services/escalated/newsletter/dispatcher.rb
+++ b/app/services/escalated/newsletter/dispatcher.rb
@@ -45,6 +45,10 @@ module Escalated
         finalize_completed_newsletters
       end
 
+      def self.rate_counters
+        @rate_counters ||= {}
+      end
+
       private
 
       def dispatch_one(delivery)
@@ -164,10 +168,6 @@ module Escalated
         self.class.rate_counters[rate_limit_key] || Rails.cache.read(rate_limit_key).to_i
       rescue StandardError
         self.class.rate_counters[rate_limit_key].to_i
-      end
-
-      def self.rate_counters
-        @rate_counters ||= {}
       end
     end
   end

--- a/app/services/escalated/newsletter/dispatcher.rb
+++ b/app/services/escalated/newsletter/dispatcher.rb
@@ -15,15 +15,18 @@ module Escalated
 
         reclaim_stuck_rows
 
-        batch_size = Escalated.configuration.newsletter_batch_size
+        remaining_capacity = rate_limit_remaining
+        return if remaining_capacity <= 0
+
+        batch_size = [Escalated.configuration.newsletter_batch_size, remaining_capacity].min
 
         ids = Escalated::NewsletterDelivery.transaction do
-          rows = Escalated::NewsletterDelivery
-                 .pending
-                 .order(:id)
-                 .lock('FOR UPDATE')
-                 .limit(batch_size)
-                 .pluck(:id)
+          scope = Escalated::NewsletterDelivery.pending
+          scope = scope.where('next_attempt_at IS NULL OR next_attempt_at <= ?', Time.current)
+          rows = scope.order(:id)
+                      .lock('FOR UPDATE')
+                      .limit(batch_size)
+                      .pluck(:id)
           if rows.any?
             Escalated::NewsletterDelivery.where(id: rows).update_all(
               status: 'queued',
@@ -38,8 +41,8 @@ module Escalated
           dispatch_one(delivery) if delivery
         end
 
-        finalize_completed_newsletters
         check_auto_pause_across_active_newsletters
+        finalize_completed_newsletters
       end
 
       private
@@ -67,10 +70,11 @@ module Escalated
           subject: delivery_full.newsletter.subject,
           body: html,
           content_type: 'text/html'
-        ).deliver_now
+        ).deliver
 
         delivery.update!(status: 'sent', sent_at: Time.current, claimed_at: nil)
         Escalated::Newsletter.where(id: delivery.newsletter_id).update_all('summary_sent = summary_sent + 1')
+        increment_rate_limit_counter
       rescue StandardError => e
         Rails.logger.warn("Newsletter delivery #{delivery.id} failed: #{e.message}")
         attempts = delivery.attempt_count + 1
@@ -78,7 +82,8 @@ module Escalated
           delivery.update!(status: 'failed', failure_reason: e.message,
                            attempt_count: attempts, claimed_at: nil)
         else
-          delivery.update!(status: 'pending', attempt_count: attempts, claimed_at: nil)
+          delivery.update!(status: 'pending', attempt_count: attempts, claimed_at: nil,
+                           next_attempt_at: backoff_for(attempts).from_now)
         end
       end
 
@@ -113,18 +118,56 @@ module Escalated
         threshold = Escalated.configuration.newsletter_auto_pause_threshold
         rate = Escalated.configuration.newsletter_auto_pause_bounce_rate
         Escalated::Newsletter.where(status: 'sending').find_each do |n|
-          total = Escalated::NewsletterDelivery.where(newsletter_id: n.id,
-                                                      status: %w[
-                                                        sent bounced complained failed
-                                                      ]).count
-          next if total < threshold
+          terminal_statuses = %w[sent bounced complained failed suppressed]
+          first_terminal = Escalated::NewsletterDelivery
+                           .where(newsletter_id: n.id, status: terminal_statuses)
+                           .order(:id)
+                           .limit(threshold)
+          total = first_terminal.count
+          next unless total >= threshold
 
-          bounced = Escalated::NewsletterDelivery.where(newsletter_id: n.id, status: 'bounced').count
+          bounced = first_terminal.select { |delivery| delivery.status == 'bounced' }.count
           if total.positive? && bounced.to_f / total >= rate
             n.update!(status: 'paused')
             Rails.logger.warn("Newsletter #{n.id} auto-paused: #{bounced}/#{total} bounced")
           end
         end
+      end
+
+      def rate_limit_remaining
+        limit = Escalated.configuration.newsletter_rate_limit_per_minute.to_i
+        return Float::INFINITY if limit <= 0
+
+        [limit - rate_counter_value, 0].max
+      end
+
+      def increment_rate_limit_counter
+        self.class.rate_counters[rate_limit_key] = rate_counter_value + 1
+        Rails.cache.write(rate_limit_key, self.class.rate_counters[rate_limit_key], expires_in: 70.seconds)
+      rescue StandardError => e
+        Rails.logger.warn("Newsletter rate counter update failed: #{e.message}")
+      end
+
+      def rate_limit_key
+        "escalated.newsletters.dispatch.#{Time.current.utc.strftime('%Y%m%d%H%M')}"
+      end
+
+      def backoff_for(attempts)
+        case attempts
+        when 1 then 1.minute
+        when 2 then 5.minutes
+        else 30.minutes
+        end
+      end
+
+      def rate_counter_value
+        self.class.rate_counters[rate_limit_key] || Rails.cache.read(rate_limit_key).to_i
+      rescue StandardError
+        self.class.rate_counters[rate_limit_key].to_i
+      end
+
+      def self.rate_counters
+        @rate_counters ||= {}
       end
     end
   end

--- a/app/views/escalated/newsletters/unsubscribe.html.erb
+++ b/app/views/escalated/newsletters/unsubscribe.html.erb
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Unsubscribe</title>
+  </head>
+  <body>
+    <% if confirmed %>
+      <p>You have been unsubscribed<%= email.present? ? " from #{email}" : '' %>.</p>
+    <% else %>
+      <p>Unsubscribe<%= email.present? ? " #{email}" : '' %> from future newsletters.</p>
+      <form method="post" action="/escalated/n/u/<%= ERB::Util.url_encode(token) %>">
+        <button type="submit">Unsubscribe</button>
+      </form>
+    <% end %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,40 @@ Escalated::Engine.routes.draw do
     end
     resources :automations, only: %i[index new create edit update destroy]
 
+    # Newsletters
+    scope 'newsletters', as: :newsletters do
+      get '/', to: 'newsletters#index'
+      get 'new', to: 'newsletters#create', as: :new
+      post '/', to: 'newsletters#store'
+      post 'preview', to: 'newsletters#preview', as: :preview
+      post 'test', to: 'newsletters#test', as: :test
+
+      get 'lists', to: 'newsletter_lists#index', as: :lists
+      get 'lists/new', to: 'newsletter_lists#create', as: :new_list
+      post 'lists', to: 'newsletter_lists#store'
+      get 'lists/:id', to: 'newsletter_lists#show', as: :list
+      put 'lists/:id', to: 'newsletter_lists#update'
+      delete 'lists/:id', to: 'newsletter_lists#destroy'
+      post 'lists/:id/members', to: 'newsletter_lists#add_member', as: :list_members
+      delete 'lists/:id/members/:contact_id', to: 'newsletter_lists#remove_member', as: :list_member
+      post 'lists/:id/import', to: 'newsletter_lists#import', as: :list_import
+
+      get 'templates', to: 'newsletter_templates#index', as: :templates
+      get 'templates/new', to: 'newsletter_templates#create', as: :new_template
+      post 'templates', to: 'newsletter_templates#store'
+      get 'templates/:id', to: 'newsletter_templates#show', as: :template
+      put 'templates/:id', to: 'newsletter_templates#update'
+      delete 'templates/:id', to: 'newsletter_templates#destroy'
+
+      get 'settings', to: 'newsletter_settings#show', as: :settings
+      put 'settings', to: 'newsletter_settings#update'
+
+      get ':id', to: 'newsletters#show', as: :show
+      get ':id/edit', to: 'newsletters#edit', as: :edit
+      put ':id', to: 'newsletters#update'
+      delete ':id', to: 'newsletters#destroy'
+    end
+
     # Workflow automation engine
     resources :workflows, only: %i[index show new create edit update destroy] do
       member do

--- a/db/migrate/062_add_next_attempt_at_to_escalated_newsletter_deliveries.rb
+++ b/db/migrate/062_add_next_attempt_at_to_escalated_newsletter_deliveries.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddNextAttemptAtToEscalatedNewsletterDeliveries < ActiveRecord::Migration[7.0]
+  def change
+    table_name = "#{Escalated.configuration.table_prefix}newsletter_deliveries"
+
+    add_column table_name, :next_attempt_at, :datetime
+    add_index table_name, :next_attempt_at
+  end
+end

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -75,6 +75,12 @@ module Escalated
         { slug: 'automation.manage', name: 'Manage automations', group: 'Automations',
           description: 'Create, edit, delete automations' },
 
+        # Newsletters
+        { slug: 'newsletters.manage', name: 'Manage newsletters', group: 'Newsletters',
+          description: 'Create, edit, delete drafts and lists/templates; send test emails.' },
+        { slug: 'newsletters.send', name: 'Send newsletters', group: 'Newsletters',
+          description: 'Schedule or send newsletters now.' },
+
         # Escalation Rules
         { slug: 'escalation.view',   name: 'View escalation rules',   group: 'Escalation Rules',
           description: 'View escalation rules' },

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -98,6 +98,30 @@ module Escalated
       end
     end
 
+    initializer 'escalated.newsletter_routes' do |app|
+      app.routes.append do
+        scope 'escalated/n', module: 'escalated', as: 'escalated_newsletters_public' do
+          get 'o/:token', to: 'newsletter_tracking#open', as: :open,
+                          constraints: { token: /[A-Za-z0-9._-]+/ }
+          get 'c/:token', to: 'newsletter_tracking#click', as: :click,
+                          constraints: { token: /[A-Za-z0-9_-]+/ }
+          get 'u/:token', to: 'newsletter_unsubscribe#show', as: :unsubscribe,
+                          constraints: { token: /[A-Za-z0-9_-]+/ }
+          post 'u/:token', to: 'newsletter_unsubscribe#store', as: :unsubscribe_store,
+                           constraints: { token: /[A-Za-z0-9_-]+/ }
+          get 'v/:token', to: 'newsletter_view_in_browser#show', as: :view,
+                          constraints: { token: /[A-Za-z0-9_-]+/ }
+        end
+
+        scope 'escalated/webhooks/newsletter', module: 'escalated' do
+          post 'postmark', to: 'newsletter_esp_webhook#postmark'
+          post 'mailgun', to: 'newsletter_esp_webhook#mailgun'
+          post 'ses', to: 'newsletter_esp_webhook#ses'
+          post 'sendgrid', to: 'newsletter_esp_webhook#sendgrid'
+        end
+      end
+    end
+
     initializer 'escalated.inertia' do
       next unless Escalated.configuration.ui_enabled?
 
@@ -182,6 +206,7 @@ module Escalated
     rake_tasks do
       load 'tasks/escalated_import.rake'
       load 'tasks/escalated_chat.rake'
+      load 'tasks/escalated_newsletters.rake'
     end
   end
 end

--- a/lib/tasks/escalated_newsletters.rake
+++ b/lib/tasks/escalated_newsletters.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :escalated do
+  namespace :newsletters do
+    unless Rake::Task.task_defined?('escalated:newsletters:dispatch')
+      desc 'Plan scheduled newsletters whose time has come and dispatch a batch of pending deliveries.'
+      task dispatch: :environment do
+        unless Escalated.configuration.enable_newsletters?
+          puts 'Newsletter feature disabled - skipping.'
+          next
+        end
+
+        Escalated::Newsletter.due.find_each do |newsletter|
+          puts "Planning newsletter ##{newsletter.id}"
+          Escalated::Newsletter::Planner.new.plan(newsletter)
+        end
+
+        puts 'Dispatching batch...'
+        Escalated::Newsletter::Dispatcher.new.dispatch_batch
+        puts 'Done.'
+      end
+    end
+  end
+end

--- a/spec/controllers/escalated/application_controller_spec.rb
+++ b/spec/controllers/escalated/application_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'json'
+require 'rails_helper'
+
+RSpec.describe Escalated::ApplicationController, type: :request do
+  let(:admin) { create(:user, :admin, email: 'shared-props@example.test') }
+
+  def sign_in_as(user)
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(described_class).to receive(:current_user).and_return(user)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  def inertia_props_from(body)
+    encoded = body[%r{data-page="(.+?)"></div>}m, 1]
+    raise 'missing Inertia page payload' unless encoded
+
+    JSON.parse(CGI.unescapeHTML(encoded))['props']
+  end
+
+  describe 'Inertia shared props' do
+    it 'includes empty permissions when there is no current user' do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Escalated::Admin::SkillsController).to receive(:require_admin!)
+      allow_any_instance_of(described_class).to receive(:current_user).and_return(nil)
+      # rubocop:enable RSpec/AnyInstance
+
+      get '/support/admin/skills'
+
+      expect(response).to have_http_status(:ok)
+      props = inertia_props_from(response.body)
+      expect(props.dig('escalated', 'permissions')).to eq([])
+    end
+
+    it 'includes permission slugs for the signed-in user via roles' do
+      manage = create(:escalated_permission, slug: 'newsletters.manage')
+      send_perm = create(:escalated_permission, slug: 'newsletters.send')
+      role = create(:escalated_role)
+      role.permissions << [manage, send_perm]
+      role.users << admin
+
+      sign_in_as(admin)
+      get '/support/admin/skills'
+
+      expect(response).to have_http_status(:ok)
+      props = inertia_props_from(response.body)
+      expect(props.dig('escalated', 'permissions')).to contain_exactly('newsletters.manage', 'newsletters.send')
+    end
+  end
+end

--- a/spec/factories/newsletters.rb
+++ b/spec/factories/newsletters.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :escalated_newsletter_list, class: 'Escalated::NewsletterList' do
+    sequence(:name) { |n| "Newsletter list #{n}" }
+    description { 'Newsletter recipients' }
+    kind { 'static' }
+    filter_json { nil }
+    created_by { nil }
+
+    trait :dynamic do
+      kind { 'dynamic' }
+      filter_json { { 'rules' => [] } }
+    end
+  end
+
+  factory :escalated_newsletter_list_member, class: 'Escalated::NewsletterListMember' do
+    association :list, factory: :escalated_newsletter_list
+    association :contact, factory: :escalated_contact
+    added_by { nil }
+  end
+
+  factory :escalated_newsletter_template, class: 'Escalated::NewsletterTemplate' do
+    sequence(:name) { |n| "Template #{n}" }
+    theme { 'default' }
+    subject_template { 'Hello {{ contact.first_name }}' }
+    body_markdown { '# Hello' }
+    merge_fields_schema { {} }
+    created_by { nil }
+  end
+
+  factory :escalated_newsletter, class: 'Escalated::Newsletter' do
+    sequence(:subject) { |n| "Newsletter #{n}" }
+    from_email { 'news@example.com' }
+    from_name { 'News Team' }
+    reply_to { 'reply@example.com' }
+    association :target_list, factory: :escalated_newsletter_list
+    template { nil }
+    theme { 'default' }
+    body_markdown { 'Hello {{ contact.first_name }}' }
+    status { 'draft' }
+    scheduled_at { nil }
+    created_by { nil }
+  end
+
+  factory :escalated_newsletter_delivery, class: 'Escalated::NewsletterDelivery' do
+    association :newsletter, factory: :escalated_newsletter
+    association :contact, factory: :escalated_contact
+    email_at_send { contact.email }
+    status { 'pending' }
+    sequence(:tracking_token) { |n| "token#{n}#{SecureRandom.hex(16)}"[0, 40] }
+    attempt_count { 0 }
+    is_test { false }
+    created_at { Time.current }
+  end
+end

--- a/spec/lib/escalated/newsletter_dispatch_task_spec.rb
+++ b/spec/lib/escalated/newsletter_dispatch_task_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'escalated:newsletters:dispatch' do
-  before(:all) do
+RSpec.describe 'escalated:newsletters:dispatch' do # rubocop:disable RSpec/DescribeClass
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
     Rails.application.load_tasks unless Rake::Task.task_defined?('escalated:newsletters:dispatch')
   end
 

--- a/spec/lib/escalated/newsletter_dispatch_task_spec.rb
+++ b/spec/lib/escalated/newsletter_dispatch_task_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'escalated:newsletters:dispatch' do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('escalated:newsletters:dispatch')
+  end
+
+  before do
+    Rake::Task['escalated:newsletters:dispatch'].reenable
+    ActionMailer::Base.deliveries.clear
+  end
+
+  it 'exits without sending when newsletters are disabled mid-flight' do
+    allow(Escalated.configuration).to receive(:enable_newsletters?).and_return(false)
+    newsletter = create(:escalated_newsletter, status: 'sending', summary_sent: 0)
+    create_list(:escalated_newsletter_delivery, 5, newsletter: newsletter, status: 'pending')
+
+    expect do
+      Rake::Task['escalated:newsletters:dispatch'].invoke
+    end.not_to raise_error
+
+    expect(ActionMailer::Base.deliveries).to be_empty
+    expect(newsletter.deliveries.pluck(:status)).to all(eq('pending'))
+    expect(newsletter.reload.summary_sent).to eq(0)
+  end
+end

--- a/spec/requests/escalated/newsletters_http_spec.rb
+++ b/spec/requests/escalated/newsletters_http_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Escalated newsletter HTTP layer', type: :request do
+  let(:admin) { create(:user, :admin, email: 'admin@example.com') }
+  let(:agent) { create(:user, :agent, email: 'agent@example.com') }
+
+  before do
+    allow(Escalated.configuration).to receive(:enable_newsletters?).and_return(true)
+    allow(Escalated.configuration).to receive_messages(
+      newsletter_default_from: 'news@example.com',
+      newsletter_default_reply_to: 'reply@example.com',
+      newsletter_default_theme: 'default',
+      newsletter_rate_limit_per_minute: 60,
+      newsletter_batch_size: 50,
+      newsletter_tracking_enabled?: true,
+      app_url: 'https://app.test',
+      notification_channels: [],
+      webhook_url: nil
+    )
+  end
+
+  def sign_in_as(user)
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Escalated::ApplicationController).to receive(:current_user).and_return(user)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe 'admin campaign routes' do
+    it 'renders the newsletter index Inertia page for admins' do
+      sign_in_as(admin)
+      create(:escalated_newsletter, status: 'draft')
+
+      get '/support/admin/newsletters'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Escalated/Admin/Newsletters/Index')
+    end
+
+    it 'creates a draft newsletter' do
+      sign_in_as(admin)
+      list = create(:escalated_newsletter_list)
+
+      expect do
+        post '/support/admin/newsletters',
+             params: {
+               subject: 'June update',
+               from_email: 'news@example.com',
+               target_list_id: list.id,
+               status: 'draft',
+               body_markdown: 'Hello'
+             }
+      end.to change(Escalated::Newsletter, :count).by(1)
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'blocks non-admins before newsletter management' do
+      sign_in_as(agent)
+
+      get '/support/admin/newsletters'
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'enforces newsletter manage permission when host roles are present' do
+      role = create(:escalated_role)
+      admin.define_singleton_method(:roles) { [role] }
+      sign_in_as(admin)
+
+      get '/support/admin/newsletters'
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'requires newsletters.send for test sends when host roles are present' do
+      manage = create(:escalated_permission, slug: 'newsletters.manage')
+      role = create(:escalated_role)
+      role.permissions << manage
+      admin.define_singleton_method(:roles) { [role] }
+      sign_in_as(admin)
+      list = create(:escalated_newsletter_list)
+
+      post '/support/admin/newsletters/test',
+           params: {
+             subject: 'Test',
+             from_email: 'news@example.com',
+             target_list_id: list.id,
+             status: 'draft',
+             body_markdown: 'Hello'
+           }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'admin list/template/settings routes' do
+    before { sign_in_as(admin) }
+
+    it 'creates and shows a static newsletter list' do
+      post '/support/admin/newsletters/lists',
+           params: { name: 'Customers', kind: 'static', description: 'Customers' }
+
+      expect(response).to have_http_status(:redirect)
+      list = Escalated::NewsletterList.last
+
+      get "/support/admin/newsletters/lists/#{list.id}"
+      expect(response.body).to include('Escalated/Admin/Newsletters/Lists/Show')
+    end
+
+    it 'creates a template and renders newsletter settings' do
+      post '/support/admin/newsletters/templates',
+           params: { name: 'Default', theme: 'default', body_markdown: 'Hello' }
+
+      expect(response).to have_http_status(:redirect)
+      expect(Escalated::NewsletterTemplate.count).to eq(1)
+
+      get '/support/admin/newsletters/settings'
+      expect(response.body).to include('Escalated/Admin/Newsletters/Settings')
+    end
+  end
+
+  describe 'public tracking routes' do
+    let(:contact) { create(:escalated_contact, email: 'reader@example.com') }
+    let(:newsletter) { create(:escalated_newsletter, status: 'sending') }
+    let(:delivery) do
+      create(:escalated_newsletter_delivery, newsletter: newsletter, contact: contact, status: 'sent',
+                                             tracking_token: 'abc123')
+    end
+
+    it 'returns a tracking pixel and records opens' do
+      get "/escalated/n/o/#{delivery.tracking_token}.gif"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('image/png')
+      expect(delivery.reload.opened_at).to be_present
+    end
+
+    it 'redirects valid clicks and rejects invalid destinations' do
+      encoded = Base64.urlsafe_encode64('https://example.com/path', padding: false)
+
+      get "/escalated/n/c/#{delivery.tracking_token}", params: { u: encoded }
+      expect(response).to redirect_to('https://example.com/path')
+
+      get "/escalated/n/c/#{delivery.tracking_token}", params: { u: Base64.urlsafe_encode64('javascript:alert(1)') }
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'unsubscribes without authentication or CSRF' do
+      post "/escalated/n/u/#{delivery.tracking_token}"
+
+      expect(response).to have_http_status(:ok)
+      expect(contact.reload.marketing_opt_out_at).to be_present
+    end
+
+    it 'returns 200 for missing view-in-browser tokens' do
+      get '/escalated/n/v/missing-token'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('This email is no longer available.')
+    end
+
+    it 'returns 404 while newsletters are disabled' do
+      allow(Escalated.configuration).to receive(:enable_newsletters?).and_return(false)
+
+      get "/escalated/n/o/#{delivery.tracking_token}.gif"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'ESP webhooks' do
+    it 'maps provider payloads to tracker events' do
+      delivery = create(:escalated_newsletter_delivery, status: 'sent', tracking_token: 'tok123')
+
+      post '/escalated/webhooks/newsletter/postmark',
+           params: {
+             RecordType: 'Bounce',
+             MessageID: "n-#{delivery.newsletter_id}-#{delivery.tracking_token}@app.test",
+             Type: 'HardBounce',
+             Description: 'Mailbox unavailable'
+           }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq('ok' => true)
+      expect(delivery.reload.status).to eq('bounced')
+    end
+  end
+end

--- a/spec/services/escalated/newsletter/bounce_suppression_store_spec.rb
+++ b/spec/services/escalated/newsletter/bounce_suppression_store_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Newsletter::BounceSuppressionStore do
+  subject(:store) { described_class.new }
+
+  it 'marks bounced and complained emails case-insensitively' do
+    store.mark_bounced('User@Example.com')
+    store.mark_complained('Other@Example.com')
+
+    expect(store.bounced?('user@example.com')).to be true
+    expect(store.bounced?('OTHER@example.com')).to be true
+  end
+
+  it 'filters sendable emails against the persisted suppression list' do
+    store.mark_bounced('blocked@example.com')
+
+    expect(store.filter_sendable(%w[ok@example.com BLOCKED@example.com])).to eq(['ok@example.com'])
+  end
+end

--- a/spec/services/escalated/newsletter/dispatcher_spec.rb
+++ b/spec/services/escalated/newsletter/dispatcher_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe Escalated::Newsletter::Dispatcher do
   end
 
   it 'does not claim deliveries whose next_attempt_at is in the future' do
-    create(:escalated_newsletter_delivery, newsletter: newsletter, status: 'pending', next_attempt_at: 5.minutes.from_now)
+    create(:escalated_newsletter_delivery, newsletter: newsletter, status: 'pending',
+                                           next_attempt_at: 5.minutes.from_now)
 
     dispatcher.dispatch_batch
 

--- a/spec/services/escalated/newsletter/dispatcher_spec.rb
+++ b/spec/services/escalated/newsletter/dispatcher_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Newsletter::Dispatcher do
+  subject(:dispatcher) { described_class.new(renderer: renderer) }
+
+  let(:renderer) { instance_double(Escalated::Newsletter::Renderer, render: '<p>Hello</p>', unsubscribe_url: 'https://app.test/u') }
+  let(:newsletter) { create(:escalated_newsletter, status: 'sending') }
+
+  before do
+    Rails.cache.clear
+    described_class.rate_counters.clear
+    ActionMailer::Base.deliveries.clear
+    allow(Escalated.configuration).to receive_messages(
+      enable_newsletters?: true,
+      newsletter_batch_size: 50,
+      newsletter_rate_limit_per_minute: 60,
+      newsletter_claim_timeout_minutes: 10,
+      newsletter_auto_pause_threshold: 100,
+      newsletter_auto_pause_bounce_rate: 0.05,
+      app_url: 'https://app.test'
+    )
+  end
+
+  it 'claims pending rows, sends mail, and marks deliveries sent' do
+    create_list(:escalated_newsletter_delivery, 2, newsletter: newsletter, status: 'pending')
+
+    dispatcher.dispatch_batch
+
+    expect(newsletter.deliveries.pluck(:status)).to all(eq('sent'))
+    expect(newsletter.deliveries.where.not(sent_at: nil).count).to eq(2)
+    expect(ActionMailer::Base.deliveries.size).to eq(2)
+  end
+
+  it 'respects batch size and finalizes completed newsletters' do
+    allow(Escalated.configuration).to receive(:newsletter_batch_size).and_return(2)
+    create_list(:escalated_newsletter_delivery, 5, newsletter: newsletter, status: 'pending')
+
+    dispatcher.dispatch_batch
+
+    expect(newsletter.deliveries.where(status: 'sent').count).to eq(2)
+    expect(newsletter.reload.status).to eq('sending')
+
+    3.times { dispatcher.dispatch_batch }
+    expect(newsletter.reload.status).to eq('sent')
+  end
+
+  it 'does nothing when newsletters are disabled' do
+    allow(Escalated.configuration).to receive(:enable_newsletters?).and_return(false)
+    create_list(:escalated_newsletter_delivery, 5, newsletter: newsletter, status: 'pending')
+
+    dispatcher.dispatch_batch
+
+    expect(newsletter.deliveries.pluck(:status)).to all(eq('pending'))
+    expect(ActionMailer::Base.deliveries).to be_empty
+  end
+
+  it 'enforces the per-minute rate limit across ticks' do
+    allow(Escalated.configuration).to receive(:newsletter_rate_limit_per_minute).and_return(2)
+    create_list(:escalated_newsletter_delivery, 5, newsletter: newsletter, status: 'pending')
+
+    dispatcher.dispatch_batch
+    dispatcher.dispatch_batch
+
+    expect(newsletter.deliveries.where(status: 'sent').count).to eq(2)
+  end
+
+  it 'does not claim deliveries whose next_attempt_at is in the future' do
+    create(:escalated_newsletter_delivery, newsletter: newsletter, status: 'pending', next_attempt_at: 5.minutes.from_now)
+
+    dispatcher.dispatch_batch
+
+    expect(newsletter.deliveries.first.reload.status).to eq('pending')
+  end
+
+  it 'auto-pauses a campaign when first terminal deliveries exceed the bounce threshold' do
+    allow(Escalated.configuration).to receive_messages(newsletter_auto_pause_threshold: 4,
+                                                       newsletter_auto_pause_bounce_rate: 0.05)
+    create(:escalated_newsletter_delivery, newsletter: newsletter, status: 'bounced')
+    create_list(:escalated_newsletter_delivery, 3, newsletter: newsletter, status: 'sent')
+
+    dispatcher.dispatch_batch
+
+    expect(newsletter.reload.status).to eq('paused')
+  end
+end

--- a/spec/services/escalated/newsletter/planner_spec.rb
+++ b/spec/services/escalated/newsletter/planner_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Newsletter::Planner do
+  subject(:planner) { described_class.new }
+
+  before do
+    allow(Escalated.configuration).to receive(:enable_newsletters?).and_return(true)
+  end
+
+  it 'creates one pending delivery per sendable contact and marks the newsletter sending' do
+    list = create(:escalated_newsletter_list)
+    contacts = create_list(:escalated_contact, 2)
+    contacts.each { |contact| create(:escalated_newsletter_list_member, list: list, contact: contact) }
+    newsletter = create(:escalated_newsletter, target_list: list, status: 'scheduled')
+
+    expect { planner.plan(newsletter) }.to change(Escalated::NewsletterDelivery, :count).by(2)
+
+    newsletter.reload
+    expect(newsletter.status).to eq('sending')
+    expect(newsletter.summary_total).to eq(2)
+    expect(newsletter.deliveries.pluck(:status)).to all(eq('pending'))
+  end
+
+  it 'skips opted-out and suppressed contacts' do
+    list = create(:escalated_newsletter_list)
+    opted_in = create(:escalated_contact, email: 'in@example.com')
+    opted_out = create(:escalated_contact, email: 'out@example.com', marketing_opt_out_at: Time.current)
+    suppressed = create(:escalated_contact, email: 'blocked@example.com')
+    [opted_in, opted_out, suppressed].each do |contact|
+      create(:escalated_newsletter_list_member, list: list, contact: contact)
+    end
+    Escalated::Newsletter::BounceSuppressionStore.new.mark_bounced(suppressed.email)
+
+    newsletter = create(:escalated_newsletter, target_list: list, status: 'scheduled')
+    planner.plan(newsletter)
+
+    expect(newsletter.deliveries.pluck(:email_at_send)).to eq(['in@example.com'])
+  end
+
+  it 'snapshots email_at_send and generates unique tracking tokens' do
+    list = create(:escalated_newsletter_list)
+    contact = create(:escalated_contact, email: 'before@example.com')
+    create(:escalated_newsletter_list_member, list: list, contact: contact)
+    newsletter = create(:escalated_newsletter, target_list: list)
+
+    planner.plan(newsletter)
+    contact.update!(email: 'after@example.com')
+
+    delivery = newsletter.deliveries.first
+    expect(delivery.email_at_send).to eq('before@example.com')
+    expect(newsletter.deliveries.pluck(:tracking_token).uniq.size).to eq(newsletter.deliveries.count)
+  end
+end

--- a/spec/services/escalated/newsletter/renderer_spec.rb
+++ b/spec/services/escalated/newsletter/renderer_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Newsletter::Renderer do
+  subject(:renderer) { described_class.new }
+
+  let(:contact) { create(:escalated_contact, name: 'Ada Lovelace', email: 'ada@example.com') }
+  let(:newsletter) do
+    create(:escalated_newsletter,
+           body_markdown: '# Hello {{ contact.first_name }} {{ contact.does_not_exist }}',
+           status: 'sending')
+  end
+  let(:delivery) { create(:escalated_newsletter_delivery, newsletter: newsletter, contact: contact, status: 'sent') }
+
+  before do
+    allow(Escalated.configuration).to receive_messages(
+      app_url: 'https://app.example.test',
+      newsletter_markdown_renderer: lambda { |markdown|
+        markdown
+          .sub(/\A# (.*)/, '<h1>\\1</h1>')
+          .gsub(/\[([^\]]+)\]\(([^)]+)\)/, '<a href="\\2">\\1</a>')
+      },
+      newsletter_tracking_enabled?: true
+    )
+  end
+
+  it 'renders markdown, merge fields, rewritten links, and a tracking pixel' do
+    newsletter.update!(body_markdown: '# Hello {{ contact.first_name }} [Site](https://example.com)')
+
+    html = renderer.render(delivery)
+
+    expect(html).to include('<h1>Hello Ada')
+    expect(html).not_to include('{{')
+    expect(html).to include("/escalated/n/c/#{delivery.tracking_token}?u=")
+    expect(html).not_to include('href="https://example.com"')
+    expect(html).to include("/escalated/n/o/#{delivery.tracking_token}.gif")
+  end
+
+  it 'does not rewrite links or inject a pixel when tracking is disabled' do
+    allow(Escalated.configuration).to receive(:newsletter_tracking_enabled?).and_return(false)
+    newsletter.update!(body_markdown: '[Site](https://example.com)')
+
+    html = renderer.render(delivery)
+
+    expect(html).to include('https://example.com')
+    expect(html).not_to include("/escalated/n/c/#{delivery.tracking_token}")
+    expect(html).not_to include("/escalated/n/o/#{delivery.tracking_token}.gif")
+  end
+
+  it 'strips javascript links and keeps unsubscribe links untracked' do
+    unsubscribe = "https://app.example.test/escalated/n/u/#{delivery.tracking_token}"
+    newsletter.update!(body_markdown: %([Unsafe](javascript:alert(1)) [Unsub](#{unsubscribe})))
+
+    html = renderer.render(delivery)
+
+    expect(html).not_to include('javascript:alert')
+    expect(html).to include(unsubscribe)
+  end
+end

--- a/spec/services/escalated/newsletter/renderer_spec.rb
+++ b/spec/services/escalated/newsletter/renderer_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Escalated::Newsletter::Renderer do
       app_url: 'https://app.example.test',
       newsletter_markdown_renderer: lambda { |markdown|
         markdown
-          .sub(/\A# (.*)/, '<h1>\\1</h1>')
-          .gsub(/\[([^\]]+)\]\(([^)]+)\)/, '<a href="\\2">\\1</a>')
+        .sub(/\A# (.*)/, '<h1>\\1</h1>')
+        .gsub(/\[([^\]]+)\]\(([^)]+)\)/, '<a href="\\2">\\1</a>')
       },
       newsletter_tracking_enabled?: true
     )

--- a/spec/services/escalated/newsletter/tracker_spec.rb
+++ b/spec/services/escalated/newsletter/tracker_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Newsletter::Tracker do
+  subject(:tracker) { described_class.new }
+
+  let(:newsletter) { create(:escalated_newsletter, status: 'sending') }
+  let(:delivery) { create(:escalated_newsletter_delivery, newsletter: newsletter, status: 'sent') }
+
+  it 'records the first open only' do
+    tracker.record_open(delivery.tracking_token)
+    tracker.record_open(delivery.tracking_token)
+
+    expect(delivery.reload.opened_at).to be_present
+    expect(newsletter.reload.summary_opened).to eq(1)
+  end
+
+  it 'records clicks and increments the newsletter click summary once' do
+    2.times { tracker.record_click(delivery.tracking_token, 'https://example.com') }
+
+    expect(delivery.reload.clicks_count).to eq(2)
+    expect(delivery.last_clicked_at).to be_present
+    expect(newsletter.reload.summary_clicked).to eq(1)
+  end
+
+  it 'records hard bounces and adds the email to the suppression store' do
+    tracker.record_bounce(delivery.tracking_token, 'hard', 'Bad mailbox')
+
+    expect(delivery.reload.status).to eq('bounced')
+    expect(delivery.bounce_reason).to eq('Bad mailbox')
+    expect(newsletter.reload.summary_bounced).to eq(1)
+    expect(Escalated::Newsletter::BounceSuppressionStore.new.bounced?(delivery.email_at_send)).to be true
+  end
+
+  it 'records complaints and ignores unknown tokens' do
+    expect { tracker.record_open('missing') }.not_to raise_error
+
+    tracker.record_complaint(delivery.tracking_token)
+
+    expect(delivery.reload.status).to eq('complained')
+    expect(newsletter.reload.summary_complained).to eq(1)
+    expect(Escalated::Newsletter::BounceSuppressionStore.new.bounced?(delivery.email_at_send)).to be true
+  end
+
+  it 'ignores opens after a bounce' do
+    delivery.update!(status: 'bounced')
+
+    tracker.record_open(delivery.tracking_token)
+
+    expect(delivery.reload.opened_at).to be_nil
+  end
+end


### PR DESCRIPTION
## What

Brings escalated-rails from **engine-only** to full newsletter parity. Rails had the tables + models + 6 services but **no HTTP layer** — this adds admin/public/webhook controllers, the dispatch rake task, enabled gate, permission enforcement, and specs.

Part of the full-parity program (mirrors the Laravel + NestJS references against `escalated/docs/superpowers/specs/2026-06-02-newsletter-http-parity-contract.md`).

## Added
- **Admin controllers** (`app/controllers/escalated/admin/newsletter*`): campaigns (index/create/store/preview/test/show/edit/update/destroy), lists (CRUD + add/remove member + CSV import), templates (CRUD), settings. Routed in `config/routes.rb` with correct ordering (settings/templates/lists before the `:id` catch-all).
- **Public controllers** (tracking open/click, unsubscribe show/store, view-in-browser) + **ESP webhook** (postmark/mailgun/ses/sendgrid), registered via a `newsletter_routes` initializer in `lib/escalated/engine.rb` (same append-routes pattern as the existing API routes) at `/escalated/n/*` and `/escalated/webhooks/newsletter/*`.
- **Dispatch worker**: `lib/tasks/escalated_newsletters.rake` (plan due + dispatch batch).
- **Enabled gate**: feature-flag guard (skips when newsletters disabled).
- **Permissions**: `newsletters.manage` (before_action on all admin) / `newsletters.send` (on test-send + store/update-when-sending) via `Escalated::NewsletterAccess` concern; seeded in `db/seeds/permissions.rb`.
- **Migration 062**: `next_attempt_at` on deliveries (retry backoff). Dispatcher aligned with the contract's 4 fleet behaviors.
- **Specs**: request spec (admin + public tracking/unsubscribe/view + ESP webhook), dispatcher/planner/tracker/renderer/bounce-store specs, dispatch-task spec, factories.

## Verification
- **Full suite: 937 examples, 0 failures** (run locally). Newsletter subset (36 examples) also green independently.
- Routes, permission enforcement, gate, and webhook providers verified against the contract.