### PR TITLE
feat(api): /api/v1/auth via host callbacks

### DIFF
--- a/app/controllers/escalated/api/v1/auth_controller.rb
+++ b/app/controllers/escalated/api/v1/auth_controller.rb
@@ -3,7 +3,19 @@
 module Escalated
   module Api
     module V1
+      # General JSON API authentication for the Flutter app and integrations.
+      # Credential handling is delegated to host-app callbacks configured on
+      # Escalated.configuration (api_authenticator / api_registrar /
+      # api_token_refresher / api_profile_updater / api_logout). Escalated owns
+      # no passwords or sessions. An unconfigured callback responds 501; a
+      # callback returning a falsy value is an auth failure (401).
+      #
+      # login/register/refresh/logout carry no token yet, so they skip token
+      # authentication; validate/me/profile use the authenticated user.
       class AuthController < BaseController
+        skip_before_action :authenticate_api_token!, only: %i[login register refresh logout]
+        skip_before_action :enforce_rate_limit!, only: %i[login register refresh logout]
+
         def validate
           user = current_user
 
@@ -19,6 +31,73 @@ module Escalated
             token_name: @current_api_token.name,
             expires_at: @current_api_token.expires_at&.iso8601
           }
+        end
+
+        def login
+          delegate(Escalated.configuration.api_authenticator, request_params)
+        end
+
+        def register
+          delegate(Escalated.configuration.api_registrar, request_params)
+        end
+
+        def refresh
+          delegate(Escalated.configuration.api_token_refresher, bearer_token)
+        end
+
+        def logout
+          callback = Escalated.configuration.api_logout
+          callback.call(bearer_token) if callback.respond_to?(:call)
+          render json: { data: { success: true } }
+        end
+
+        def me
+          user = current_user
+          render json: {
+            data: {
+              id: user.id,
+              name: user.respond_to?(:name) ? user.name : user.email,
+              email: user.email
+            }
+          }
+        end
+
+        def profile
+          callback = Escalated.configuration.api_profile_updater
+          return render_not_configured unless callback.respond_to?(:call)
+
+          result = callback.call(current_user, request_params)
+          return render_unauthorized unless result
+
+          render json: { data: result }
+        end
+
+        private
+
+        def delegate(callback, arg)
+          return render_not_configured unless callback.respond_to?(:call)
+
+          result = callback.call(arg)
+          return render_unauthorized unless result
+
+          render json: { data: result }
+        end
+
+        def request_params
+          params.except(:controller, :action, :format).to_unsafe_h
+        end
+
+        def bearer_token
+          header = request.headers['Authorization'].to_s
+          header.start_with?('Bearer ') ? header[7..].to_s.strip : ''
+        end
+
+        def render_not_configured
+          render json: { error: 'Authentication is not configured' }, status: :not_implemented
+        end
+
+        def render_unauthorized
+          render json: { error: 'Unauthorized' }, status: :unauthorized
         end
       end
     end

--- a/lib/escalated/configuration.rb
+++ b/lib/escalated/configuration.rb
@@ -77,7 +77,16 @@ module Escalated
                   # Host-defined custom ticket actions
                   :ticket_actions,
                   # Host models a ticket can be about (Project, Customer, …)
-                  :ticket_subject_types
+                  :ticket_subject_types,
+                  # Host-app authentication callbacks for the general JSON API
+                  # auth endpoints (login/register/refresh/profile/logout).
+                  # Each is a callable; nil means the endpoint responds 501.
+                  # Escalated owns no credentials, so it ships no password hasher.
+                  :api_authenticator,
+                  :api_registrar,
+                  :api_token_refresher,
+                  :api_profile_updater,
+                  :api_logout
 
     def initialize
       @mode = :self_hosted
@@ -165,6 +174,13 @@ module Escalated
       @newsletter_brand_physical_address = nil
       @ticket_actions = []
       @ticket_subject_types = []
