### PR TITLE
fix(assignment): skip offline agents in auto-assignment

### DIFF
--- a/lib/escalated/services/assignment_service.rb
+++ b/lib/escalated/services/assignment_service.rb
@@ -23,22 +23,7 @@ module Escalated
         end
 
         def round_robin(department)
-          agents = department.agents.to_a
-          return nil if agents.empty?
-
-          # Find the agent with the fewest open tickets in this department
-          agent_loads = agents.map do |agent|
-            open_count = Escalated::Ticket
-                         .by_open
-                         .assigned_to(agent.id)
-                         .where(department_id: department.id)
-                         .count
-
-            { agent: agent, count: open_count }
-          end
-
-          # Sort by ticket count, then by last assignment time for tie-breaking
-          agent_loads.min_by { |a| a[:count] }[:agent]
+          least_loaded(department.agents.to_a, department)
         end
 
         def reassign(ticket, new_agent, actor:)
@@ -71,7 +56,45 @@ module Escalated
         private
 
         def next_available_agent(department)
-          round_robin(department)
+          agents = department.agents.to_a
+          return nil if agents.empty?
+
+          # Prefer agents who are currently available for support work (chat
+          # status online or away). Offline agents are skipped so long as at
+          # least one available agent exists; if nobody is available we fall
+          # back to the full roster so tickets are never stranded. See issue #67.
+          candidates = available_agents(agents).presence || agents
+          least_loaded(candidates, department)
+        end
+
+        # Narrows a list of agent users to those whose chat presence is online
+        # or away (i.e. not offline and not presence-less).
+        def available_agents(agents)
+          return agents if agents.empty?
+
+          available_ids = Escalated::AgentProfile
+                          .chat_available
+                          .where(user_id: agents.map(&:id))
+                          .pluck(:user_id)
+
+          agents.select { |agent| available_ids.include?(agent.id) }
+        end
+
+        # Returns the agent with the fewest open tickets in the department.
+        def least_loaded(agents, department)
+          return nil if agents.empty?
+
+          agent_loads = agents.map do |agent|
+            open_count = Escalated::Ticket
+                         .by_open
+                         .assigned_to(agent.id)
+                         .where(department_id: department.id)
+                         .count
+
+            { agent: agent, count: open_count }
+          end
+
+          agent_loads.min_by { |a| a[:count] }[:agent]
         end
       end
     end

--- a/spec/services/escalated/assignment_service_spec.rb
+++ b/spec/services/escalated/assignment_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Escalated::Services::AssignmentService do
+  describe '.auto_assign' do
+    let(:department) { create(:escalated_department) }
+
+    def add_agent(chat_status:)
+      agent = create(:user, :agent)
+      department.agents << agent
+      create(:escalated_agent_profile, user: agent, chat_status: chat_status)
+      agent
+    end
+
+    it 'skips offline agents and assigns to an available one' do
+      # The offline agent carries the lighter load, so a load-only round-robin
+      # would route to it. Availability filtering must take precedence (issue #67).
+      add_agent(chat_status: 'offline')
+      online = add_agent(chat_status: 'online')
+
+      # Give the online agent an existing open ticket so it is strictly the
+      # heavier-loaded candidate; the offline agent has none.
+      create(:escalated_ticket, department: department, assigned_to: online.id, status: :in_progress)
+
+      ticket = create(:escalated_ticket, department: department)
+
+      result = described_class.auto_assign(ticket)
+
+      expect(result).to eq(online)
+      expect(ticket.reload.assigned_to).to eq(online.id)
+    end
+
+    it 'treats "away" agents as available' do
+      add_agent(chat_status: 'offline')
+      away = add_agent(chat_status: 'away')
+
+      ticket = create(:escalated_ticket, department: department)
+
+      expect(described_class.auto_assign(ticket)).to eq(away)
+    end
+
+    it 'still assigns when every agent is offline so tickets are not stranded' do
+      offline_a = add_agent(chat_status: 'offline')
+      offline_b = add_agent(chat_status: 'offline')
+
+      ticket = create(:escalated_ticket, department: department)
+
+      result = described_class.auto_assign(ticket)
+
+      expect(result).to be_present
+      expect([offline_a.id, offline_b.id]).to include(ticket.reload.assigned_to)
+    end
+  end
+end


### PR DESCRIPTION
Closes #67

## Problem
`AssignmentService.auto_assign` delegated straight to `round_robin`, which picks the least-loaded agent from the **entire** department roster with no regard for chat presence. New tickets could therefore be auto-assigned to agents who are **offline**.

## Fix
`next_available_agent` now prefers agents whose `AgentProfile.chat_status` is **online or away** (the existing `chat_available` scope). Offline (and presence-less) agents are skipped **as long as at least one available agent exists**; if nobody is available it falls back to the full roster so tickets are never stranded. Load balancing (fewest open tickets) still applies within the chosen pool.

Refactored the load calculation into a private `least_loaded(agents, department)` helper shared by `round_robin` and `next_available_agent` (public `round_robin` API unchanged).

## Tests
New `spec/services/escalated/assignment_service_spec.rb`:
- offline agent skipped in favour of a **heavier-loaded** available agent (deterministic red→green),
- "away" treated as available,
- all-offline fallback still assigns (no stranded ticket).

Verified locally: 3 examples, 0 failures; RuboCop clean.