+
+      # API auth callbacks (host-provided; nil → endpoint responds 501)
+      @api_authenticator = nil
+      @api_registrar = nil
+      @api_token_refresher = nil
+      @api_profile_updater = nil
+      @api_logout = nil
     end
 
     def self_hosted?

--- a/lib/escalated/engine.rb
+++ b/lib/escalated/engine.rb
@@ -72,6 +72,12 @@ module Escalated
         if Escalated.configuration.api_enabled
           scope Escalated.configuration.api_prefix, module: 'escalated/api/v1', as: 'escalated_api_v1' do
             post 'auth/validate', to: 'auth#validate'
+            post 'auth/login', to: 'auth#login'
+            post 'auth/register', to: 'auth#register'
+            post 'auth/logout', to: 'auth#logout'
+            post 'auth/refresh', to: 'auth#refresh'
+            get 'auth/me', to: 'auth#me'
+            patch 'auth/profile', to: 'auth#profile'
             get 'dashboard', to: 'dashboard#index'
 
             resources :tickets, param: :reference, only: %i[index show create destroy] do

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -48,6 +48,7 @@ Escalated.configure do |config|
   config.user_class = 'User'
   config.table_prefix = 'escalated_'
   config.route_prefix = 'support'
+  config.api_enabled = true # Mount the JSON API routes for request specs
   config.notification_channels = [] # Disable email notifications in tests
   config.sla = {
     enabled: true,

--- a/spec/requests/escalated/api_auth_spec.rb
+++ b/spec/requests/escalated/api_auth_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API auth endpoints', type: :request do
+  after do
+    Escalated.configure do |c|
+      c.api_authenticator = nil
+      c.api_logout = nil
+    end
+  end
+
+  describe 'POST /support/api/v1/auth/login' do
+    it 'responds 501 when no authenticator is configured' do
+      post '/support/api/v1/auth/login', params: {}, as: :json
+      expect(response).to have_http_status(:not_implemented)
+    end
+
+    it 'delegates to the configured authenticator' do
+      Escalated.configure { |c| c.api_authenticator = ->(params) { { token: 'abc', email: params['email'] } } }
+
+      post '/support/api/v1/auth/login', params: { email: 'a@b.com' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['data']).to eq('token' => 'abc', 'email' => 'a@b.com')
+    end
+
+    it 'responds 401 when the authenticator returns nil' do
+      Escalated.configure { |c| c.api_authenticator = ->(_params) {} }
+
+      post '/support/api/v1/auth/login', params: {}, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /support/api/v1/auth/logout' do
+    it 'always succeeds and forwards the bearer token' do
+      seen = {}
+      Escalated.configure { |c| c.api_logout = ->(token) { seen[:token] = token } }
+
+      post '/support/api/v1/auth/logout',
+           headers: { 'Authorization' => 'Bearer tok123' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['data']).to eq('success' => true)
+      expect(seen[:token]).to eq('tok123')
+    end
+  end
+end


### PR DESCRIPTION
Adds the general JSON API **auth contract** (consumed by the Flutter app) to Rails, using the **host-callback** model — dependency-free, no password hashing in the engine. Matches the Phoenix / Go / NestJS / Django reference.

## What
- Host-callback config on `Escalated.configuration` (`api_authenticator` / `api_registrar` / `api_token_refresher` / `api_profile_updater` / `api_logout`).
- `Api::V1::AuthController` gains `login`, `register`, `logout`, `refresh`, `me`, `profile` (joining `validate`). `login/register/refresh/logout` `skip_before_action :authenticate_api_token!` (no token yet); `me`/`profile` use the authenticated user. Unconfigured → `501`; falsy result → `401`.
- Routes added in the engine's `api_routes` initializer.
- The dummy app now sets `api_enabled = true` so request specs can mount the API routes.

## Verification
- `bundle exec rubocop` clean on all changed files (the CI gate; one `NilLambda` nit fixed).
- New `spec/requests/escalated/api_auth_spec.rb` — 4 examples (501 not-configured, delegation, 401 falsy, logout always-200 + token forwarding).
- Re-ran all request specs: **22 examples, 0 failures** — no regression from enabling the API in the dummy.